### PR TITLE
[MOB-19375] -  HandleNotificationResponse API returns MessagingPushTrackingStatus enum

### DIFF
--- a/code/messaging/src/androidTest/java/com/adobe/marketing/mobile/messaging/internal/MessagingPublicAPITests.java
+++ b/code/messaging/src/androidTest/java/com/adobe/marketing/mobile/messaging/internal/MessagingPublicAPITests.java
@@ -318,17 +318,10 @@ public class MessagingPublicAPITests {
         // test
         Messaging.handleNotificationResponse(intent, true, null);
 
-        // verify messaging event
+        // verify no messaging request event is sent
         List<Event> messagingRequestEvents = getDispatchedEventsWith(MessagingTestConstants.EventType.MESSAGING,
                 EventSource.REQUEST_CONTENT);
-        assertEquals(1, messagingRequestEvents.size());
-        assertEquals(expectedMessagingEventData, messagingRequestEvents.get(0).getEventData().toString());
-
-        // verify push tracking edge event
-        List<Event> edgeRequestEvents = getDispatchedEventsWith(MessagingTestConstants.EventType.EDGE,
-                EventSource.REQUEST_CONTENT);
-        assertEquals(1, edgeRequestEvents.size());
-        assertEquals(expectedEdgeEventData, edgeRequestEvents.get(0).getEventData().toString());
+        assertEquals(0, messagingRequestEvents.size());
     }
 
     @Test

--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/MessagingPushTrackingStatus.java
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/MessagingPushTrackingStatus.java
@@ -1,0 +1,47 @@
+/*
+  Copyright 2023 Adobe. All rights reserved.
+  This file is licensed to you under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License. You may obtain a copy
+  of the License at http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software distributed under
+  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+  OF ANY KIND, either express or implied. See the License for the specific language
+  governing permissions and limitations under the License.
+*/
+
+package com.adobe.marketing.mobile;
+
+public enum MessagingPushTrackingStatus {
+    TRACKING_INITIATED(0, "Tracking initiated"),
+    NO_DATASET_CONFIGURED(1, "No dataset configured"),
+    NO_TRACKING_DATA(2, "Missing tracking data in the intent"),
+    INVALID_INTENT(3, "Provided intent for tracking is invalid"),
+    INVALID_MESSAGE_ID(4, "Provided MessageId for tracking is empty/null"),
+    UNKNOWN_ERROR(5, "Unknown error");
+
+    MessagingPushTrackingStatus(final int value, final String description) {
+        this.value = value;
+        this.description = description;
+    }
+    final int value;
+    final String description;
+
+    public String getDescription() {
+        return description;
+    }
+
+    public int getValue() {
+        return value;
+    }
+
+    public static MessagingPushTrackingStatus fromInt(final int value) {
+        for (MessagingPushTrackingStatus b : MessagingPushTrackingStatus.values()) {
+            if (b.value == (value)) {
+                return b;
+            }
+        }
+
+        return UNKNOWN_ERROR;
+    }
+}

--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/PushTrackingStatus.java
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/PushTrackingStatus.java
@@ -12,15 +12,34 @@
 
 package com.adobe.marketing.mobile;
 
