### PR TITLE
[MOB-18622] - Handle IAM Click URl without deeplink gracefully

### DIFF
--- a/code/app/build.gradle
+++ b/code/app/build.gradle
@@ -12,7 +12,6 @@ android {
         versionCode 1
         versionName "2.0.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
-        multiDexEnabled true
     }
 
     buildTypes {

--- a/code/app/build.gradle
+++ b/code/app/build.gradle
@@ -12,6 +12,7 @@ android {
         versionCode 1
         versionName "2.0.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+        multiDexEnabled true
     }
 
     buildTypes {

--- a/code/gradle.properties
+++ b/code/gradle.properties
@@ -20,8 +20,8 @@ mavenRepoName=AdobeMobileMessagingSdk
 mavenRepoDescription=Adobe Experience Platform Messaging extension for the Adobe Experience Platform Mobile SDK
 mavenUploadDryRunFlag=false
 
-mavenCoreVersion=2.1.0
+mavenCoreVersion=2.1.2
 mavenEdgeIdentityVersion=2.0.0
 mavenEdgeVersion=2.0.0
 mavenLifecycleVersion=2.0.1
-mavenAssuranceVersion=2.0.0
+mavenAssuranceVersion=2.0.1

--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/internal/MessagingFullscreenMessageDelegate.java
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/internal/MessagingFullscreenMessageDelegate.java
@@ -89,63 +89,70 @@ class MessagingFullscreenMessageDelegate implements FullscreenMessageDelegate {
             return true;
         }
 
-        // check adbinapp scheme
+
         final String messageScheme = uri.getScheme();
 
+        // Quick bail out if scheme is not "adbinapp"
         if (messageScheme == null || !messageScheme.equals(MessagingConstants.QueryParameters.ADOBE_INAPP)) {
             Log.debug(MessagingConstants.LOG_TAG, SELF_TAG, "Invalid message scheme found in URI. (%s)", urlString);
             return false;
         }
 
-        // url decode the query parameters
-        final String queryParams;
-        try {
-            queryParams = URLDecoder.decode(uri.getQuery(), StandardCharsets.UTF_8.toString());
-        } catch (final UnsupportedEncodingException exception) {
-            Log.debug(MessagingConstants.LOG_TAG, SELF_TAG,  "UnsupportedEncodingException occurred when decoding query parameters %s.", uri.getQuery());
-            return false;
-        }
-
-        // Populate message data
-        final Map<String, String> messageData = extractQueryParameters(queryParams);
-
         final MessageSettings messageSettings = fullscreenMessage.getMessageSettings();
         final Message message = (Message) messageSettings.getParent();
 
-        if (!MapUtils.isNullOrEmpty(messageData)) {
-            // handle optional tracking
-            final String interaction = messageData.remove(MessagingConstants.QueryParameters.INTERACTION);
-            if (!StringUtils.isNullOrEmpty(interaction)) {
-                // ensure we have the MessagingExtension class available for tracking
-                final Object messagingExtension = message.getParent();
-                if (messagingExtension != null) {
-                    Log.debug(MessagingConstants.LOG_TAG, SELF_TAG, "Tracking message interaction (%s)", interaction);
-                    message.track(interaction, MessagingEdgeEventType.IN_APP_INTERACT);
-                }
+        // Handle query parameters
+        final String queryString = uri.getQuery();
+        if (!StringUtils.isNullOrEmpty(queryString)) {
+
+            String decodedQueryString;
+            try {
+                decodedQueryString = URLDecoder.decode(queryString, StandardCharsets.UTF_8.toString());
+            } catch (final UnsupportedEncodingException exception) {
+                Log.debug(MessagingConstants.LOG_TAG, SELF_TAG,  "UnsupportedEncodingException occurred when decoding query parameters %s.", uri.getQuery());
+                return false;
             }
 
-            // handle optional deep link
-            String link = messageData.remove(MessagingConstants.QueryParameters.LINK);
-            if (!StringUtils.isNullOrEmpty(link)) {
-                // handle optional javascript code to be executed
-                if (link.startsWith(MessagingConstants.QueryParameters.JAVASCRIPT_QUERY_KEY)) {
-                    Log.debug(MessagingConstants.LOG_TAG, SELF_TAG, "Evaluating javascript (%s)", link);
-                    message.evaluateJavascript(link);
-                } else {
-                    // if we have any remaining query parameters we need to append them to the deeplink
-                    if (!messageData.isEmpty()) {
-                        for (final Map.Entry<String, String> entry : messageData.entrySet()) {
-                            link = link.concat("&").concat(entry.getKey()).concat("=").concat(entry.getValue());
-                        }
+            final Map<String, String> messageData = extractQueryParameters(decodedQueryString);
+            if (!MapUtils.isNullOrEmpty(messageData)) {
+                // handle optional tracking
+                final String interaction = messageData.remove(MessagingConstants.QueryParameters.INTERACTION);
+                if (!StringUtils.isNullOrEmpty(interaction)) {
+
+                    // ensure we have the MessagingExtension class available for tracking
+                    final Object messagingExtension = message.getParent();
+                    if (messagingExtension != null) {
+                        Log.debug(MessagingConstants.LOG_TAG, SELF_TAG, "Tracking message interaction (%s)", interaction);
+                        message.track(interaction, MessagingEdgeEventType.IN_APP_INTERACT);
                     }
-                    Log.debug(MessagingConstants.LOG_TAG, SELF_TAG, "Loading deeplink (%s)", link);
-                    openUrl(link);
+                }
+
+                // handle optional deep link
+                String link = messageData.remove(MessagingConstants.QueryParameters.LINK);
+                if (!StringUtils.isNullOrEmpty(link)) {
+
+                    // handle optional javascript code to be executed
+                    if (link.startsWith(MessagingConstants.QueryParameters.JAVASCRIPT_QUERY_KEY)) {
+                        Log.debug(MessagingConstants.LOG_TAG, SELF_TAG, "Evaluating javascript (%s)", link);
+                        message.evaluateJavascript(link);
+                    } else {
+
+                        // if we have any remaining query parameters we need to append them to the deeplink
+                        if (!messageData.isEmpty()) {
+                            for (final Map.Entry<String, String> entry : messageData.entrySet()) {
+                                link = link.concat("&").concat(entry.getKey()).concat("=").concat(entry.getValue());
+                            }
+                        }
+                        Log.debug(MessagingConstants.LOG_TAG, SELF_TAG, "Loading deeplink (%s)", link);
+                        openUrl(link);
+                    }
                 }
             }
         }
 
         final String host = uri.getHost();
-        if ((host.equals(MessagingConstants.QueryParameters.PATH_DISMISS)) || (host.equals(MessagingConstants.QueryParameters.PATH_CANCEL))) {
+        if (host.equals(MessagingConstants.QueryParameters.PATH_DISMISS)) {
+            Log.trace(MessagingConstants.LOG_TAG, SELF_TAG, "Captured dismiss button click on In-App Message.");
             message.dismiss(true);
         }
 

--- a/code/messaging/src/test/java/com/adobe/marketing/mobile/messaging/internal/MessagingFullscreenMessageDelegateTests.java
+++ b/code/messaging/src/test/java/com/adobe/marketing/mobile/messaging/internal/MessagingFullscreenMessageDelegateTests.java
@@ -218,6 +218,22 @@ public class MessagingFullscreenMessageDelegateTests {
     }
 
     @Test
+    public void test_overrideUrlLoad_uRLWithNoQueryParameters() {
+        // setup
+        when(mockFullscreenMessage.getMessageSettings()).thenReturn(mockMessageSettings);
+        when(mockMessageSettings.getParent()).thenReturn(internalMessage);
+
+        // test
+        internalMessage.overrideUrlLoad(mockFullscreenMessage, "adbinapp://dismiss");
+
+        // verify no message tracking call and message settings weren't created
+        verify(mockMessagingExtension, times(0)).sendPropositionInteraction(anyString(), any(MessagingEdgeEventType.class), eq(internalMessage));
+        verify(mockMessageSettings, times(1)).getParent();
+        // TODO: To verify if that dismiss by mocking FullscreenMessage in internalMessage class
+        //verify(mockFullscreenMessage, times(1)).dismiss();
+    }
+
+    @Test
     public void test_overrideUrlLoadWithJavascriptPayload() {
         // setup
         scriptHandlerMap = new HashMap<>();


### PR DESCRIPTION
- `URLDecoder.decode` method is not happy when an null/empty query parameters are passed to be decoded

- Fix adds a null check and act accordingly 