### PR TITLE
[MOB-16614] fix a crash by preventing an additional message.dismiss from being called

### DIFF
--- a/code/messaging/src/androidTest/java/com/adobe/marketing/mobile/E2EFunctionalTests.java
+++ b/code/messaging/src/androidTest/java/com/adobe/marketing/mobile/E2EFunctionalTests.java
@@ -52,7 +52,7 @@ public class E2EFunctionalTests {
     @Before
     public void setup() throws Exception {
         MessagingTestUtils.cleanCache();
-        MessagingTestUtils.setEdgeIdentityPersistence(MessagingTestUtils.createIdentityMap("ECID", "mockECID"), TestHelper.defaultApplication);
+        MessagingTestUtils.setEdgeIdentityPersistence(MessagingTestUtils.createIdentityMap("ECID", "80195814545200720557089495418993853789"), TestHelper.defaultApplication);
 
         Messaging.registerExtension();
         Optimize.registerExtension();

--- a/code/messaging/src/phone/java/com/adobe/marketing/mobile/MessagingDelegate.java
+++ b/code/messaging/src/phone/java/com/adobe/marketing/mobile/MessagingDelegate.java
@@ -66,9 +66,6 @@ public class MessagingDelegate implements FullscreenMessageDelegate {
     public void onDismiss(final FullscreenMessage fullscreenMessage) {
         Log.debug(LOG_TAG,
                 "%s - Fullscreen message dismissed.", SELF_TAG);
-        final MessageSettings aepMessageSettings = ((AEPMessage) fullscreenMessage).getSettings();
-        final Message message = (Message) aepMessageSettings.getParent();
-        message.dismiss(false);
     }
 
     /**

--- a/code/messaging/src/test/java/com/adobe/marketing/mobile/MessagingDelegateTests.java
+++ b/code/messaging/src/test/java/com/adobe/marketing/mobile/MessagingDelegateTests.java
@@ -115,9 +115,6 @@ public class MessagingDelegateTests {
         // verify Log.debug called
         verifyStatic(Log.class);
         Log.debug(anyString(), anyString(), any());
-
-        // verify Message.dismiss() called 1 time
-        verify(mockMessage, times(1)).dismiss(anyBoolean());
     }
 
     @Test


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
When a custom messaging delegate is not set message.dismiss() was being called twice which was causing a crash to occur on the second call. to resolve it, all message dismissal will be handled via message.overrideUrlLoad to ensure one call per message dismissal is made.

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
