### PR TITLE
Fix display tracking accuracy

### DIFF
--- a/code/app/src/main/java/com/adobe/marketing/mobile/messagingsample/MainActivity.kt
+++ b/code/app/src/main/java/com/adobe/marketing/mobile/messagingsample/MainActivity.kt
@@ -545,6 +545,23 @@ class CustomDelegate : MessagingDelegate {
             this.currentMessage = (fullscreenMessage.parent) as? Message
             this.webview = currentMessage?.webView
 
+            // example: setting a javascript handler on the webview to retrieve javascript output from the loaded in-app html
+            // sample html script:
+            // <script>
+            // function getText() {
+            // var textBox = document.getElementById("myText");
+            // var textValue = textBox.value;
+            // myInappCallback.run(textValue);
+            // window.location.href = "adbinapp://dismiss";
+            // }
+            // </script>
+            currentMessage?.handleJavascriptMessage("myInappCallback") { content ->
+                if (content != null) {
+                    println("Javascript handler content: $content")
+                    currentMessage?.track(content, MessagingEdgeEventType.IN_APP_INTERACT)
+                }
+            }
+
             // if we're not showing the message now, we can save it for later
             if(!showMessages) {
                 println("message was suppressed: ${currentMessage?.id}")
@@ -557,15 +574,6 @@ class CustomDelegate : MessagingDelegate {
     override fun onShow(fullscreenMessage: FullscreenMessage?) {
         this.currentMessage = fullscreenMessage?.parent as Message?
         this.webview = currentMessage?.webView
-
-        // example: in-line handling of javascript calls in the AJO in-app message html
-        // the content callback will contain the output of (function() { return 'inline js return value'; })();
-        currentMessage?.handleJavascriptMessage("handler_name") { content ->
-            if (content != null) {
-                println("magical handling of our content from js! content is: $content")
-                currentMessage?.track(content, MessagingEdgeEventType.IN_APP_INTERACT)
-            }
-        }
 
         // example: running javascript on the webview created by the Messaging extension.
         // running javascript content must be done on the ui thread

--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/internal/InternalMessage.java
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/internal/InternalMessage.java
@@ -240,9 +240,6 @@ class InternalMessage extends MessagingFullscreenMessageDelegate implements Mess
 
     void show(final boolean withMessagingDelegateControl) {
         if (aepMessage != null) {
-            if (autoTrack) {
-                track(null, MessagingEdgeEventType.IN_APP_DISPLAY);
-            }
             aepMessage.show(withMessagingDelegateControl);
         }
     }

--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/internal/MessagingFullscreenMessageDelegate.java
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/internal/MessagingFullscreenMessageDelegate.java
@@ -23,11 +23,8 @@ import com.adobe.marketing.mobile.services.ui.UIService;
 import com.adobe.marketing.mobile.util.MapUtils;
 import com.adobe.marketing.mobile.util.StringUtils;
 
-import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.net.URLDecoder;
-import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -44,6 +41,10 @@ class MessagingFullscreenMessageDelegate implements FullscreenMessageDelegate {
      */
     @Override
     public void onShow(final FullscreenMessage fullscreenMessage) {
+        final InternalMessage message = (InternalMessage) fullscreenMessage.getParent();
+        if (message.getAutoTrack()) {
+            message.track(null, MessagingEdgeEventType.IN_APP_DISPLAY);
+        }
         Log.debug(MessagingConstants.LOG_TAG, SELF_TAG, "Fullscreen message shown.");
     }
 

--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/internal/MessagingFullscreenMessageDelegate.java
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/internal/MessagingFullscreenMessageDelegate.java
@@ -42,7 +42,7 @@ class MessagingFullscreenMessageDelegate implements FullscreenMessageDelegate {
     @Override
     public void onShow(final FullscreenMessage fullscreenMessage) {
         final InternalMessage message = (InternalMessage) fullscreenMessage.getParent();
-        if (message.getAutoTrack()) {
+        if (message != null && message.getAutoTrack()) {
             message.track(null, MessagingEdgeEventType.IN_APP_DISPLAY);
         }
         Log.debug(MessagingConstants.LOG_TAG, SELF_TAG, "Fullscreen message shown.");

--- a/code/messaging/src/test/java/com/adobe/marketing/mobile/messaging/internal/InternalMessageTests.java
+++ b/code/messaging/src/test/java/com/adobe/marketing/mobile/messaging/internal/InternalMessageTests.java
@@ -340,8 +340,6 @@ public class InternalMessageTests {
     @Test
     public void test_messageShow() {
         // setup
-        ArgumentCaptor<String> interactionArgumentCaptor = ArgumentCaptor.forClass(String.class);
-        ArgumentCaptor<MessagingEdgeEventType> messagingEdgeEventTypeArgumentCaptor = ArgumentCaptor.forClass(MessagingEdgeEventType.class);
         runUsingMockedServiceProvider(() -> {
             try {
                 internalMessage = new InternalMessage(mockMessagingExtension, createRuleConsequence(), new HashMap<>(), new HashMap<>());
@@ -353,21 +351,12 @@ public class InternalMessageTests {
 
             // verify fullscreen message show called
             verify(mockFullscreenMessage, times(1)).show(eq(false));
-
-            // verify tracking event data
-            verify(mockMessagingExtension, times(1)).sendPropositionInteraction(interactionArgumentCaptor.capture(), messagingEdgeEventTypeArgumentCaptor.capture(), any(InternalMessage.class));
-            MessagingEdgeEventType eventType = messagingEdgeEventTypeArgumentCaptor.getValue();
-            String interaction = interactionArgumentCaptor.getValue();
-            assertEquals(eventType, MessagingEdgeEventType.IN_APP_DISPLAY);
-            assertEquals(null, interaction);
         });
     }
 
     @Test
     public void test_messageShow_withShowMessageTrueInCustomDelegate() {
         // setup
-        ArgumentCaptor<String> interactionArgumentCaptor = ArgumentCaptor.forClass(String.class);
-        ArgumentCaptor<MessagingEdgeEventType> messagingEdgeEventTypeArgumentCaptor = ArgumentCaptor.forClass(MessagingEdgeEventType.class);
         runUsingMockedServiceProvider(() -> {
             // setup custom delegate, show message is true by default
             CustomMessagingDelegate customMessageDelegate = new CustomMessagingDelegate();
@@ -383,21 +372,12 @@ public class InternalMessageTests {
 
             // verify fullscreen message show called
             verify(mockFullscreenMessage, times(1)).show(eq(false));
-
-            // verify tracking event data
-            verify(mockMessagingExtension, times(1)).sendPropositionInteraction(interactionArgumentCaptor.capture(), messagingEdgeEventTypeArgumentCaptor.capture(), any(InternalMessage.class));
-            MessagingEdgeEventType eventType = messagingEdgeEventTypeArgumentCaptor.getValue();
-            String interaction = interactionArgumentCaptor.getValue();
-            assertEquals(eventType, MessagingEdgeEventType.IN_APP_DISPLAY);
-            assertEquals(null, interaction);
         });
     }
 
     @Test
     public void test_messageShow_withShowMessageFalseInCustomDelegate() {
         // setup
-        ArgumentCaptor<String> interactionArgumentCaptor = ArgumentCaptor.forClass(String.class);
-        ArgumentCaptor<MessagingEdgeEventType> messagingEdgeEventTypeArgumentCaptor = ArgumentCaptor.forClass(MessagingEdgeEventType.class);
         runUsingMockedServiceProvider(() -> {
             // setup custom delegate, show message is true by default
             CustomMessagingDelegate customMessageDelegate = new CustomMessagingDelegate();
@@ -415,13 +395,6 @@ public class InternalMessageTests {
 
             // verify fullscreen message show called
             verify(mockFullscreenMessage, times(1)).show(eq(false));
-
-            // verify tracking event data
-            verify(mockMessagingExtension, times(1)).sendPropositionInteraction(interactionArgumentCaptor.capture(), messagingEdgeEventTypeArgumentCaptor.capture(), any(InternalMessage.class));
-            MessagingEdgeEventType eventType = messagingEdgeEventTypeArgumentCaptor.getValue();
-            String interaction = interactionArgumentCaptor.getValue();
-            assertEquals(eventType, MessagingEdgeEventType.IN_APP_DISPLAY);
-            assertEquals(null, interaction);
         });
     }
 

--- a/code/messaging/src/test/java/com/adobe/marketing/mobile/messaging/internal/MessagingFullscreenMessageDelegateTests.java
+++ b/code/messaging/src/test/java/com/adobe/marketing/mobile/messaging/internal/MessagingFullscreenMessageDelegateTests.java
@@ -121,35 +121,80 @@ public class MessagingFullscreenMessageDelegateTests {
     }
 
     @Test
-    public void test_onMessageShow() {
+    public void test_onMessageShow_whenMessageAutoTrackIsTrue() {
         try (MockedStatic<Log> logMockedStatic = mockStatic(Log.class)) {
+            // setup
+            ArgumentCaptor<String> logArgumentCaptor = ArgumentCaptor.forClass(String.class);
+            ArgumentCaptor<String> interactionArgumentCaptor = ArgumentCaptor.forClass(String.class);
+            ArgumentCaptor<MessagingEdgeEventType> messagingEdgeEventTypeArgumentCaptor = ArgumentCaptor.forClass(MessagingEdgeEventType.class);
+            InternalMessage mockInternalMessage = Mockito.mock(InternalMessage.class);
+            when(mockInternalMessage.getAutoTrack()).thenReturn(true);
+            when(mockFullscreenMessage.getParent()).thenReturn(mockInternalMessage);
+
             // test
             internalMessage.onShow(mockFullscreenMessage);
 
-            // verify
-            logMockedStatic.verify(() -> Log.debug(anyString(), anyString(), anyString()), times(1));
+            // verify tracking event data
+            verify(mockInternalMessage, times(1)).track(interactionArgumentCaptor.capture(), messagingEdgeEventTypeArgumentCaptor.capture());
+            MessagingEdgeEventType eventType = messagingEdgeEventTypeArgumentCaptor.getValue();
+            String interaction = interactionArgumentCaptor.getValue();
+            assertEquals(eventType, MessagingEdgeEventType.IN_APP_DISPLAY);
+            assertEquals(null, interaction);
+
+            // verify message display logging
+            logMockedStatic.verify(() -> Log.debug(anyString(), anyString(), logArgumentCaptor.capture()), times(1));
+            assertEquals("Fullscreen message shown.", logArgumentCaptor.getValue());
+        }
+    }
+
+    @Test
+    public void test_onMessageShow_whenMessageAutoTrackIsFalse() {
+        try (MockedStatic<Log> logMockedStatic = mockStatic(Log.class)) {
+            // setup
+            ArgumentCaptor<String> logArgumentCaptor = ArgumentCaptor.forClass(String.class);
+            InternalMessage mockInternalMessage = Mockito.mock(InternalMessage.class);
+            when(mockInternalMessage.getAutoTrack()).thenReturn(false);
+            when(mockFullscreenMessage.getParent()).thenReturn(mockInternalMessage);
+
+            // test
+            internalMessage.onShow(mockFullscreenMessage);
+
+            // verify no tracking event
+            verify(mockInternalMessage, times(0)).track(anyString(), any(MessagingEdgeEventType.class));
+
+            // verify message display logging
+            logMockedStatic.verify(() -> Log.debug(anyString(), anyString(), logArgumentCaptor.capture()), times(1));
+            assertEquals("Fullscreen message shown.", logArgumentCaptor.getValue());
         }
     }
 
     @Test
     public void test_onMessageDismiss() {
         try (MockedStatic<Log> logMockedStatic = mockStatic(Log.class)) {
+            // setup
+            ArgumentCaptor<String> logArgumentCaptor = ArgumentCaptor.forClass(String.class);
+
             // test
             internalMessage.onDismiss(mockFullscreenMessage);
 
-            // verify
-            logMockedStatic.verify(() -> Log.debug(anyString(), anyString(), anyString()), times(1));
+            // verify message dismiss logging
+            logMockedStatic.verify(() -> Log.debug(anyString(), anyString(), logArgumentCaptor.capture()), times(1));
+            assertEquals("Fullscreen message dismissed.", logArgumentCaptor.getValue());
         }
     }
 
     @Test
     public void test_onMessageShowFailure() {
         try (MockedStatic<Log> logMockedStatic = mockStatic(Log.class)) {
+            // setup
+            ArgumentCaptor<String> logArgumentCaptor = ArgumentCaptor.forClass(String.class);
+
             // test
             internalMessage.onShowFailure();
 
-            // verify
-            logMockedStatic.verify(() -> Log.debug(anyString(), anyString(), anyString()), times(1));
+            // verify message failed to show logging
+            logMockedStatic.verify(() -> Log.debug(anyString(), anyString(), logArgumentCaptor.capture()), times(1));
+            assertEquals("Fullscreen message failed to show.", logArgumentCaptor.getValue());
         }
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Display tracking was incorrectly being done before the in-app message was actually displayed. Move the display tracking to MessagingFullscreenMessageDelegate.onShow to ensure that a message is actually displayed before display tracking is done.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
