### PR TITLE
fix in-app message id extraction

### DIFF
--- a/code/app/src/main/java/com/adobe/marketing/mobile/messagingsample/CodeBasedCardAdapter.kt
+++ b/code/app/src/main/java/com/adobe/marketing/mobile/messagingsample/CodeBasedCardAdapter.kt
@@ -19,6 +19,7 @@ import android.widget.TextView
 import androidx.recyclerview.widget.RecyclerView
 import com.adobe.marketing.mobile.messaging.MessagingProposition
 import com.adobe.marketing.mobile.services.ServiceProvider
+import org.json.JSONArray
 import org.json.JSONObject
 import java.nio.charset.StandardCharsets
 
@@ -49,8 +50,13 @@ class CodeBasedCardAdapter(messagingPropositions: MutableList<MessagingPropositi
                 }
             } else { // show code based experiences with text or json content in a text view
                 if (mimeType == "application/json") {
-                    val json = JSONObject(contentString)
-                    holder.textView.text = json.toString(5)
+                    if (contentString.startsWith("[")) { // we have a json array
+                        val jsonArray = JSONArray(contentString)
+                        holder.textView.text = jsonArray.toString(5)
+                    } else {
+                        val json = JSONObject(contentString)
+                        holder.textView.text = json.toString(5)
+                    }
                 } else {
                     holder.textView.text = contentString
                 }

--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/InternalMessage.java
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/InternalMessage.java
@@ -93,6 +93,12 @@ class InternalMessage extends MessagingFullscreenMessageDelegate implements Mess
         this.webViewHandler = webViewHandler != null ? webViewHandler : new Handler(ServiceProvider.getInstance().getAppContextService().getApplication().getMainLooper());
         this.scriptHandlers = scriptHandlers != null ? scriptHandlers : new HashMap<>();
 
+        id = consequence.getId();
+        if (StringUtils.isNullOrEmpty(id)) {
+            Log.debug(MessagingConstants.LOG_TAG, SELF_TAG, "Invalid consequence (%s). Required field \"id\" is null or empty.", consequence.toString());
+            throw new MessageRequiredFieldMissingException("Required field: Message \"id\" is null or empty.");
+        }
+
         details = consequence.getDetail();
         if (MapUtils.isNullOrEmpty(details)) {
             Log.debug(MessagingConstants.LOG_TAG, SELF_TAG, "Invalid consequence (%s). Required field \"detail\" is null or empty.", consequence.toString());
@@ -109,12 +115,6 @@ class InternalMessage extends MessagingFullscreenMessageDelegate implements Mess
         if (MapUtils.isNullOrEmpty(data)) {
             Log.debug(MessagingConstants.LOG_TAG, SELF_TAG, "Invalid consequence (%s). Required field \"data\" is null or empty.", consequence.toString());
             throw new MessageRequiredFieldMissingException("Required field: \"data\" is null or empty.");
-        }
-
-        id = DataReader.optString(data, MESSAGE_CONSEQUENCE_ID, "");
-        if (StringUtils.isNullOrEmpty(id)) {
-            Log.debug(MessagingConstants.LOG_TAG, SELF_TAG, "Invalid consequence (%s). Required field \"id\" is null or empty.", consequence.toString());
-            throw new MessageRequiredFieldMissingException("Required field: Message \"id\" is null or empty.");
         }
 
         final String html = DataReader.optString(data, MESSAGE_CONSEQUENCE_DETAIL_KEY_CONTENT, "");

--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/MessagingPropositionItem.java
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/MessagingPropositionItem.java
@@ -31,6 +31,7 @@ import java.io.ObjectOutputStream;
 import java.io.Serializable;
 import java.lang.ref.SoftReference;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -154,15 +155,21 @@ public class MessagingPropositionItem implements Serializable {
             final String schema = DataReader.getString(eventData, PAYLOAD_SCHEMA);
             final Map<String, Object> contentMap = DataReader.getTypedMap(Object.class, eventData, PAYLOAD_DATA);
 
-            String content = null;
             JSONObject jsonContent = null;
-            if (schema.equals(SCHEMA_RULESET_ITEM)) { // in-app content
+            JSONArray jsonArray = null;
+            String content = null;
+            if (schema.equals(SCHEMA_RULESET_ITEM)) {
+                // in-app content
                 jsonContent = new JSONObject(contentMap);
-            } else if (schema.equals(SCHEMA_JSON_CONTENT)) { // feed or code based json content
+            } else if (schema.equals(SCHEMA_JSON_CONTENT)) {
+                // feed or code based json content
                 final Object contentObject = contentMap.get(PAYLOAD_CONTENT);
                 if (contentObject != null) {
+                    // create a json array for list content. Json objects are created for map or string content.
                     if (contentObject instanceof Map) {
                         jsonContent = new JSONObject((Map) contentObject);
+                    } else if (contentObject instanceof List) {
+                        jsonArray = new JSONArray((List) contentObject);
                     } else {
                         jsonContent = new JSONObject(contentObject.toString());
                     }
@@ -173,6 +180,8 @@ public class MessagingPropositionItem implements Serializable {
 
             if (jsonContent != null && jsonContent.length() > 0) {
                 content = jsonContent.toString();
+            } else if (jsonArray != null && jsonArray.length() > 0) {
+                content = jsonArray.toString();
             }
 
             if (!StringUtils.isNullOrEmpty(content)) {
@@ -202,8 +211,13 @@ public class MessagingPropositionItem implements Serializable {
 
         try {
             if (schema.equals(SCHEMA_RULESET_ITEM) || schema.equals(SCHEMA_JSON_CONTENT)) { // in-app, feed, or code based content
-                final JSONObject jsonContent = new JSONObject(content);
-                data.put(PAYLOAD_CONTENT, JSONUtils.toMap(jsonContent));
+                if (content.startsWith("[")) { // we have a json array
+                    final JSONArray jsonArray = new JSONArray(content);
+                    data.put(PAYLOAD_CONTENT, JSONUtils.toList(jsonArray));
+                } else { // handle it as a json object
+                    final JSONObject jsonContent = new JSONObject(content);
+                    data.put(PAYLOAD_CONTENT, JSONUtils.toMap(jsonContent));
+                }
             } else { // html or text content
                 data.put(PAYLOAD_CONTENT, content);
             }

--- a/code/messaging/src/test/java/com/adobe/marketing/mobile/messaging/InternalMessageTests.java
+++ b/code/messaging/src/test/java/com/adobe/marketing/mobile/messaging/InternalMessageTests.java
@@ -19,6 +19,7 @@ import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -201,19 +202,21 @@ public class InternalMessageTests {
     @Test
     public void test_messageConstructor_MissingConsequenceId() {
         // setup
+        RuleConsequence mockConsequence = mock(RuleConsequence.class);
         Map<String, Object> details = new HashMap<>();
         Map<String, Object> data = new HashMap<>();
         data.put(MessagingTestConstants.EventDataKeys.RulesEngine.MESSAGE_CONSEQUENCE_DETAIL_KEY_REMOTE_ASSETS, new ArrayList<String>());
         data.put(MessagingTestConstants.EventDataKeys.RulesEngine.MESSAGE_CONSEQUENCE_DETAIL_KEY_CONTENT, html);
-        data.put(MessagingConstants.EventDataKeys.RulesEngine.MESSAGE_CONSEQUENCE_ID, "");
         details.put(MessagingTestConstants.EventDataKeys.RulesEngine.MESSAGE_CONSEQUENCE_DETAIL_KEY_DATA, data);
         details.put(MessagingTestConstants.EventDataKeys.RulesEngine.MESSAGE_CONSEQUENCE_DETAIL_KEY_SCHEMA, MessagingConstants.SchemaValues.SCHEMA_IAM);
-        RuleConsequence consequence = new RuleConsequence("123456789", MessagingTestConstants.EventDataKeys.RulesEngine.MESSAGE_CONSEQUENCE_CJM_VALUE, details);
+        when(mockConsequence.getId()).thenReturn(null);
+        when(mockConsequence.getDetail()).thenReturn(details);
+        when(mockConsequence.getType()).thenReturn(MessagingConstants.SchemaValues.SCHEMA_IAM);
 
         runUsingMockedServiceProvider(() -> {
             // test
             try {
-                internalMessage = new InternalMessage(mockMessagingExtension, consequence, new HashMap<>(), new HashMap<>());
+                internalMessage = new InternalMessage(mockMessagingExtension, mockConsequence, new HashMap<>(), new HashMap<>());
             } catch (Exception exception) {
                 assertEquals(MessageRequiredFieldMissingException.class, exception.getClass());
             }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- fix bug with extracting the consequence id as it is present in the consequence and not the consequence detail data map
- correctly handle json array proposition content
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
