### PR TITLE
provide default implementation for Message.getAutoTrack()

### DIFF
--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/Message.java
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/Message.java
@@ -18,6 +18,8 @@ import android.webkit.WebView;
 import com.adobe.marketing.mobile.messaging.internal.WebViewJavascriptInterface;
 
 public interface Message {
+    boolean autoTrack = true;
+
     /**
      * Dispatch tracking information via a Messaging request content event.
      *
@@ -79,4 +81,13 @@ public interface Message {
      * @param enabled {@code boolean} if true, tracking is done automatically for {@code Message} show, dismiss, and triggered events.
      */
     void setAutoTrack(boolean enabled);
+
+    /**
+     * Gets the {@link Message}'s auto tracking preference.
+     *
+     * @return {@code boolean} containing the auto tracking preference.
+     */
+    default boolean getAutoTrack() {
+        return autoTrack;
+    }
 }

--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/Message.java
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/Message.java
@@ -61,7 +61,7 @@ public interface Message {
      *
      * @param suppressAutoTrack if true, tracking is not done automatically for a dismiss event
      */
-    void dismiss(boolean suppressAutoTrack);
+    void dismiss(final boolean suppressAutoTrack);
 
     /**
      * Returns the {@link Message}'s id.
@@ -78,7 +78,7 @@ public interface Message {
      *
      * @param enabled {@code boolean} if true, tracking is done automatically for {@code Message} show, dismiss, and triggered events.
      */
-    void setAutoTrack(boolean enabled);
+    void setAutoTrack(final boolean enabled);
 
     /**
      * Gets the {@link Message}'s auto tracking preference.

--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/Message.java
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/Message.java
@@ -18,8 +18,6 @@ import android.webkit.WebView;
 import com.adobe.marketing.mobile.messaging.internal.WebViewJavascriptInterface;
 
 public interface Message {
-    boolean autoTrack = true;
-
     /**
      * Dispatch tracking information via a Messaging request content event.
      *
@@ -88,6 +86,6 @@ public interface Message {
      * @return {@code boolean} containing the auto tracking preference.
      */
     default boolean getAutoTrack() {
-        return autoTrack;
+        return true;
     }
 }

--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/internal/InternalMessage.java
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/internal/InternalMessage.java
@@ -280,6 +280,11 @@ class InternalMessage extends MessagingFullscreenMessageDelegate implements Mess
         this.autoTrack = useAutoTrack;
     }
 
+    @Override
+    public boolean getAutoTrack() {
+        return autoTrack;
+    }
+
     /**
      * Sample mobile parameters payload represented by a MessageSettings object:
      {

--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/internal/MessagingExtension.java
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/internal/MessagingExtension.java
@@ -344,7 +344,7 @@ public final class MessagingExtension extends Extension {
     public void sendPropositionInteraction(final String interaction, final MessagingEdgeEventType eventType, final InternalMessage message) {
         final PropositionInfo propositionInfo = message.propositionInfo;
         if (propositionInfo == null || MessagingUtils.isMapNullOrEmpty(propositionInfo.scopeDetails)) {
-            Log.trace(LOG_TAG, "%s - Unable to record an in-app message interaction, the scope details were not found for this message.", SELF_TAG);
+            Log.trace(LOG_TAG, MessagingExtension.SELF_TAG, "Unable to record an in-app message interaction, the scope details were not found for this message.");
             return;
         }
         final List<Map<String, Object>> propositions = new ArrayList<>();


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
- Provide a default implementation for getAutoTrack() in the Message interface as it was previously present in the now internal InternalMessage class.
- also fix logging bug in MessagingExtension
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
