### PR TITLE
[MOB-14404] Adding push token to the shared state

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The Adobe Experience Platform Messaging extension for Android is currently in Be
 Integrate the AEPMessaging extension into your app by including the following in your gradle file's `dependencies`:
 
 ```
-implementation 'com.adobe.marketing.mobile:messaging:1.0.0-beta-1'
+implementation 'com.adobe.marketing.mobile:messaging:1.0.0-beta-2'
 implementation 'com.adobe.marketing.mobile:edge:1.+'
 implementation 'com.adobe.marketing.mobile:edgeidentity:1.+'
 implementation 'com.adobe.marketing.mobile:sdk-core:1.+'

--- a/code/app/build.gradle
+++ b/code/app/build.gradle
@@ -11,7 +11,7 @@ android {
         minSdkVersion 19
         targetSdkVersion 29
         versionCode 1
-        versionName "1.0.0-beta-1"
+        versionName "1.0.0-beta-2"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
 

--- a/code/gradle.properties
+++ b/code/gradle.properties
@@ -14,7 +14,7 @@ android.enableJetifier=true
 moduleProjectName=messaging
 moduleName=messaging
 moduleAARName=messaging-phone-release.aar
-moduleVersion=1.0.0-beta-1
+moduleVersion=1.0.0-beta-2
 
 mavenRepoName=AdobeMobileMessagingSdk
 mavenRepoDescription=Adobe Experience Platform Messaging extension for the Adobe Experience Platform Mobile SDK

--- a/code/messaging/src/androidTest/java/com/adobe/marketing/mobile/PushTokenSyncingTests.java
+++ b/code/messaging/src/androidTest/java/com/adobe/marketing/mobile/PushTokenSyncingTests.java
@@ -23,11 +23,14 @@ import org.junit.runner.RunWith;
 
 import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 
 import static com.adobe.marketing.mobile.TestHelper.getDispatchedEventsWith;
+import static com.adobe.marketing.mobile.TestHelper.getSharedStateFor;
 import static com.adobe.marketing.mobile.TestHelper.resetTestExpectations;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 @RunWith(AndroidJUnit4.class)
 public class PushTokenSyncingTests {
@@ -42,6 +45,12 @@ public class PushTokenSyncingTests {
     @Before
     public void setup() throws Exception {
         MessagingFunctionalTestUtil.setEdgeIdentityPersistence(MessagingFunctionalTestUtil.createIdentityMap("ECID", "mockECID"));
+        HashMap<String, Object> config = new HashMap<String, Object>() {
+            {
+                put("someconfig", "someconfigvalue");
+            }
+        };
+        MobileCore.updateConfiguration(config);
         Messaging.registerExtension();
         com.adobe.marketing.mobile.edge.identity.Identity.registerExtension();
 
@@ -77,6 +86,11 @@ public class PushTokenSyncingTests {
                 EventSource.REQUEST_CONTENT.getName());
         assertEquals(1, edgeRequestEvents.size());
         assertEquals(expectedEdgeEvent, edgeRequestEvents.get(0).getData().toString());
+
+        // verify shared state is updated with the push token
+        Map<String, String> sharedStateMap = TestUtils.flattenMap(getSharedStateFor(MessagingConstant.EXTENSION_NAME,1000));
+        String pushToken = sharedStateMap.get(MessagingConstant.SharedState.Messaging.PUSH_IDENTIFIER);
+        assertEquals("mockPushToken", pushToken);
     }
 
     @Test
@@ -93,6 +107,11 @@ public class PushTokenSyncingTests {
         List<Event> edgeRequestEvents = getDispatchedEventsWith(MessagingConstant.EventType.EDGE,
                 EventSource.REQUEST_CONTENT.getName());
         assertEquals(0, edgeRequestEvents.size());
+
+        // verify shared state is updated with the push token
+        Map<String, String> sharedStateMap = TestUtils.flattenMap(getSharedStateFor(MessagingConstant.EXTENSION_NAME,1000));
+        String pushToken = sharedStateMap.get(MessagingConstant.SharedState.Messaging.PUSH_IDENTIFIER);
+        assertNull(pushToken);
     }
 
     @Test
@@ -109,5 +128,10 @@ public class PushTokenSyncingTests {
         List<Event> edgeRequestEvents = getDispatchedEventsWith(MessagingConstant.EventType.EDGE,
                 EventSource.REQUEST_CONTENT.getName());
         assertEquals(0, edgeRequestEvents.size());
+
+        // verify shared state is updated with the push token
+        Map<String, String> sharedStateMap = TestUtils.flattenMap(getSharedStateFor(MessagingConstant.EXTENSION_NAME,1000));
+        String pushToken = sharedStateMap.get(MessagingConstant.SharedState.Messaging.PUSH_IDENTIFIER);
+        assertNull(pushToken);
     }
 }

--- a/code/messaging/src/androidTest/java/com/adobe/marketing/mobile/PushTokenSyncingTests.java
+++ b/code/messaging/src/androidTest/java/com/adobe/marketing/mobile/PushTokenSyncingTests.java
@@ -47,7 +47,7 @@ public class PushTokenSyncingTests {
         MessagingFunctionalTestUtil.setEdgeIdentityPersistence(MessagingFunctionalTestUtil.createIdentityMap("ECID", "mockECID"));
         HashMap<String, Object> config = new HashMap<String, Object>() {
             {
-                put("someconfig", "someconfigvalue");
+                put("someconfig", "someConfigValue");
             }
         };
         MobileCore.updateConfiguration(config);

--- a/code/messaging/src/androidTest/java/com/adobe/marketing/mobile/TestConstants.java
+++ b/code/messaging/src/androidTest/java/com/adobe/marketing/mobile/TestConstants.java
@@ -38,6 +38,7 @@ public class TestConstants {
 
 	public final class SharedStateName {
 		public static final String EVENT_HUB = "com.adobe.module.eventhub";
+		public static final String EDGE_IDENTITY = "com.adobe.module.identity";
 		private SharedStateName() { }
 	}
 }

--- a/code/messaging/src/phone/java/com/adobe/marketing/mobile/MessagingConstant.java
+++ b/code/messaging/src/phone/java/com/adobe/marketing/mobile/MessagingConstant.java
@@ -14,7 +14,7 @@ package com.adobe.marketing.mobile;
 final class MessagingConstant {
 
     static final String LOG_TAG = "Messaging";
-    static final String EXTENSION_VERSION = "1.0.0-beta-1";
+    static final String EXTENSION_VERSION = "1.0.0-beta-2";
     static final String EXTENSION_NAME = "com.adobe.messaging";
 
     private MessagingConstant() {}
@@ -138,6 +138,10 @@ final class MessagingConstant {
             static final String ID = "id";
 
             private EdgeIdentity() {/* no-op */}
+        }
+
+        static final class Messaging {
+            static final String PUSH_IDENTIFIER = "pushidentifier";
         }
     }
 

--- a/code/messaging/src/phone/java/com/adobe/marketing/mobile/MessagingInternal.java
+++ b/code/messaging/src/phone/java/com/adobe/marketing/mobile/MessagingInternal.java
@@ -247,6 +247,19 @@ class MessagingInternal extends Extension implements MessagingEventsHandler {
         if (eventData == null) {
             return;
         }
+
+        // Update the push token to the shared state
+        ExtensionErrorCallback<ExtensionError> errorCallback = new ExtensionErrorCallback<ExtensionError>() {
+            @Override
+            public void error(final ExtensionError extensionError) {
+                Log.warning(MessagingConstant.LOG_TAG, String.format("An error occurred while setting the push token in the shared state %s",
+                        extensionError.getErrorName()));
+            }
+        };
+        Map<String, Object> map = new HashMap<>();
+        map.put(MessagingConstant.SharedState.Messaging.PUSH_IDENTIFIER, pushToken);
+        getApi().setSharedEventState(map, event, errorCallback);
+
         // Send an edge event with profile data as event data
         final Event profileEvent = new Event.Builder(MessagingConstant.EventName.MESSAGING_PUSH_PROFILE_EDGE_EVENT, MessagingConstant.EventType.EDGE, EventSource.REQUEST_CONTENT.getName())
                 .setEventData(eventData)

--- a/code/messaging/src/test/java/com/adobe/marketing/mobile/MessagingInternalTests.java
+++ b/code/messaging/src/test/java/com/adobe/marketing/mobile/MessagingInternalTests.java
@@ -42,10 +42,9 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @RunWith(PowerMockRunner.class)
-@PrepareForTest({Event.class, MobileCore.class, ExtensionApi.class, ExtensionUnexpectedError.class, MessagingState.class, LocalStorageService.class, App.class, Context.class})
+@PrepareForTest({Event.class, MobileCore.class, ExtensionApi.class, ExtensionUnexpectedError.class, MessagingState.class, App.class, Context.class})
 public class MessagingInternalTests {
 
-    private int EXECUTOR_TIMEOUT = 5;
     private MessagingInternal messagingInternal;
 
     // Mocks
@@ -328,6 +327,9 @@ public class MessagingInternalTests {
         assertEquals(MessagingConstant.EventType.EDGE.toLowerCase(), event.getEventType().getName());
         assertEquals(EventSource.REQUEST_CONTENT.getName(), event.getSource());
         assertEquals(expectedEventData, event.getData().toString());
+
+        // verify if the push token is stored in shared state
+        verify(mockExtensionApi, times(1)).setSharedEventState(any(Map.class), any(Event.class), any(ExtensionErrorCallback.class));
     }
 
 
@@ -349,6 +351,7 @@ public class MessagingInternalTests {
         // verify
         PowerMockito.verifyStatic(MobileCore.class, times(0));
         MobileCore.dispatchEvent(any(Event.class), any(ExtensionErrorCallback.class));
+        verify(mockExtensionApi, times(0)).setSharedEventState(any(Map.class), any(Event.class), any(ExtensionErrorCallback.class));
     }
 
     @Test
@@ -371,6 +374,7 @@ public class MessagingInternalTests {
         // verify
         PowerMockito.verifyStatic(MobileCore.class, times(0));
         MobileCore.dispatchEvent(any(Event.class), any(ExtensionErrorCallback.class));
+        verify(mockExtensionApi, times(0)).setSharedEventState(any(Map.class), any(Event.class), any(ExtensionErrorCallback.class));
     }
 
     @Test
@@ -387,9 +391,6 @@ public class MessagingInternalTests {
         // private mocks
         Whitebox.setInternalState(messagingInternal, "messagingState", messagingState);
 
-        // when getLocalStorageService() return mockLocalStorageService
-        LocalStorageService.DataStore mockDataStore = mock(LocalStorageService.DataStore.class);
-
         // when - then return mock
         when(messagingState.getEcid()).thenReturn(mockECID);
 
@@ -399,6 +400,7 @@ public class MessagingInternalTests {
         // verify
         PowerMockito.verifyStatic(MobileCore.class, times(0));
         MobileCore.dispatchEvent(any(Event.class), any(ExtensionErrorCallback.class));
+        verify(mockExtensionApi, times(0)).setSharedEventState(any(Map.class), any(Event.class), any(ExtensionErrorCallback.class));
     }
 
     // ========================================================================================


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

On every MobileCore.setPushIdentifier API call, which dispatches Generic Request Identity event is listened by Messaging extension.
Now the push identifier is extracted and shared in Messaging extension's shared state
StateStateDetails

{
 "pushidentifier" : '<push_token>"
}
This shared state in read by Assurance extension, which forwards the data to Griffon session for populating the PushDebugger plugin

Note
Pushtoken is shared in shared state regardless of the ability of Messaging extension to sync the token with the edge network

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