-public enum MessagingPushTrackingStatus {
+public enum PushTrackingStatus {
+    /**
+     * This status is set when all the required data for tracking is available and when the tracking is initiated.
+     */
     TRACKING_INITIATED(0, "Tracking initiated"),
+    /**
+     * This status is set when the tracking is not initiated because no tracking dataset is configured.
+     */
     NO_DATASET_CONFIGURED(1, "No dataset configured"),
+
+    /**
+     * This status is set when the tracking is not initiated because the intent does not contain tracking data.
+     */
     NO_TRACKING_DATA(2, "Missing tracking data in the intent"),
+    /**
+     * This status is set when the tracking is not initiated because the intent is invalid.
+     */
     INVALID_INTENT(3, "Provided intent for tracking is invalid"),
+    /**
+     * This status is set when the tracking is not initiated because the message id is invalid.
+     */
     INVALID_MESSAGE_ID(4, "Provided MessageId for tracking is empty/null"),
+    /**
+     * This status is set when the tracking is not initiated because of an unknown error.
+     */
     UNKNOWN_ERROR(5, "Unknown error");
 
-    MessagingPushTrackingStatus(final int value, final String description) {
+    PushTrackingStatus(final int value, final String description) {
         this.value = value;
         this.description = description;
     }
@@ -35,8 +54,8 @@ public enum MessagingPushTrackingStatus {
         return value;
     }
 
-    public static MessagingPushTrackingStatus fromInt(final int value) {
-        for (MessagingPushTrackingStatus b : MessagingPushTrackingStatus.values()) {
+    public static PushTrackingStatus fromInt(final int value) {
+        for (PushTrackingStatus b : PushTrackingStatus.values()) {
             if (b.value == (value)) {
                 return b;
             }

--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/PushTrackingStatus.java
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/PushTrackingStatus.java
@@ -18,24 +18,24 @@ public enum PushTrackingStatus {
      */
     TRACKING_INITIATED(0, "Tracking initiated"),
     /**
-     * This status is set when the tracking is not initiated because no tracking dataset is configured.
+     * This status is set when tracking is not initiated because no tracking dataset is configured.
      */
     NO_DATASET_CONFIGURED(1, "No dataset configured"),
 
     /**
-     * This status is set when the tracking is not initiated because the intent does not contain tracking data.
+     * This status is set when tracking is not initiated because the intent does not contain tracking data.
      */
     NO_TRACKING_DATA(2, "Missing tracking data in the intent"),
     /**
-     * This status is set when the tracking is not initiated because the intent is invalid.
+     * This status is set when tracking is not initiated because the intent is invalid.
      */
     INVALID_INTENT(3, "Provided intent for tracking is invalid"),
     /**
-     * This status is set when the tracking is not initiated because the message id is invalid.
+     * This status is set when tracking is not initiated because the message id is invalid.
      */
     INVALID_MESSAGE_ID(4, "Provided MessageId for tracking is empty/null"),
     /**
-     * This status is set when the tracking is not initiated because of an unknown error.
+     * This status is set when tracking is not initiated because of an unknown error.
      */
     UNKNOWN_ERROR(5, "Unknown error");
 
@@ -46,14 +46,26 @@ public enum PushTrackingStatus {
     final int value;
     final String description;
 
+    /**
+     * @return  the string description of {@link PushTrackingStatus}
+     */
     public String getDescription() {
         return description;
     }
 
+    /**
+     * @return the enum {@code Integer} value of {@link PushTrackingStatus}
+     */
     public int getValue() {
         return value;
     }
 
+    /**
+     * Returns the {@link PushTrackingStatus} enum for the provided {@code int} value.
+     *
+     * @param value {@code int} value of the enum
+     * @return {@link PushTrackingStatus} enum value
+     */
     public static PushTrackingStatus fromInt(final int value) {
         for (PushTrackingStatus b : PushTrackingStatus.values()) {
             if (b.value == (value)) {

--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/PushTrackingStatus.java
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/PushTrackingStatus.java
@@ -67,7 +67,7 @@ public enum PushTrackingStatus {
      * @return {@link PushTrackingStatus} enum value
      */
     public static PushTrackingStatus fromInt(final int value) {
-        for (PushTrackingStatus b : PushTrackingStatus.values()) {
+        for (final PushTrackingStatus b : PushTrackingStatus.values()) {
             if (b.value == (value)) {
                 return b;
             }

--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/internal/MessagingConstants.java
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/internal/MessagingConstants.java
@@ -241,8 +241,10 @@ final class MessagingConstants {
     final class EventName {
         static final String MESSAGE_INTERACTION_EVENT = "Messaging interaction event";
         static final String PUSH_TRACKING_EDGE_EVENT = "Push tracking edge event";
+        static final String PUSH_TRACKING_STATUS_EVENT = "Push tracking status event";
         static final String PUSH_PROFILE_EDGE_EVENT = "Push notification profile edge event";
         static final String REFRESH_MESSAGES_EVENT = "Retrieve message definitions";
+
         static final String ASSURANCE_SPOOFED_IAM_EVENT_NAME = "Rule Consequence Event (Spoof)";
 
         private EventName() {

--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/internal/MessagingConstants.java
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/internal/MessagingConstants.java
@@ -15,7 +15,7 @@ package com.adobe.marketing.mobile.messaging.internal;
 final class MessagingConstants {
 
     static final String LOG_TAG = "Messaging";
-    static final String EXTENSION_VERSION = "2.1.5";
+    static final String EXTENSION_VERSION = "2.2.0";
     static final String FRIENDLY_EXTENSION_NAME = "Messaging";
     static final String EXTENSION_NAME = "com.adobe.messaging";
     static final String RULES_ENGINE_NAME = EXTENSION_NAME + ".rulesengine";
@@ -111,9 +111,11 @@ final class MessagingConstants {
             static final String TRACK_INFO_KEY_APPLICATION_OPENED = "applicationOpened";
             static final String TRACK_INFO_KEY_ACTION_ID = "actionId";
             static final String TRACK_INFO_KEY_ADOBE_XDM = "adobe_xdm";
-
             static final String REFRESH_MESSAGES = "refreshmessages";
 
+            static final String PUSH_NOTIFICATION_TRACKING_STATUS = "pushTrackingStatus";
+
+            static final String PUSH_NOTIFICATION_TRACKING_MESSAGE = "pushTrackingStatusMessage";
             private Messaging() {
             }
 

--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/internal/MessagingConstants.java
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/internal/MessagingConstants.java
@@ -15,7 +15,7 @@ package com.adobe.marketing.mobile.messaging.internal;
 final class MessagingConstants {
 
     static final String LOG_TAG = "Messaging";
-    static final String EXTENSION_VERSION = "2.1.4";
+    static final String EXTENSION_VERSION = "2.1.5";
     static final String FRIENDLY_EXTENSION_NAME = "Messaging";
     static final String EXTENSION_NAME = "com.adobe.messaging";
     static final String RULES_ENGINE_NAME = EXTENSION_NAME + ".rulesengine";

--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/internal/MessagingExtension.java
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/internal/MessagingExtension.java
@@ -254,6 +254,7 @@ public final class MessagingExtension extends Extension {
             final Map<String, Object> configSharedState = getSharedState(MessagingConstants.SharedState.Configuration.EXTENSION_NAME, eventToProcess);
             final String experienceEventDatasetId = DataReader.optString(configSharedState, MessagingConstants.SharedState.Configuration.EXPERIENCE_EVENT_DATASET_ID, "");
             if (StringUtils.isNullOrEmpty(experienceEventDatasetId)) {
+                MessagingUtils.sendTrackingResponseEvent(MessagingPushTrackingStatus.NO_DATASET_CONFIGURED, getApi(),eventToProcess);
                 Log.warning(LOG_TAG, SELF_TAG, "Unable to track push notification interaction, experience event dataset id is empty. Check the messaging launch extension to add the experience event dataset.");
                 return;
             }
@@ -298,7 +299,14 @@ public final class MessagingExtension extends Extension {
                 getApi());
     }
 
-    void handleTrackingInfo(final Event event, final String datasetId) {
+    /**
+     * Handles the push tracking information from the messaging request content event.
+     * <p>
+     *   The push tracking information is sent to the platform via configured dataset.
+     * @param event {@link Event} containing the push tracking information
+     * @param datasetId A valid {@link String} containing the dataset id
+     */
+    private void handleTrackingInfo(@NonNull final Event event,@NonNull final String datasetId) {
         final Map<String, Object> eventData = event.getEventData();
         if (eventData == null) {
             Log.debug(LOG_TAG, SELF_TAG, "handleTrackingInfo - Cannot track information, eventData is null.");
@@ -312,12 +320,6 @@ public final class MessagingExtension extends Extension {
         if (StringUtils.isNullOrEmpty(eventType) || StringUtils.isNullOrEmpty(messageId)) {
             MessagingUtils.sendTrackingResponseEvent(MessagingPushTrackingStatus.INVALID_MESSAGE_ID, getApi(),event);
             Log.debug(LOG_TAG, SELF_TAG, "handleTrackingInfo - Cannot track information, eventType or messageId is either null or empty.");
-            return;
-        }
-
-        if (StringUtils.isNullOrEmpty(datasetId)) {
-            MessagingUtils.sendTrackingResponseEvent(MessagingPushTrackingStatus.NO_DATASET_CONFIGURED, getApi(),event);
-            Log.warning(LOG_TAG, SELF_TAG, "Unable to record a message interaction, configuration information is not available.");
             return;
         }
 

--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/internal/MessagingExtension.java
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/internal/MessagingExtension.java
@@ -309,7 +309,8 @@ public final class MessagingExtension extends Extension {
     private void handleTrackingInfo(@NonNull final Event event,@NonNull final String datasetId) {
         final Map<String, Object> eventData = event.getEventData();
         if (eventData == null) {
-            Log.debug(LOG_TAG, SELF_TAG, "handleTrackingInfo - Cannot track information, eventData is null.");
+            MessagingUtils.sendTrackingResponseEvent(PushTrackingStatus.UNKNOWN_ERROR, getApi(),event);
+            Log.debug(LOG_TAG, SELF_TAG, "Unable to track push notification interaction, eventData is null.");
             return;
         }
         final String eventType = DataReader.optString(eventData, MessagingConstants.EventDataKeys.Messaging.TRACK_INFO_KEY_EVENT_TYPE, "");
@@ -317,9 +318,15 @@ public final class MessagingExtension extends Extension {
         final boolean isApplicationOpened = DataReader.optBoolean(eventData, MessagingConstants.EventDataKeys.Messaging.TRACK_INFO_KEY_APPLICATION_OPENED, false);
         final String actionId = DataReader.optString(eventData, MessagingConstants.EventDataKeys.Messaging.TRACK_INFO_KEY_ACTION_ID, null);
 
-        if (StringUtils.isNullOrEmpty(eventType) || StringUtils.isNullOrEmpty(messageId)) {
+        if (StringUtils.isNullOrEmpty(eventType)) {
+            MessagingUtils.sendTrackingResponseEvent(PushTrackingStatus.UNKNOWN_ERROR, getApi(),event);
+            Log.debug(LOG_TAG, SELF_TAG, "Unable to track push notification interaction, eventType is either null or empty.");
+            return;
+        }
+
+        if (StringUtils.isNullOrEmpty(messageId)) {
             MessagingUtils.sendTrackingResponseEvent(PushTrackingStatus.INVALID_MESSAGE_ID, getApi(),event);
-            Log.debug(LOG_TAG, SELF_TAG, "handleTrackingInfo - Cannot track information, eventType or messageId is either null or empty.");
+            Log.debug(LOG_TAG, SELF_TAG, "Unable to track push notification interaction, messageId is either null or empty.");
             return;
         }
 

--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/internal/MessagingExtension.java
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/internal/MessagingExtension.java
@@ -306,10 +306,10 @@ public final class MessagingExtension extends Extension {
      * @param event {@link Event} containing the push tracking information
      * @param datasetId A valid {@link String} containing the dataset id
      */
-    private void handleTrackingInfo(@NonNull final Event event,@NonNull final String datasetId) {
+    private void handleTrackingInfo(@NonNull final Event event, @NonNull final String datasetId) {
         final Map<String, Object> eventData = event.getEventData();
         if (eventData == null) {
-            MessagingUtils.sendTrackingResponseEvent(PushTrackingStatus.UNKNOWN_ERROR, getApi(),event);
+            MessagingUtils.sendTrackingResponseEvent(PushTrackingStatus.UNKNOWN_ERROR, getApi(), event);
             Log.debug(LOG_TAG, SELF_TAG, "Unable to track push notification interaction, eventData is null.");
             return;
         }
@@ -319,13 +319,13 @@ public final class MessagingExtension extends Extension {
         final String actionId = DataReader.optString(eventData, MessagingConstants.EventDataKeys.Messaging.TRACK_INFO_KEY_ACTION_ID, null);
 
         if (StringUtils.isNullOrEmpty(eventType)) {
-            MessagingUtils.sendTrackingResponseEvent(PushTrackingStatus.UNKNOWN_ERROR, getApi(),event);
+            MessagingUtils.sendTrackingResponseEvent(PushTrackingStatus.UNKNOWN_ERROR, getApi(), event);
             Log.debug(LOG_TAG, SELF_TAG, "Unable to track push notification interaction, eventType is either null or empty.");
             return;
         }
 
         if (StringUtils.isNullOrEmpty(messageId)) {
-            MessagingUtils.sendTrackingResponseEvent(PushTrackingStatus.INVALID_MESSAGE_ID, getApi(),event);
+            MessagingUtils.sendTrackingResponseEvent(PushTrackingStatus.INVALID_MESSAGE_ID, getApi(), event);
             Log.debug(LOG_TAG, SELF_TAG, "Unable to track push notification interaction, messageId is either null or empty.");
             return;
         }
@@ -349,7 +349,7 @@ public final class MessagingExtension extends Extension {
         xdmData.put(XDM, xdmMap);
         xdmData.put(META, metaMap);
 
-        MessagingUtils.sendTrackingResponseEvent(PushTrackingStatus.TRACKING_INITIATED, getApi(),event);
+        MessagingUtils.sendTrackingResponseEvent(PushTrackingStatus.TRACKING_INITIATED, getApi(), event);
 
         // dispatch push tracking event
         MessagingUtils.sendEvent(MessagingConstants.EventName.PUSH_TRACKING_EDGE_EVENT,

--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/internal/MessagingExtension.java
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/internal/MessagingExtension.java
@@ -59,6 +59,7 @@ import com.adobe.marketing.mobile.Extension;
 import com.adobe.marketing.mobile.ExtensionApi;
 import com.adobe.marketing.mobile.ExtensionEventListener;
 import com.adobe.marketing.mobile.MessagingEdgeEventType;
+import com.adobe.marketing.mobile.MessagingPushTrackingStatus;
 import com.adobe.marketing.mobile.SharedStateResolution;
 import com.adobe.marketing.mobile.SharedStateResult;
 import com.adobe.marketing.mobile.launch.rulesengine.LaunchRulesEngine;
@@ -309,11 +310,13 @@ public final class MessagingExtension extends Extension {
         final String actionId = DataReader.optString(eventData, MessagingConstants.EventDataKeys.Messaging.TRACK_INFO_KEY_ACTION_ID, null);
 
         if (StringUtils.isNullOrEmpty(eventType) || StringUtils.isNullOrEmpty(messageId)) {
+            MessagingUtils.sendTrackingResponseEvent(MessagingPushTrackingStatus.INVALID_MESSAGE_ID, getApi(),event);
             Log.debug(LOG_TAG, SELF_TAG, "handleTrackingInfo - Cannot track information, eventType or messageId is either null or empty.");
             return;
         }
 
         if (StringUtils.isNullOrEmpty(datasetId)) {
+            MessagingUtils.sendTrackingResponseEvent(MessagingPushTrackingStatus.NO_DATASET_CONFIGURED, getApi(),event);
             Log.warning(LOG_TAG, SELF_TAG, "Unable to record a message interaction, configuration information is not available.");
             return;
         }
@@ -336,6 +339,8 @@ public final class MessagingExtension extends Extension {
         final Map<String, Object> xdmData = new HashMap<>();
         xdmData.put(XDM, xdmMap);
         xdmData.put(META, metaMap);
+
+        MessagingUtils.sendTrackingResponseEvent(MessagingPushTrackingStatus.TRACKING_INITIATED, getApi(),event);
 
         // dispatch push tracking event
         MessagingUtils.sendEvent(MessagingConstants.EventName.PUSH_TRACKING_EDGE_EVENT,

--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/internal/MessagingExtension.java
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/internal/MessagingExtension.java
@@ -59,7 +59,7 @@ import com.adobe.marketing.mobile.Extension;
 import com.adobe.marketing.mobile.ExtensionApi;
 import com.adobe.marketing.mobile.ExtensionEventListener;
 import com.adobe.marketing.mobile.MessagingEdgeEventType;
-import com.adobe.marketing.mobile.MessagingPushTrackingStatus;
+import com.adobe.marketing.mobile.PushTrackingStatus;
 import com.adobe.marketing.mobile.SharedStateResolution;
 import com.adobe.marketing.mobile.SharedStateResult;
 import com.adobe.marketing.mobile.launch.rulesengine.LaunchRulesEngine;
@@ -254,7 +254,7 @@ public final class MessagingExtension extends Extension {
             final Map<String, Object> configSharedState = getSharedState(MessagingConstants.SharedState.Configuration.EXTENSION_NAME, eventToProcess);
             final String experienceEventDatasetId = DataReader.optString(configSharedState, MessagingConstants.SharedState.Configuration.EXPERIENCE_EVENT_DATASET_ID, "");
             if (StringUtils.isNullOrEmpty(experienceEventDatasetId)) {
-                MessagingUtils.sendTrackingResponseEvent(MessagingPushTrackingStatus.NO_DATASET_CONFIGURED, getApi(),eventToProcess);
+                MessagingUtils.sendTrackingResponseEvent(PushTrackingStatus.NO_DATASET_CONFIGURED, getApi(),eventToProcess);
                 Log.warning(LOG_TAG, SELF_TAG, "Unable to track push notification interaction, experience event dataset id is empty. Check the messaging launch extension to add the experience event dataset.");
                 return;
             }
@@ -318,7 +318,7 @@ public final class MessagingExtension extends Extension {
         final String actionId = DataReader.optString(eventData, MessagingConstants.EventDataKeys.Messaging.TRACK_INFO_KEY_ACTION_ID, null);
 
         if (StringUtils.isNullOrEmpty(eventType) || StringUtils.isNullOrEmpty(messageId)) {
-            MessagingUtils.sendTrackingResponseEvent(MessagingPushTrackingStatus.INVALID_MESSAGE_ID, getApi(),event);
+            MessagingUtils.sendTrackingResponseEvent(PushTrackingStatus.INVALID_MESSAGE_ID, getApi(),event);
             Log.debug(LOG_TAG, SELF_TAG, "handleTrackingInfo - Cannot track information, eventType or messageId is either null or empty.");
             return;
         }
@@ -342,7 +342,7 @@ public final class MessagingExtension extends Extension {
         xdmData.put(XDM, xdmMap);
         xdmData.put(META, metaMap);
 
-        MessagingUtils.sendTrackingResponseEvent(MessagingPushTrackingStatus.TRACKING_INITIATED, getApi(),event);
+        MessagingUtils.sendTrackingResponseEvent(PushTrackingStatus.TRACKING_INITIATED, getApi(),event);
 
         // dispatch push tracking event
         MessagingUtils.sendEvent(MessagingConstants.EventName.PUSH_TRACKING_EDGE_EVENT,

--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/internal/MessagingUtils.java
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/internal/MessagingUtils.java
@@ -181,11 +181,11 @@ class MessagingUtils {
     /**
      * Sends a tracking status response event with the given parameters.
      *
-     * @param status a {@link MessagingPushTrackingStatus} containing the status of the tracking request
+     * @param status a {@link PushTrackingStatus} containing the status of the tracking request
      * @param extensionApi {@link ExtensionApi} to use for dispatching the event
      * @param requestEvent {@link Event} to be used as the request event
      */
-    static void sendTrackingResponseEvent(final MessagingPushTrackingStatus status, final ExtensionApi extensionApi, final Event requestEvent) {
+    static void sendTrackingResponseEvent(final PushTrackingStatus status, final ExtensionApi extensionApi, final Event requestEvent) {
         final Map<String, Object> responseEventData = new HashMap<>();
         responseEventData.put(MessagingConstants.EventDataKeys.Messaging.PUSH_NOTIFICATION_TRACKING_STATUS, status.getValue());
         responseEventData.put(MessagingConstants.EventDataKeys.Messaging.PUSH_NOTIFICATION_TRACKING_MESSAGE, status.getDescription());

--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/internal/MessagingUtils.java
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/internal/MessagingUtils.java
@@ -28,6 +28,7 @@ import com.adobe.marketing.mobile.util.MapUtils;
 
 import java.io.File;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -175,6 +176,24 @@ class MessagingUtils {
      */
     static void sendEvent(final String eventName, final String eventType, final String eventSource, final Map<String, Object> data, final ExtensionApi extensionApi) {
         sendEvent(eventName, eventType, eventSource, data, null, extensionApi);
+    }
+
+    /**
+     * Sends a tracking status response event with the given parameters.
+     *
+     * @param status a {@link MessagingPushTrackingStatus} containing the status of the tracking request
+     * @param extensionApi {@link ExtensionApi} to use for dispatching the event
+     * @param requestEvent {@link Event} to be used as the request event
+     */
+    static void sendTrackingResponseEvent(final MessagingPushTrackingStatus status, final ExtensionApi extensionApi, final Event requestEvent) {
+        final Map<String, Object> responseEventData = new HashMap<>();
+        responseEventData.put(MessagingConstants.EventDataKeys.Messaging.PUSH_NOTIFICATION_TRACKING_STATUS, status.getValue());
+        responseEventData.put(MessagingConstants.EventDataKeys.Messaging.PUSH_NOTIFICATION_TRACKING_MESSAGE, status.getDescription());
+        final Event event = new Event.Builder("Push tracking status event", EventType.MESSAGING, EventSource.RESPONSE_CONTENT)
+                .setEventData(responseEventData)
+                .inResponseToEvent(requestEvent)
+                .build();
+        extensionApi.dispatch(event);
     }
 
     // ========================================================================================

--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/internal/MessagingUtils.java
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/internal/MessagingUtils.java
@@ -189,7 +189,7 @@ class MessagingUtils {
         final Map<String, Object> responseEventData = new HashMap<>();
         responseEventData.put(MessagingConstants.EventDataKeys.Messaging.PUSH_NOTIFICATION_TRACKING_STATUS, status.getValue());
         responseEventData.put(MessagingConstants.EventDataKeys.Messaging.PUSH_NOTIFICATION_TRACKING_MESSAGE, status.getDescription());
-        final Event event = new Event.Builder("Push tracking status event", EventType.MESSAGING, EventSource.RESPONSE_CONTENT)
+        final Event event = new Event.Builder(MessagingConstants.EventName.PUSH_TRACKING_STATUS_EVENT , EventType.MESSAGING, EventSource.RESPONSE_CONTENT)
                 .setEventData(responseEventData)
                 .inResponseToEvent(requestEvent)
                 .build();

--- a/code/messaging/src/phone/java/com/adobe/marketing/mobile/Messaging.java
+++ b/code/messaging/src/phone/java/com/adobe/marketing/mobile/Messaging.java
@@ -114,15 +114,19 @@ public final class Messaging {
 
     /**
      * Sends the push notification interactions as an experience event to Adobe Experience Edge.
+     * This method will return false if the notification being tracked is not from Adobe Journey Optimizer.
      *
      * @param intent            object which contains the tracking and xdm information.
      * @param applicationOpened Boolean values denoting whether the application was opened when notification was clicked
      * @param customActionId    String value of the custom action (e.g button id on the notification) which was clicked.
+     *
+     * @return boolean value indicating whether the intent has required details for tracking.
      */
-    public static void handleNotificationResponse(@NonNull final Intent intent, final boolean applicationOpened, @Nullable final String customActionId) {
+    @SuppressWarnings("UnusedReturnValue")
+    public static boolean handleNotificationResponse(@NonNull final Intent intent, final boolean applicationOpened, @Nullable final String customActionId) {
         if (intent == null) {
             Log.warning(LOG_TAG, CLASS_NAME, "Failed to track notification interactions, intent provided is null");
-            return;
+            return false;
         }
         String messageId = intent.getStringExtra(TRACK_INFO_KEY_MESSAGE_ID);
         if (StringUtils.isNullOrEmpty(messageId)) {
@@ -131,14 +135,14 @@ public final class Messaging {
             messageId = intent.getStringExtra(TRACK_INFO_KEY_GOOGLE_MESSAGE_ID);
             if (StringUtils.isNullOrEmpty(messageId)) {
                 Log.warning(LOG_TAG, CLASS_NAME, "Failed to track notification interactions, message id provided is null");
-                return;
+                return false;
             }
         }
 
         final String xdmData = intent.getStringExtra(TRACK_INFO_KEY_ADOBE_XDM);
         if (StringUtils.isNullOrEmpty(xdmData)) {
             Log.warning(LOG_TAG, CLASS_NAME, "No tracking data found in the intent, Ignoring to track AJO notification interactions.");
-            return;
+            return false;
         }
 
         final Map<String, Object> eventData = new HashMap<>();
@@ -167,6 +171,7 @@ public final class Messaging {
             public void call(final Event event) {
             }
         });
+        return true;
     }
 
     /**

--- a/code/messaging/src/phone/java/com/adobe/marketing/mobile/Messaging.java
+++ b/code/messaging/src/phone/java/com/adobe/marketing/mobile/Messaging.java
@@ -116,7 +116,6 @@ public final class Messaging {
 
     /**
      * Sends the push notification interactions as an experience event to Adobe Experience Edge.
-     * This method will return false if the notification being tracked is not from Adobe Journey Optimizer.
      *
      * @param intent            object which contains the tracking and xdm information.
      * @param applicationOpened Boolean values denoting whether the application was opened when notification was clicked
@@ -130,12 +129,11 @@ public final class Messaging {
 
     /**
      * Sends the push notification interactions as an experience event to Adobe Experience Edge.
-     * This method will return false if the notification being tracked is not from Adobe Journey Optimizer.
      *
      * @param intent            object which contains the tracking and xdm information.
      * @param applicationOpened Boolean values denoting whether the application was opened when notification was clicked
      * @param customActionId    String value of the custom action (e.g button id on the notification) which was clicked.
-     * @param callback          Callback which will be invoked with the status of the tracking.
+     * @param callback          Callback which will be invoked with the status of push notification tracking.
      */
     @SuppressWarnings("UnusedReturnValue")
     public static void handleNotificationResponse(@NonNull final Intent intent,

--- a/code/messaging/src/phone/java/com/adobe/marketing/mobile/Messaging.java
+++ b/code/messaging/src/phone/java/com/adobe/marketing/mobile/Messaging.java
@@ -141,10 +141,10 @@ public final class Messaging {
     public static void handleNotificationResponse(@NonNull final Intent intent,
                                                   final boolean applicationOpened,
                                                   @Nullable final String customActionId,
-                                                  @Nullable final AdobeCallback<MessagingPushTrackingStatus> callback) {
+                                                  @Nullable final AdobeCallback<PushTrackingStatus> callback) {
         if (intent == null) {
             Log.warning(LOG_TAG, CLASS_NAME, "Failed to track notification interactions, intent provided is null");
-            callTrackingCallback(MessagingPushTrackingStatus.INVALID_INTENT, callback);
+            callTrackingCallback(PushTrackingStatus.INVALID_INTENT, callback);
             return;
         }
         String messageId = intent.getStringExtra(TRACK_INFO_KEY_MESSAGE_ID);
@@ -154,7 +154,7 @@ public final class Messaging {
             messageId = intent.getStringExtra(TRACK_INFO_KEY_GOOGLE_MESSAGE_ID);
             if (StringUtils.isNullOrEmpty(messageId)) {
                 Log.warning(LOG_TAG, CLASS_NAME, "Failed to track notification interactions, message id provided is null");
-                callTrackingCallback(MessagingPushTrackingStatus.INVALID_MESSAGE_ID, callback);
+                callTrackingCallback(PushTrackingStatus.INVALID_MESSAGE_ID, callback);
                 return;
             }
         }
@@ -162,7 +162,7 @@ public final class Messaging {
         final String xdmData = intent.getStringExtra(TRACK_INFO_KEY_ADOBE_XDM);
         if (StringUtils.isNullOrEmpty(xdmData)) {
             Log.warning(LOG_TAG, CLASS_NAME, "No tracking data found in the intent, Ignoring to track AJO notification interactions.");
-            callTrackingCallback(MessagingPushTrackingStatus.NO_TRACKING_DATA, callback);
+            callTrackingCallback(PushTrackingStatus.NO_TRACKING_DATA, callback);
             return;
         }
 
@@ -185,7 +185,7 @@ public final class Messaging {
         MobileCore.dispatchEventWithResponseCallback(messagingEvent, TIMEOUT_MILLIS, new AdobeCallbackWithError<Event>() {
             @Override
             public void fail(final AdobeError adobeError) {
-                callTrackingCallback(MessagingPushTrackingStatus.UNKNOWN_ERROR,callback);
+                callTrackingCallback(PushTrackingStatus.UNKNOWN_ERROR,callback);
             }
 
             @Override
@@ -193,16 +193,16 @@ public final class Messaging {
                 final Map<String,Object> responseEventData = event.getEventData();
 
                 if (responseEventData == null) {
-                    callTrackingCallback(MessagingPushTrackingStatus.UNKNOWN_ERROR,callback);
+                    callTrackingCallback(PushTrackingStatus.UNKNOWN_ERROR,callback);
                 }
 
                 try {
                     final int resultStatusInteger = DataReader.getInt(responseEventData,PUSH_NOTIFICATION_TRACKING_STATUS);
-                    final MessagingPushTrackingStatus status = MessagingPushTrackingStatus.fromInt(resultStatusInteger);
+                    final PushTrackingStatus status = PushTrackingStatus.fromInt(resultStatusInteger);
                     callTrackingCallback(status,callback);
 
                 } catch (final DataReaderException e) {
-                    callTrackingCallback(MessagingPushTrackingStatus.UNKNOWN_ERROR,callback);
+                    callTrackingCallback(PushTrackingStatus.UNKNOWN_ERROR,callback);
                 }
             }
         });
@@ -222,7 +222,7 @@ public final class Messaging {
 
         MobileCore.dispatchEvent(refreshMessageEvent);
     }
-    private static void callTrackingCallback(final MessagingPushTrackingStatus trackingStatus, final AdobeCallback<MessagingPushTrackingStatus> callback) {
+    private static void callTrackingCallback(final PushTrackingStatus trackingStatus, final AdobeCallback<PushTrackingStatus> callback) {
         if (callback != null) {
             callback.call(trackingStatus);
         }

--- a/code/messaging/src/phone/java/com/adobe/marketing/mobile/Messaging.java
+++ b/code/messaging/src/phone/java/com/adobe/marketing/mobile/Messaging.java
@@ -26,7 +26,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 public final class Messaging {
-    private static final String EXTENSION_VERSION = "2.1.4";
+    private static final String EXTENSION_VERSION = "2.1.5";
     private static final String LOG_TAG = "Messaging";
     private static final String CLASS_NAME = "Messaging";
 
@@ -136,8 +136,9 @@ public final class Messaging {
         }
 
         final String xdmData = intent.getStringExtra(TRACK_INFO_KEY_ADOBE_XDM);
-        if (xdmData == null) {
-            Log.warning(LOG_TAG, CLASS_NAME, "XDM data provided is null");
+        if (StringUtils.isNullOrEmpty(xdmData)) {
+            Log.warning(LOG_TAG, CLASS_NAME, "No tracking data found in the intent, Ignoring to track AJO notification interactions.");
+            return;
         }
 
         final Map<String, Object> eventData = new HashMap<>();

--- a/code/messaging/src/test/java/com/adobe/marketing/mobile/MessagingTests.java
+++ b/code/messaging/src/test/java/com/adobe/marketing/mobile/MessagingTests.java
@@ -53,11 +53,11 @@ public class MessagingTests {
     ArgumentCaptor<AdobeCallbackWithError<Event>> callbackWithErrorArgumentCaptor;
     ArgumentCaptor<Event> dispatchEventCaptor;
     CountDownLatch latch;
-    MessagingPushTrackingStatus[] capturedStatus = new MessagingPushTrackingStatus[1];
+    PushTrackingStatus[] capturedStatus = new PushTrackingStatus[1];
     @Before
     public void before() {
         latch = new CountDownLatch(1);
-        capturedStatus = new MessagingPushTrackingStatus[1];
+        capturedStatus = new PushTrackingStatus[1];
 
         // Mock MobileCore
         dispatchEventCaptor = ArgumentCaptor.forClass(Event.class);
@@ -203,11 +203,11 @@ public class MessagingTests {
     public void test_handleNotificationResponse_WhenParamsAreNull() throws InterruptedException {
         final ArgumentCaptor<Event> eventCaptor = ArgumentCaptor.forClass(Event.class);
         final CountDownLatch latch = new CountDownLatch(1);
-        final MessagingPushTrackingStatus[] capturedStatus = new MessagingPushTrackingStatus[1];
+        final PushTrackingStatus[] capturedStatus = new PushTrackingStatus[1];
         // test
-        Messaging.handleNotificationResponse(null, false, null, new AdobeCallback<MessagingPushTrackingStatus>() {
+        Messaging.handleNotificationResponse(null, false, null, new AdobeCallback<PushTrackingStatus>() {
             @Override
-            public void call(MessagingPushTrackingStatus trackingStatus) {
+            public void call(PushTrackingStatus trackingStatus) {
                 latch.countDown();
                 capturedStatus[0] = trackingStatus;
             }
@@ -215,7 +215,7 @@ public class MessagingTests {
 
         // verify
         latch.await(2, TimeUnit.SECONDS);
-        assertEquals(MessagingPushTrackingStatus.INVALID_INTENT, capturedStatus[0]);
+        assertEquals(PushTrackingStatus.INVALID_INTENT, capturedStatus[0]);
         verifyNoInteractions(MobileCore.class);
     }
 
@@ -248,9 +248,9 @@ public class MessagingTests {
         when(mockIntent.getStringExtra(ArgumentMatchers.contains("messageId"))).thenReturn(messageId);
 
         // test
-        Messaging.handleNotificationResponse(mockIntent, true, mockActionId, new AdobeCallback<MessagingPushTrackingStatus>() {
+        Messaging.handleNotificationResponse(mockIntent, true, mockActionId, new AdobeCallback<PushTrackingStatus>() {
             @Override
-            public void call(MessagingPushTrackingStatus trackingStatus) {
+            public void call(PushTrackingStatus trackingStatus) {
                 latch.countDown();
                 capturedStatus[0] = trackingStatus;
             }
@@ -258,7 +258,7 @@ public class MessagingTests {
 
         // verify no event was sent
         latch.await(2, TimeUnit.SECONDS);
-        assertEquals(MessagingPushTrackingStatus.NO_TRACKING_DATA, capturedStatus[0]);
+        assertEquals(PushTrackingStatus.NO_TRACKING_DATA, capturedStatus[0]);
         verifyNoInteractions(MobileCore.class);
     }
 
@@ -269,9 +269,9 @@ public class MessagingTests {
         when(mockIntent.getStringExtra(anyString())).thenReturn(mockXdm);
 
         // test
-        Messaging.handleNotificationResponse(mockIntent, true, mockActionId, new AdobeCallback<MessagingPushTrackingStatus>() {
+        Messaging.handleNotificationResponse(mockIntent, true, mockActionId, new AdobeCallback<PushTrackingStatus>() {
             @Override
-            public void call(MessagingPushTrackingStatus trackingStatus) {
+            public void call(PushTrackingStatus trackingStatus) {
                 latch.countDown();
                 capturedStatus[0] = trackingStatus;
             }
@@ -292,7 +292,7 @@ public class MessagingTests {
 
         // verify the return value
         latch.await(2, TimeUnit.SECONDS);
-        assertEquals(MessagingPushTrackingStatus.UNKNOWN_ERROR, capturedStatus[0]);
+        assertEquals(PushTrackingStatus.UNKNOWN_ERROR, capturedStatus[0]);
     }
 
     @Test
@@ -303,16 +303,16 @@ public class MessagingTests {
         when(mockIntent.getStringExtra(anyString())).thenReturn(messageId);
 
         // test
-        Messaging.handleNotificationResponse(mockIntent, true, mockActionId, new AdobeCallback<MessagingPushTrackingStatus>() {
+        Messaging.handleNotificationResponse(mockIntent, true, mockActionId, new AdobeCallback<PushTrackingStatus>() {
             @Override
-            public void call(MessagingPushTrackingStatus trackingStatus) {
+            public void call(PushTrackingStatus trackingStatus) {
                 latch.countDown();
                 capturedStatus[0] = trackingStatus;
             }
         });
 
         // verify
-        assertEquals(MessagingPushTrackingStatus.INVALID_MESSAGE_ID, capturedStatus[0]);
+        assertEquals(PushTrackingStatus.INVALID_MESSAGE_ID, capturedStatus[0]);
         verify(mockIntent, times(2)).getStringExtra(anyString());
         verifyNoInteractions(MobileCore.class);
     }

--- a/code/messaging/src/test/java/com/adobe/marketing/mobile/MessagingTests.java
+++ b/code/messaging/src/test/java/com/adobe/marketing/mobile/MessagingTests.java
@@ -13,6 +13,7 @@ package com.adobe.marketing.mobile;
 import static com.adobe.marketing.mobile.messaging.internal.MessagingTestConstants.EventDataKeys.Messaging.TRACK_INFO_KEY_ACTION_ID;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -225,15 +226,8 @@ public class MessagingTests {
             // test
             Messaging.handleNotificationResponse(mockIntent, true, mockActionId);
 
-            // verify
-            verify(mockIntent, times(2)).getStringExtra(anyString());
-
-            // verify event
-            Event event = eventCaptor.getValue();
-            Map<String, Object> eventData = event.getEventData();
-            assertNotNull(eventData);
-            assertEquals(MessagingTestConstants.EventType.MESSAGING, event.getType());
-            assertEquals(eventData.get(TRACK_INFO_KEY_ACTION_ID), mockActionId);
+            // verify no event was sent
+            verifyNoInteractions(MobileCore.class);
         });
     }
 

--- a/code/messaging/src/test/java/com/adobe/marketing/mobile/MessagingTests.java
+++ b/code/messaging/src/test/java/com/adobe/marketing/mobile/MessagingTests.java
@@ -12,8 +12,10 @@ package com.adobe.marketing.mobile;
 
 import static com.adobe.marketing.mobile.messaging.internal.MessagingTestConstants.EventDataKeys.Messaging.TRACK_INFO_KEY_ACTION_ID;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -102,7 +104,7 @@ public class MessagingTests {
         boolean done = Messaging.addPushTrackingDetails(null, null, null);
 
         // verify
-        Assert.assertFalse(done);
+        assertFalse(done);
     }
 
     @Test
@@ -145,7 +147,7 @@ public class MessagingTests {
         boolean done = Messaging.addPushTrackingDetails(mockIntent, mockMessageId, mockDataMap);
 
         // verify
-        Assert.assertFalse(done);
+        assertFalse(done);
     }
 
     @Test
@@ -157,7 +159,7 @@ public class MessagingTests {
         boolean done = Messaging.addPushTrackingDetails(mockIntent, mockMessageId, mockDataMap);
 
         // verify
-        Assert.assertFalse(done);
+        assertFalse(done);
     }
 
     @Test
@@ -171,7 +173,7 @@ public class MessagingTests {
         boolean done = Messaging.addPushTrackingDetails(mockIntent, mockMessageId, mockDataMap);
 
         // verify
-        Assert.assertFalse(done);
+        assertFalse(done);
     }
 
     // ========================================================================================
@@ -182,9 +184,10 @@ public class MessagingTests {
         final ArgumentCaptor<Event> eventCaptor = ArgumentCaptor.forClass(Event.class);
         runWithMockedMobileCore(eventCaptor, null, null, () -> {
             // test
-            Messaging.handleNotificationResponse(null, false, null);
+            boolean result = Messaging.handleNotificationResponse(null, false, null);
 
             // verify
+            assertFalse(result);
             verifyNoInteractions(MobileCore.class);
         });
     }
@@ -224,9 +227,10 @@ public class MessagingTests {
             when(mockIntent.getStringExtra(ArgumentMatchers.contains("messageId"))).thenReturn(messageId);
 
             // test
-            Messaging.handleNotificationResponse(mockIntent, true, mockActionId);
+            boolean result = Messaging.handleNotificationResponse(mockIntent, true, mockActionId);
 
             // verify no event was sent
+            assertFalse(result);
             verifyNoInteractions(MobileCore.class);
         });
     }
@@ -242,10 +246,11 @@ public class MessagingTests {
             when(mockIntent.getStringExtra(anyString())).thenReturn(mockXdm);
 
             // test
-            Messaging.handleNotificationResponse(mockIntent, true, mockActionId);
+            boolean result = Messaging.handleNotificationResponse(mockIntent, true, mockActionId);
 
             // verify
             verify(mockIntent, times(2)).getStringExtra(anyString());
+            assertTrue(result);
 
             MobileCore.dispatchEventWithResponseCallback(eventCaptor.capture(), anyLong(), callbackCaptor.capture());
 
@@ -270,9 +275,10 @@ public class MessagingTests {
             when(mockIntent.getStringExtra(anyString())).thenReturn(messageId);
 
             // test
-            Messaging.handleNotificationResponse(mockIntent, true, mockActionId);
+            boolean result = Messaging.handleNotificationResponse(mockIntent, true, mockActionId);
 
             // verify
+            assertFalse(result);
             verify(mockIntent, times(2)).getStringExtra(anyString());
             verifyNoInteractions(MobileCore.class);
         });

--- a/code/messaging/src/test/java/com/adobe/marketing/mobile/MessagingTests.java
+++ b/code/messaging/src/test/java/com/adobe/marketing/mobile/MessagingTests.java
@@ -10,54 +10,75 @@
 */
 package com.adobe.marketing.mobile;
 
-import static com.adobe.marketing.mobile.messaging.internal.MessagingTestConstants.EventDataKeys.Messaging.TRACK_INFO_KEY_ACTION_ID;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
+
 
 import android.content.Intent;
 
 import com.adobe.marketing.mobile.messaging.internal.MessagingExtension;
 import com.adobe.marketing.mobile.messaging.internal.MessagingTestConstants;
 
+import org.junit.After;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mock;
 import org.mockito.MockedStatic;
-import org.mockito.Mockito;
 import org.mockito.junit.MockitoJUnitRunner;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 
 @RunWith(MockitoJUnitRunner.Silent.class)
 public class MessagingTests {
     @Mock
     Intent mockIntent;
+    MockedStatic<MobileCore> mobileCore;
+    ArgumentCaptor<AdobeCallbackWithError<Event>> callbackWithErrorArgumentCaptor;
+    ArgumentCaptor<Event> dispatchEventCaptor;
+    CountDownLatch latch;
+    MessagingPushTrackingStatus[] capturedStatus = new MessagingPushTrackingStatus[1];
+    @Before
+    public void before() {
+        latch = new CountDownLatch(1);
+        capturedStatus = new MessagingPushTrackingStatus[1];
 
-    private void runWithMockedMobileCore(final ArgumentCaptor<Event> eventArgumentCaptor,
-                                         final ArgumentCaptor<AdobeCallbackWithError<Event>> callbackWithErrorArgumentCaptor,
-                                         final ArgumentCaptor<ExtensionErrorCallback<ExtensionError>> extensionErrorCallbackArgumentCaptor,
-                                         final Runnable testRunnable) {
-        try (MockedStatic<MobileCore> mobileCoreMockedStatic = Mockito.mockStatic(MobileCore.class)) {
-            mobileCoreMockedStatic.when(() -> MobileCore.registerExtension(any(), extensionErrorCallbackArgumentCaptor != null ? extensionErrorCallbackArgumentCaptor.capture() : any(ExtensionErrorCallback.class))).thenCallRealMethod();
-            mobileCoreMockedStatic.when(() -> MobileCore.dispatchEventWithResponseCallback(eventArgumentCaptor  != null ? eventArgumentCaptor.capture() : any(Event.class), anyLong(), callbackWithErrorArgumentCaptor != null ? callbackWithErrorArgumentCaptor.capture() : any(AdobeCallbackWithError.class))).thenCallRealMethod();
-            mobileCoreMockedStatic.when(() -> MobileCore.dispatchEvent(eventArgumentCaptor  != null ? eventArgumentCaptor.capture() : any(Event.class))).thenCallRealMethod();
-            testRunnable.run();
-        }
+        // Mock MobileCore
+        dispatchEventCaptor = ArgumentCaptor.forClass(Event.class);
+        callbackWithErrorArgumentCaptor = ArgumentCaptor.forClass(AdobeCallbackWithError.class);
+
+        mobileCore = mockStatic(MobileCore.class);
+
+        mobileCore.when(() -> MobileCore.dispatchEventWithResponseCallback(dispatchEventCaptor.capture(), anyLong(),callbackWithErrorArgumentCaptor.capture())).thenCallRealMethod();
+        mobileCore.when(() -> MobileCore.dispatchEvent(dispatchEventCaptor.capture())).thenCallRealMethod();
+
     }
+
+    @After
+    public void after() {
+        mobileCore.close();
+        dispatchEventCaptor = null;
+        callbackWithErrorArgumentCaptor = null;
+        capturedStatus = null;
+        latch = null;
+    }
+
 
     // ========================================================================================
     // extensionVersion
@@ -77,22 +98,21 @@ public class MessagingTests {
 
     @Test
     public void test_registerExtensionAPI() {
-        final ArgumentCaptor<Event> eventCaptor = ArgumentCaptor.forClass(Event.class);
         final ArgumentCaptor<ExtensionErrorCallback<ExtensionError>> callbackCaptor = ArgumentCaptor.forClass(ExtensionErrorCallback.class);
-        runWithMockedMobileCore(eventCaptor, null, callbackCaptor, () -> {
-            // test
-            Messaging.registerExtension();
 
-            // The monitor extension should register with core
-            MobileCore.registerExtension(ArgumentMatchers.eq(MessagingExtension.class), callbackCaptor.capture());
+        // test
+        Messaging.registerExtension();
 
-            // verify the callback
-            ExtensionErrorCallback extensionErrorCallback = callbackCaptor.getAllValues().get(0);
-            Assert.assertNotNull("The extension callback should not be null", extensionErrorCallback);
+        // The monitor extension should register with core
+        mobileCore.verify(() -> MobileCore.registerExtension(any(), callbackCaptor.capture()));
+        MobileCore.registerExtension(ArgumentMatchers.eq(MessagingExtension.class), callbackCaptor.capture());
 
-            // should not crash on calling the callback
-            extensionErrorCallback.error(ExtensionError.UNEXPECTED_ERROR);
-        });
+        // verify the callback
+        ExtensionErrorCallback extensionErrorCallback = callbackCaptor.getAllValues().get(0);
+        Assert.assertNotNull("The extension callback should not be null", extensionErrorCallback);
+
+        // should not crash on calling the callback
+        extensionErrorCallback.error(ExtensionError.UNEXPECTED_ERROR);
     }
 
     // ========================================================================================
@@ -180,22 +200,27 @@ public class MessagingTests {
     // handleNotificationResponse
     // ========================================================================================
     @Test
-    public void test_handleNotificationResponse_WhenParamsAreNull() {
+    public void test_handleNotificationResponse_WhenParamsAreNull() throws InterruptedException {
         final ArgumentCaptor<Event> eventCaptor = ArgumentCaptor.forClass(Event.class);
-        runWithMockedMobileCore(eventCaptor, null, null, () -> {
-            // test
-            boolean result = Messaging.handleNotificationResponse(null, false, null);
-
-            // verify
-            assertFalse(result);
-            verifyNoInteractions(MobileCore.class);
+        final CountDownLatch latch = new CountDownLatch(1);
+        final MessagingPushTrackingStatus[] capturedStatus = new MessagingPushTrackingStatus[1];
+        // test
+        Messaging.handleNotificationResponse(null, false, null, new AdobeCallback<MessagingPushTrackingStatus>() {
+            @Override
+            public void call(MessagingPushTrackingStatus trackingStatus) {
+                latch.countDown();
+                capturedStatus[0] = trackingStatus;
+            }
         });
+
+        // verify
+        latch.await(2, TimeUnit.SECONDS);
+        assertEquals(MessagingPushTrackingStatus.INVALID_INTENT, capturedStatus[0]);
+        verifyNoInteractions(MobileCore.class);
     }
 
     @Test
     public void test_handleNotificationResponse() {
-        final ArgumentCaptor<Event> eventCaptor = ArgumentCaptor.forClass(Event.class);
-        runWithMockedMobileCore(eventCaptor, null, null, () -> {
             String mockActionId = "mockActionId";
             String mockXdm = "mockXdm";
 
@@ -206,106 +231,111 @@ public class MessagingTests {
 
             // verify
             verify(mockIntent, times(2)).getStringExtra(anyString());
-            MobileCore.dispatchEvent(eventCaptor.capture(), any(ExtensionErrorCallback.class));
+            mobileCore.verify(() -> MobileCore.dispatchEventWithResponseCallback(any(),anyLong(),any()));
 
             // verify event
-            Event event = eventCaptor.getValue();
+            Event event = dispatchEventCaptor.getValue();
             Map<String, Object> eventData = event.getEventData();
             assertNotNull(eventData);
             assertEquals(MessagingTestConstants.EventType.MESSAGING, event.getType());
-            assertEquals(eventData.get(TRACK_INFO_KEY_ACTION_ID), mockActionId);
-        });
+            assertEquals(eventData.get("actionId"), mockActionId);
     }
 
     @Test
-    public void test_handleNotificationResponseNoXdmData() {
-        final ArgumentCaptor<Event> eventCaptor = ArgumentCaptor.forClass(Event.class);
-        runWithMockedMobileCore(eventCaptor, null, null, () -> {
-            String mockActionId = "mockActionId";
-            String messageId = "messageId";
+    public void test_handleNotificationResponseNoXdmData() throws Exception {
+        String mockActionId = "mockActionId";
+        String messageId = "messageId";
+        when(mockIntent.getStringExtra(ArgumentMatchers.contains("messageId"))).thenReturn(messageId);
 
-            when(mockIntent.getStringExtra(ArgumentMatchers.contains("messageId"))).thenReturn(messageId);
-
-            // test
-            boolean result = Messaging.handleNotificationResponse(mockIntent, true, mockActionId);
-
-            // verify no event was sent
-            assertFalse(result);
-            verifyNoInteractions(MobileCore.class);
+        // test
+        Messaging.handleNotificationResponse(mockIntent, true, mockActionId, new AdobeCallback<MessagingPushTrackingStatus>() {
+            @Override
+            public void call(MessagingPushTrackingStatus trackingStatus) {
+                latch.countDown();
+                capturedStatus[0] = trackingStatus;
+            }
         });
+
+        // verify no event was sent
+        latch.await(2, TimeUnit.SECONDS);
+        assertEquals(MessagingPushTrackingStatus.NO_TRACKING_DATA, capturedStatus[0]);
+        verifyNoInteractions(MobileCore.class);
     }
 
     @Test
-    public void test_handleNotificationResponseEventDispatchError() {
-        final ArgumentCaptor<Event> eventCaptor = ArgumentCaptor.forClass(Event.class);
-        final ArgumentCaptor<AdobeCallbackWithError<Event>> callbackCaptor = ArgumentCaptor.forClass(AdobeCallbackWithError.class);
-        runWithMockedMobileCore(eventCaptor, callbackCaptor, null, () -> {
-            String mockActionId = "mockActionId";
-            String mockXdm = "mockXdm";
+    public void test_handleNotificationResponse_EventDispatchError() throws Exception{
+        String mockActionId = "mockActionId";
+        String mockXdm = "mockXdm";
+        when(mockIntent.getStringExtra(anyString())).thenReturn(mockXdm);
 
-            when(mockIntent.getStringExtra(anyString())).thenReturn(mockXdm);
-
-            // test
-            boolean result = Messaging.handleNotificationResponse(mockIntent, true, mockActionId);
-
-            // verify
-            verify(mockIntent, times(2)).getStringExtra(anyString());
-            assertTrue(result);
-
-            MobileCore.dispatchEventWithResponseCallback(eventCaptor.capture(), anyLong(), callbackCaptor.capture());
-
-            // verify event
-            Event event = eventCaptor.getAllValues().get(0);
-            Map<String, Object> eventData = event.getEventData();
-            assertNotNull(eventData);
-            assertEquals(MessagingTestConstants.EventType.MESSAGING, event.getType());
-            assertEquals(eventData.get(TRACK_INFO_KEY_ACTION_ID), mockActionId);
-            // no exception should occur when triggering unexpected error callback
-            callbackCaptor.getAllValues().get(0).fail(AdobeError.UNEXPECTED_ERROR);
+        // test
+        Messaging.handleNotificationResponse(mockIntent, true, mockActionId, new AdobeCallback<MessagingPushTrackingStatus>() {
+            @Override
+            public void call(MessagingPushTrackingStatus trackingStatus) {
+                latch.countDown();
+                capturedStatus[0] = trackingStatus;
+            }
         });
+
+        // verify
+        mobileCore.verify(() -> MobileCore.dispatchEventWithResponseCallback(any(),anyLong(),any()));
+
+        // verify event
+        Event event = dispatchEventCaptor.getAllValues().get(0);
+        Map<String, Object> eventData = event.getEventData();
+        assertNotNull(eventData);
+        assertEquals(MessagingTestConstants.EventType.MESSAGING, event.getType());
+        assertEquals(eventData.get("actionId"), mockActionId);
+
+        // no exception should occur when triggering unexpected error callback
+        callbackWithErrorArgumentCaptor.getAllValues().get(0).fail(AdobeError.UNEXPECTED_ERROR);
+
+        // verify the return value
+        latch.await(2, TimeUnit.SECONDS);
+        assertEquals(MessagingPushTrackingStatus.UNKNOWN_ERROR, capturedStatus[0]);
     }
 
     @Test
     public void test_handleNotificationResponseWithEmptyMessageId() {
-        final ArgumentCaptor<Event> eventCaptor = ArgumentCaptor.forClass(Event.class);
-        runWithMockedMobileCore(eventCaptor, null, null, () -> {
-            String mockActionId = "mockActionId";
-            String messageId = "";
+        String mockActionId = "mockActionId";
+        String messageId = "";
 
-            when(mockIntent.getStringExtra(anyString())).thenReturn(messageId);
+        when(mockIntent.getStringExtra(anyString())).thenReturn(messageId);
 
-            // test
-            boolean result = Messaging.handleNotificationResponse(mockIntent, true, mockActionId);
-
-            // verify
-            assertFalse(result);
-            verify(mockIntent, times(2)).getStringExtra(anyString());
-            verifyNoInteractions(MobileCore.class);
+        // test
+        Messaging.handleNotificationResponse(mockIntent, true, mockActionId, new AdobeCallback<MessagingPushTrackingStatus>() {
+            @Override
+            public void call(MessagingPushTrackingStatus trackingStatus) {
+                latch.countDown();
+                capturedStatus[0] = trackingStatus;
+            }
         });
+
+        // verify
+        assertEquals(MessagingPushTrackingStatus.INVALID_MESSAGE_ID, capturedStatus[0]);
+        verify(mockIntent, times(2)).getStringExtra(anyString());
+        verifyNoInteractions(MobileCore.class);
     }
 
     @Test
     public void test_handleNotificationResponseWithEmptyAction() {
-        final ArgumentCaptor<Event> eventCaptor = ArgumentCaptor.forClass(Event.class);
-        runWithMockedMobileCore(eventCaptor, null, null, () -> {
-            String mockActionId = "";
-            String messageId = "mockXdm";
+        String mockActionId = "";
+        String messageId = "mockXdm";
 
-            when(mockIntent.getStringExtra(anyString())).thenReturn(messageId);
+        when(mockIntent.getStringExtra(anyString())).thenReturn(messageId);
 
-            // test
-            Messaging.handleNotificationResponse(mockIntent, true, mockActionId);
+        // test
+        Messaging.handleNotificationResponse(mockIntent, true, mockActionId);
 
-            // verify
-            verify(mockIntent, times(2)).getStringExtra(anyString());
+        // verify
+        verify(mockIntent, times(2)).getStringExtra(anyString());
 
-            // verify event
-            Event event = eventCaptor.getAllValues().get(0);
-            Map<String, Object> eventData = event.getEventData();
-            assertNotNull(eventData);
-            assertEquals(MessagingTestConstants.EventType.MESSAGING, event.getType());
-            assertEquals("", mockActionId);
-        });
+        // verify event
+        Event event = dispatchEventCaptor.getAllValues().get(0);
+        Map<String, Object> eventData = event.getEventData();
+        assertNotNull(eventData);
+        assertEquals(MessagingTestConstants.EventType.MESSAGING, event.getType());
+        assertEquals("", mockActionId);
     }
 
     // ========================================================================================
@@ -313,19 +343,15 @@ public class MessagingTests {
     // ========================================================================================
     @Test
     public void test_refreshInAppMessage() {
-        final ArgumentCaptor<Event> eventCaptor = ArgumentCaptor.forClass(Event.class);
-        runWithMockedMobileCore(eventCaptor, null, null, () -> {
+        // test
+        Messaging.refreshInAppMessages();
 
-            // test
-            Messaging.refreshInAppMessages();
-
-            // verify event
-            Event event = eventCaptor.getValue();
-            Map<String, Object> eventData = event.getEventData();
-            assertNotNull(eventData);
-            assertEquals(MessagingTestConstants.EventType.MESSAGING, event.getType());
-            assertEquals(MessagingTestConstants.EventSource.REQUEST_CONTENT, event.getSource());
-            assertEquals(MessagingTestConstants.EventName.REFRESH_MESSAGES_EVENT, event.getName());
-        });
+        // verify event
+        Event event = dispatchEventCaptor.getValue();
+        Map<String, Object> eventData = event.getEventData();
+        assertNotNull(eventData);
+        assertEquals(MessagingTestConstants.EventType.MESSAGING, event.getType());
+        assertEquals(MessagingTestConstants.EventSource.REQUEST_CONTENT, event.getSource());
+        assertEquals(MessagingTestConstants.EventName.REFRESH_MESSAGES_EVENT, event.getName());
     }
 }

--- a/code/messaging/src/test/java/com/adobe/marketing/mobile/messaging/internal/MessagingExtensionTests.java
+++ b/code/messaging/src/test/java/com/adobe/marketing/mobile/messaging/internal/MessagingExtensionTests.java
@@ -748,8 +748,8 @@ public class MessagingExtensionTests {
             verify(mockExtensionApi, times(1)).dispatch(dispatchEventCaptor.capture());
             final Event pushTrackingStatusEvent = dispatchEventCaptor.getAllValues().get(0);
             assertEquals("Push tracking status event", pushTrackingStatusEvent.getName());
-            assertEquals(PushTrackingStatus.INVALID_MESSAGE_ID.getValue(), pushTrackingStatusEvent.getEventData().get("pushTrackingStatus"));
-            assertEquals(PushTrackingStatus.INVALID_MESSAGE_ID.getDescription(), pushTrackingStatusEvent.getEventData().get("pushTrackingStatusMessage"));
+            assertEquals(PushTrackingStatus.UNKNOWN_ERROR.getValue(), pushTrackingStatusEvent.getEventData().get("pushTrackingStatus"));
+            assertEquals(PushTrackingStatus.UNKNOWN_ERROR.getDescription(), pushTrackingStatusEvent.getEventData().get("pushTrackingStatusMessage"));
         });
     }
 

--- a/code/messaging/src/test/java/com/adobe/marketing/mobile/messaging/internal/MessagingExtensionTests.java
+++ b/code/messaging/src/test/java/com/adobe/marketing/mobile/messaging/internal/MessagingExtensionTests.java
@@ -35,7 +35,7 @@ import com.adobe.marketing.mobile.EventSource;
 import com.adobe.marketing.mobile.EventType;
 import com.adobe.marketing.mobile.ExtensionApi;
 import com.adobe.marketing.mobile.MessagingEdgeEventType;
-import com.adobe.marketing.mobile.MessagingPushTrackingStatus;
+import com.adobe.marketing.mobile.PushTrackingStatus;
 import com.adobe.marketing.mobile.MobileCore;
 import com.adobe.marketing.mobile.SharedStateResolution;
 import com.adobe.marketing.mobile.SharedStateResult;
@@ -660,8 +660,8 @@ public class MessagingExtensionTests {
             assertEquals("Push tracking status event", pushTrackingStatusEvent.getName());
             assertEquals(EventType.MESSAGING, pushTrackingStatusEvent.getType());
             assertEquals(EventSource.RESPONSE_CONTENT, pushTrackingStatusEvent.getSource());
-            assertEquals(MessagingPushTrackingStatus.TRACKING_INITIATED.getValue(), pushTrackingStatusEvent.getEventData().get("pushTrackingStatus"));
-            assertEquals(MessagingPushTrackingStatus.TRACKING_INITIATED.getDescription(), pushTrackingStatusEvent.getEventData().get("pushTrackingStatusMessage"));
+            assertEquals(PushTrackingStatus.TRACKING_INITIATED.getValue(), pushTrackingStatusEvent.getEventData().get("pushTrackingStatus"));
+            assertEquals(PushTrackingStatus.TRACKING_INITIATED.getDescription(), pushTrackingStatusEvent.getEventData().get("pushTrackingStatusMessage"));
 
             // verify push tracking status event
             final Event pushTrackingEdgeEvent = dispatchEventCaptor.getAllValues().get(1);
@@ -695,8 +695,8 @@ public class MessagingExtensionTests {
             // verify push tracking status event
             final Event pushTrackingStatusEvent = dispatchEventCaptor.getAllValues().get(0);
             assertEquals("Push tracking status event", pushTrackingStatusEvent.getName());
-            assertEquals(MessagingPushTrackingStatus.TRACKING_INITIATED.getValue(), pushTrackingStatusEvent.getEventData().get("pushTrackingStatus"));
-            assertEquals(MessagingPushTrackingStatus.TRACKING_INITIATED.getDescription(), pushTrackingStatusEvent.getEventData().get("pushTrackingStatusMessage"));
+            assertEquals(PushTrackingStatus.TRACKING_INITIATED.getValue(), pushTrackingStatusEvent.getEventData().get("pushTrackingStatus"));
+            assertEquals(PushTrackingStatus.TRACKING_INITIATED.getDescription(), pushTrackingStatusEvent.getEventData().get("pushTrackingStatusMessage"));
 
             // verify push tracking status event
             final Event pushTrackingEdgeEvent = dispatchEventCaptor.getAllValues().get(1);
@@ -748,8 +748,8 @@ public class MessagingExtensionTests {
             verify(mockExtensionApi, times(1)).dispatch(dispatchEventCaptor.capture());
             final Event pushTrackingStatusEvent = dispatchEventCaptor.getAllValues().get(0);
             assertEquals("Push tracking status event", pushTrackingStatusEvent.getName());
-            assertEquals(MessagingPushTrackingStatus.INVALID_MESSAGE_ID.getValue(), pushTrackingStatusEvent.getEventData().get("pushTrackingStatus"));
-            assertEquals(MessagingPushTrackingStatus.INVALID_MESSAGE_ID.getDescription(), pushTrackingStatusEvent.getEventData().get("pushTrackingStatusMessage"));
+            assertEquals(PushTrackingStatus.INVALID_MESSAGE_ID.getValue(), pushTrackingStatusEvent.getEventData().get("pushTrackingStatus"));
+            assertEquals(PushTrackingStatus.INVALID_MESSAGE_ID.getDescription(), pushTrackingStatusEvent.getEventData().get("pushTrackingStatusMessage"));
         });
     }
 
@@ -767,8 +767,8 @@ public class MessagingExtensionTests {
             verify(mockExtensionApi, times(1)).dispatch(dispatchEventCaptor.capture());
             final Event pushTrackingStatusEvent = dispatchEventCaptor.getAllValues().get(0);
             assertEquals("Push tracking status event", pushTrackingStatusEvent.getName());
-            assertEquals(MessagingPushTrackingStatus.INVALID_MESSAGE_ID.getValue(), pushTrackingStatusEvent.getEventData().get("pushTrackingStatus"));
-            assertEquals(MessagingPushTrackingStatus.INVALID_MESSAGE_ID.getDescription(), pushTrackingStatusEvent.getEventData().get("pushTrackingStatusMessage"));
+            assertEquals(PushTrackingStatus.INVALID_MESSAGE_ID.getValue(), pushTrackingStatusEvent.getEventData().get("pushTrackingStatus"));
+            assertEquals(PushTrackingStatus.INVALID_MESSAGE_ID.getDescription(), pushTrackingStatusEvent.getEventData().get("pushTrackingStatusMessage"));
         });
     }
 
@@ -790,8 +790,8 @@ public class MessagingExtensionTests {
             verify(mockExtensionApi, times(1)).dispatch(dispatchEventCaptor.capture());
             final Event pushTrackingStatusEvent = dispatchEventCaptor.getAllValues().get(0);
             assertEquals("Push tracking status event", pushTrackingStatusEvent.getName());
-            assertEquals(MessagingPushTrackingStatus.NO_DATASET_CONFIGURED.getValue(), pushTrackingStatusEvent.getEventData().get("pushTrackingStatus"));
-            assertEquals(MessagingPushTrackingStatus.NO_DATASET_CONFIGURED.getDescription(), pushTrackingStatusEvent.getEventData().get("pushTrackingStatusMessage"));
+            assertEquals(PushTrackingStatus.NO_DATASET_CONFIGURED.getValue(), pushTrackingStatusEvent.getEventData().get("pushTrackingStatus"));
+            assertEquals(PushTrackingStatus.NO_DATASET_CONFIGURED.getDescription(), pushTrackingStatusEvent.getEventData().get("pushTrackingStatusMessage"));
         });
     }
 


### PR DESCRIPTION
Two changes are made to handleNotificationResponse API

- The API stops processing the notification response. If no tracking key "_xdm" is found in the notification response.
- handleNotificationResponse takes in a callback that returns enum PushTrackingStatus

- A public enum PushTrackingStaus is introduced with the following values
     * TRACKING_INITIATED               - Returned when all the required data are available and the tracking has been initiated by Messaging Extension
     * NO_DATASET_CONFIGURED.     - Returned when no tracking dataset is configured for Messaging Extension
     * NO_TRACKING_DATA                - Returned when no tracking information is found in the Notification Response
     * INVALID_MESSAGE_ID.            - Returned when NotificationReponse has empty/null identifier.
     * UNKNOWN_ERROR                   - Returned when any other unknown errors happens within the SDK
     * INVALID_INTENT                       - Returned when the intent passed into the API is invalid for tracking
