### PR TITLE
-fix network calls for message asset downloading

### DIFF
--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/internal/MessageAssetDownloader.java
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/internal/MessageAssetDownloader.java
@@ -86,6 +86,10 @@ class MessageAssetDownloader {
             final Map<String, String> requestProperties = extractHeadersFromCache(cachedAsset);
             final NetworkRequest networkRequest = new NetworkRequest(url, HttpMethod.GET, null, requestProperties, MessagingConstants.DEFAULT_TIMEOUT, MessagingConstants.DEFAULT_TIMEOUT);
             ServiceProvider.getInstance().getNetworkService().connectAsync(networkRequest, connection -> {
+                if (connection == null) {
+                    Log.warning(MessagingConstants.LOG_TAG, SELF_TAG, "downloadAssetCollection - connection returned from NetworkService was null. Aborting asset download for: %s", url);
+                    return;
+                }
                 if (connection.getResponseCode() == HttpURLConnection.HTTP_NOT_MODIFIED) {
                     Log.debug(MessagingConstants.LOG_TAG, SELF_TAG, "downloadAssetCollection - Asset was cached previously: %s", url);
                     connection.close();


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

check for null connection in network call to download and cache remote assets for iam.

during app startup, core tries to initialize the Messaging extension by calling its constructor (in `MessagingExtension`).  the constructor initializes an `InAppNotificationHandler`, which kicks off downloading assets for cached messages to be used later in the app lifecycle.  the downloading happens in the `MessageAssetDownloader` class. in the situation where network service returns a null connection (an exception was thrown while trying to make the network call), the Messaging extension initialization would fail resulting in failure to register with the EventHub.

this fix will cause any failure while attempting to download an asset for an in-app message to be ignored, with no retry.  in the case where an asset can't be found in the cache, it will be downloaded from remote at the time of rendering an in-app message.

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
