### PR TITLE
fix fragment creation issue

### DIFF
--- a/code/messaging/src/phone/java/com/adobe/marketing/mobile/Message.java
+++ b/code/messaging/src/phone/java/com/adobe/marketing/mobile/Message.java
@@ -210,6 +210,12 @@ public class Message extends MessagingDelegate {
     // ui management
     public void show() {
         if (aepMessage != null) {
+            // check if messages should be displayed before attempting to show one
+            if (!(ServiceProvider.getInstance().getMessageDelegate()).shouldShowMessage(aepMessage)) {
+                Log.debug(LOG_TAG,
+                        "%s - Message couldn't be displayed, MessagingDelegate#shouldShowMessage states the message should not be displayed.", SELF_TAG);
+                return;
+            }
             if (autoTrack) {
                 track(null, MessagingEdgeEventType.IN_APP_DISPLAY);
             }

--- a/code/messaging/src/test/java/com/adobe/marketing/mobile/MessagingInternalHandleRulesResponseContentTests.java
+++ b/code/messaging/src/test/java/com/adobe/marketing/mobile/MessagingInternalHandleRulesResponseContentTests.java
@@ -29,6 +29,7 @@ import android.os.Bundle;
 
 import com.adobe.marketing.mobile.services.ServiceProvider;
 import com.adobe.marketing.mobile.services.ui.AEPMessage;
+import com.adobe.marketing.mobile.services.ui.FullscreenMessage;
 import com.adobe.marketing.mobile.services.ui.FullscreenMessageDelegate;
 import com.adobe.marketing.mobile.services.ui.MessageSettings;
 import com.adobe.marketing.mobile.services.ui.UIService;
@@ -96,6 +97,8 @@ public class MessagingInternalHandleRulesResponseContentTests {
     AEPMessage mockAEPMessage;
     @Mock
     ServiceProvider mockServiceProvider;
+    @Mock
+    MessagingDelegate mockMessagingDelegate;
 
     private MessagingInternal messagingInternal;
     private JsonUtilityService jsonUtilityService;
@@ -108,7 +111,7 @@ public class MessagingInternalHandleRulesResponseContentTests {
 
         setupMocks();
         setupPlatformServicesMocks();
-        setupAcitivtyAndPlacementIdMocks();
+        setupActivityAndPlacementIdMocks();
         setupSharedStateMocks();
 
         messagingInternal = new MessagingInternal(mockExtensionApi);
@@ -129,6 +132,8 @@ public class MessagingInternalHandleRulesResponseContentTests {
         when(mockPlatformServices.getJsonUtilityService()).thenReturn(jsonUtilityService);
         when(mockServiceProvider.getUIService()).thenReturn(mockUIService);
         when(ServiceProvider.getInstance()).thenReturn(mockServiceProvider);
+        when(mockServiceProvider.getMessageDelegate()).thenReturn(mockMessagingDelegate);
+        when(mockMessagingDelegate.shouldShowMessage(any(FullscreenMessage.class))).thenReturn(true);
         when(mockPlatformServices.getEncodingService()).thenReturn(mockAndroidEncodingService);
         when(mockPlatformServices.getSystemInfoService()).thenReturn(mockAndroidSystemInfoService);
         when(mockPlatformServices.getNetworkService()).thenReturn(mockAndroidNetworkService);
@@ -141,7 +146,7 @@ public class MessagingInternalHandleRulesResponseContentTests {
         Mockito.when(mockUIService.createFullscreenMessage(any(String.class), any(MessageSettings.class), any(Map.class))).thenReturn(mockAEPMessage);
     }
 
-    void setupAcitivtyAndPlacementIdMocks() throws PackageManager.NameNotFoundException {
+    void setupActivityAndPlacementIdMocks() throws PackageManager.NameNotFoundException {
         // setup activity id mocks
         when(App.getApplication()).thenReturn(mockApplication);
         when(mockApplication.getPackageManager()).thenReturn(packageManager);


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description
- a message fragment shouldn't be created if the MesagingDelegate states that messages shouldn't be shown
- cleanup some unit tests + fix a custom message delegate test
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
