### PR TITLE
updating code for content cards

### DIFF
--- a/code/messaging/src/androidTest/java/com/adobe/marketing/mobile/messaging/E2EFunctionalTests.java
+++ b/code/messaging/src/androidTest/java/com/adobe/marketing/mobile/messaging/E2EFunctionalTests.java
@@ -38,7 +38,7 @@ import com.adobe.marketing.mobile.Messaging;
 import com.adobe.marketing.mobile.MobileCore;
 import com.adobe.marketing.mobile.SDKHelper;
 import com.adobe.marketing.mobile.edge.identity.Identity;
-import com.adobe.marketing.mobile.test.BuildConfig;
+//import com.adobe.marketing.mobile.test.BuildConfig;
 import com.adobe.marketing.mobile.util.TestHelper;
 import java.util.ArrayList;
 import java.util.HashMap;

--- a/code/messaging/src/androidTest/java/com/adobe/marketing/mobile/messaging/E2EFunctionalTests.java
+++ b/code/messaging/src/androidTest/java/com/adobe/marketing/mobile/messaging/E2EFunctionalTests.java
@@ -38,7 +38,6 @@ import com.adobe.marketing.mobile.Messaging;
 import com.adobe.marketing.mobile.MobileCore;
 import com.adobe.marketing.mobile.SDKHelper;
 import com.adobe.marketing.mobile.edge.identity.Identity;
-//import com.adobe.marketing.mobile.test.BuildConfig;
 import com.adobe.marketing.mobile.util.TestHelper;
 import java.util.ArrayList;
 import java.util.HashMap;

--- a/code/messaging/src/androidTest/java/com/adobe/marketing/mobile/messaging/MessageCachingFunctionalTests.java
+++ b/code/messaging/src/androidTest/java/com/adobe/marketing/mobile/messaging/MessageCachingFunctionalTests.java
@@ -21,7 +21,6 @@ import com.adobe.marketing.mobile.Extension;
 import com.adobe.marketing.mobile.Messaging;
 import com.adobe.marketing.mobile.MobileCore;
 import com.adobe.marketing.mobile.edge.identity.Identity;
-//import com.adobe.marketing.mobile.test.BuildConfig;
 import com.adobe.marketing.mobile.util.TestHelper;
 import java.util.ArrayList;
 import java.util.Collections;

--- a/code/messaging/src/androidTest/java/com/adobe/marketing/mobile/messaging/MessageCachingFunctionalTests.java
+++ b/code/messaging/src/androidTest/java/com/adobe/marketing/mobile/messaging/MessageCachingFunctionalTests.java
@@ -21,7 +21,7 @@ import com.adobe.marketing.mobile.Extension;
 import com.adobe.marketing.mobile.Messaging;
 import com.adobe.marketing.mobile.MobileCore;
 import com.adobe.marketing.mobile.edge.identity.Identity;
-import com.adobe.marketing.mobile.test.BuildConfig;
+//import com.adobe.marketing.mobile.test.BuildConfig;
 import com.adobe.marketing.mobile.util.TestHelper;
 import java.util.ArrayList;
 import java.util.Collections;

--- a/code/messaging/src/androidTest/java/com/adobe/marketing/mobile/messaging/MessagingPublicAPITests.java
+++ b/code/messaging/src/androidTest/java/com/adobe/marketing/mobile/messaging/MessagingPublicAPITests.java
@@ -28,7 +28,6 @@ import com.adobe.marketing.mobile.Extension;
 import com.adobe.marketing.mobile.Messaging;
 import com.adobe.marketing.mobile.MobileCore;
 import com.adobe.marketing.mobile.edge.identity.Identity;
-//import com.adobe.marketing.mobile.test.BuildConfig;
 import com.adobe.marketing.mobile.util.DataReader;
 import com.adobe.marketing.mobile.util.MonitorExtension;
 import com.adobe.marketing.mobile.util.TestHelper;

--- a/code/messaging/src/androidTest/java/com/adobe/marketing/mobile/messaging/MessagingPublicAPITests.java
+++ b/code/messaging/src/androidTest/java/com/adobe/marketing/mobile/messaging/MessagingPublicAPITests.java
@@ -28,7 +28,7 @@ import com.adobe.marketing.mobile.Extension;
 import com.adobe.marketing.mobile.Messaging;
 import com.adobe.marketing.mobile.MobileCore;
 import com.adobe.marketing.mobile.edge.identity.Identity;
-import com.adobe.marketing.mobile.test.BuildConfig;
+//import com.adobe.marketing.mobile.test.BuildConfig;
 import com.adobe.marketing.mobile.util.DataReader;
 import com.adobe.marketing.mobile.util.MonitorExtension;
 import com.adobe.marketing.mobile.util.TestHelper;

--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/ContentCard.java
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/ContentCard.java
@@ -16,7 +16,6 @@ import androidx.annotation.Nullable;
 import com.adobe.marketing.mobile.MessagingEdgeEventType;
 import com.adobe.marketing.mobile.services.Log;
 import com.adobe.marketing.mobile.util.StringUtils;
-
 import java.lang.ref.SoftReference;
 
 /**

--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/ContentCard.java
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/ContentCard.java
@@ -11,6 +11,8 @@
 
 package com.adobe.marketing.mobile.messaging;
 
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import com.adobe.marketing.mobile.MessagingEdgeEventType;
 import com.adobe.marketing.mobile.services.Log;
 import com.adobe.marketing.mobile.util.StringUtils;
@@ -49,15 +51,15 @@ public class ContentCard {
         private final ContentCard contentCard;
 
         /**
-         * Builder constructor with required {@code ContentCard} attributes as parameters.
+         * Builder constructor with required {@link ContentCard} attributes as parameters.
          *
-         * <p>It sets default values for the remaining {@link ContentCard} attributes.
+         * <p>It sets default values for the remaining {@code ContentCard} attributes.
          *
          * @param title required {@link String} plain-text title for the content card
-         * @param body required {@link String} plain-text body representing the content for the
+         * @param body required {@code String} plain-text body representing the content for the
          *     content card
          */
-        public Builder(final String title, final String body) {
+        public Builder(@NonNull final String title, @NonNull final String body) {
             contentCard = new ContentCard();
             contentCard.title = StringUtils.isNullOrEmpty(title) ? "" : title;
             contentCard.body = StringUtils.isNullOrEmpty(body) ? "" : body;
@@ -133,7 +135,7 @@ public class ContentCard {
          *
          * @return {@link ContentCard} object or null.
          */
-        public ContentCard build() {
+        @Nullable public ContentCard build() {
             // title and body are required
             if (StringUtils.isNullOrEmpty(contentCard.title)
                     || StringUtils.isNullOrEmpty(contentCard.body)) {
@@ -177,7 +179,7 @@ public class ContentCard {
      *
      * @return {@link String} containing the {@link ContentCard} image url.
      */
-    public String getImageUrl() {
+    @Nullable public String getImageUrl() {
         return imageUrl;
     }
 
@@ -186,7 +188,7 @@ public class ContentCard {
      *
      * @return {@link String} containing the {@link ContentCard} action url.
      */
-    public String getActionUrl() {
+    @Nullable public String getActionUrl() {
         return actionUrl;
     }
 
@@ -195,7 +197,7 @@ public class ContentCard {
      *
      * @return {@link String} containing the {@link ContentCard} action title.
      */
-    public String getActionTitle() {
+    @Nullable public String getActionTitle() {
         return actionTitle;
     }
 

--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/ContentCard.java
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/ContentCard.java
@@ -1,5 +1,5 @@
 /*
-  Copyright 2023 Adobe. All rights reserved.
+  Copyright 2024 Adobe. All rights reserved.
   This file is licensed to you under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License. You may obtain a copy
   of the License at http://www.apache.org/licenses/LICENSE-2.0
@@ -17,134 +17,134 @@ import com.adobe.marketing.mobile.util.StringUtils;
 import java.lang.ref.SoftReference;
 
 /**
- * A {@link FeedItem} object encapsulates the information necessary for a non-disruptive yet
- * interactive offer. Customers can use the Messaging SDK to render the feed item data in a
+ * A {@link ContentCard} object encapsulates the information necessary for a non-disruptive yet
+ * interactive offer. Customers can use the Messaging SDK to render the content card in a
  * pre-defined format or implement their own rendering.
  */
-@Deprecated
-public class FeedItem {
-    private static final String SELF_TAG = "FeedItem";
-    // Plain-text title for the feed item
+public class ContentCard {
+    private static final String SELF_TAG = "ContentCard";
+
+    // Plain-text title for the content card
     private String title;
-    // Plain-text body representing the content for the feed item
+    // Plain-text body representing the content for the content card
     private String body;
-    // String representing a URI that contains an image to be used for this feed item
+    // String representing a URI that contains an image to be used for this content card
     private String imageUrl;
-    // Contains a URL to be opened if the user interacts with the feed item
+    // Contains a URL to be opened if the user interacts with the content card
     private String actionUrl;
-    // Required if actionUrl is provided. Text to be used in title of button or link in feed item
+    // Required if actionUrl is provided. Text to be used in title of button or link in content card
     private String actionTitle;
-    // Reference to parent feedItemSchemaData instance
-    FeedItemSchemaData parent;
+    // Reference to parent ContentCardSchemaData instance
+    ContentCardSchemaData parent;
 
     /**
      * Private constructor.
      *
-     * <p>Use {@link Builder} to create {@link FeedItem} object.
+     * <p>Use {@link Builder} to create {@link ContentCard} object.
      */
-    private FeedItem() {}
+    private ContentCard() {}
 
     /** {@code FeedItem} Builder. */
     public static class Builder {
         private boolean didBuild;
-        private final FeedItem feedItem;
+        private final ContentCard contentCard;
 
         /**
-         * Builder constructor with required {@code FeedItem} attributes as parameters.
+         * Builder constructor with required {@code ContentCard} attributes as parameters.
          *
-         * <p>It sets default values for the remaining {@link FeedItem} attributes.
+         * <p>It sets default values for the remaining {@link ContentCard} attributes.
          *
-         * @param title required {@link String} plain-text title for the feed item
-         * @param body required {@link String} plain-text body representing the content for the feed
-         *     item
+         * @param title required {@link String} plain-text title for the content card
+         * @param body required {@link String} plain-text body representing the content for the
+         *     content card
          */
         public Builder(final String title, final String body) {
-            feedItem = new FeedItem();
-            feedItem.title = StringUtils.isNullOrEmpty(title) ? "" : title;
-            feedItem.body = StringUtils.isNullOrEmpty(body) ? "" : body;
-            feedItem.imageUrl = "";
-            feedItem.actionUrl = "";
-            feedItem.actionTitle = "";
+            contentCard = new ContentCard();
+            contentCard.title = StringUtils.isNullOrEmpty(title) ? "" : title;
+            contentCard.body = StringUtils.isNullOrEmpty(body) ? "" : body;
+            contentCard.imageUrl = "";
+            contentCard.actionUrl = "";
+            contentCard.actionTitle = "";
             didBuild = false;
         }
 
         /**
-         * Sets the image url for this {@code FeedItem}.
+         * Sets the image url for this {@code ContentCard}.
          *
-         * @param imageUrl {@link String} containing the {@link FeedItem} image url.
-         * @return this FeedItem {@link Builder}
+         * @param imageUrl {@link String} containing the {@link ContentCard} image url.
+         * @return this ContentCard {@link Builder}
          * @throws UnsupportedOperationException if this method is invoked after {@link
          *     Builder#build()}.
          */
         public Builder setImageUrl(final String imageUrl) {
             throwIfAlreadyBuilt();
 
-            feedItem.imageUrl = imageUrl;
+            contentCard.imageUrl = imageUrl;
             return this;
         }
 
         /**
-         * Sets the action url for this {@code FeedItem}.
+         * Sets the action url for this {@code ContentCard}.
          *
-         * @param actionUrl {@link String} containing the {@link FeedItem} action url.
-         * @return this FeedItem {@link Builder}
+         * @param actionUrl {@link String} containing the {@link ContentCard} action url.
+         * @return this ContentCard {@link Builder}
          * @throws UnsupportedOperationException if this method is invoked after {@link
          *     Builder#build()}.
          */
         public Builder setActionUrl(final String actionUrl) {
             throwIfAlreadyBuilt();
 
-            feedItem.actionUrl = actionUrl;
+            contentCard.actionUrl = actionUrl;
             return this;
         }
 
         /**
-         * Sets the action title for this {@code FeedItem}.
+         * Sets the action title for this {@code ContentCard}.
          *
-         * @param actionTitle {@link String} containing the {@link FeedItem} action title.
-         * @return this FeedItem {@link Builder}
+         * @param actionTitle {@link String} containing the {@link ContentCard} action title.
+         * @return this ContentCard {@link Builder}
          * @throws UnsupportedOperationException if this method is invoked after {@link
          *     Builder#build()}.
          */
         public Builder setActionTitle(final String actionTitle) {
             throwIfAlreadyBuilt();
 
-            feedItem.actionTitle = actionTitle;
+            contentCard.actionTitle = actionTitle;
             return this;
         }
 
         /**
-         * Sets the {@code FeedItemSchemaData} parent object.
+         * Sets the {@code ContentCardSchemaData} parent object.
          *
-         * @param parent {@link FeedItemSchemaData} object which is the parent for this {@link
-         *     FeedItem}.
+         * @param parent {@link ContentCardSchemaData} object which is the parent for this {@link
+         *     ContentCard}.
          * @return this FeedItem {@link Builder}
          * @throws UnsupportedOperationException if this method is invoked after {@link
          *     Builder#build()}.
          */
-        public Builder setParent(final FeedItemSchemaData parent) {
+        public Builder setParent(final ContentCardSchemaData parent) {
             throwIfAlreadyBuilt();
 
-            feedItem.parent = parent;
+            contentCard.parent = parent;
             return this;
         }
 
         /**
-         * Builds and returns the {@code FeedItem} object.
+         * Builds and returns the {@code ContentCard} object.
          *
-         * @return {@link FeedItem} object or null.
+         * @return {@link ContentCard} object or null.
          */
-        public FeedItem build() {
+        public ContentCard build() {
             // title and body are required
-            if (StringUtils.isNullOrEmpty(feedItem.title)
-                    || StringUtils.isNullOrEmpty(feedItem.body)) {
+            if (StringUtils.isNullOrEmpty(contentCard.title)
+                    || StringUtils.isNullOrEmpty(contentCard.body)) {
                 return null;
             }
 
             throwIfAlreadyBuilt();
             didBuild = true;
 
-            return feedItem;
+            return contentCard;
         }
 
         private void throwIfAlreadyBuilt() {
@@ -156,45 +156,45 @@ public class FeedItem {
     }
 
     /**
-     * Gets the {@code FeedItem} title.
+     * Gets the {@code ContentCard} title.
      *
-     * @return {@link String} containing the {@link FeedItem} title.
+     * @return {@link String} containing the {@link ContentCard} title.
      */
     public String getTitle() {
         return title;
     }
 
     /**
-     * Gets the {@code FeedItem} body.
+     * Gets the {@code ContentCard} body.
      *
-     * @return {@link String} containing the {@link FeedItem} body.
+     * @return {@link String} containing the {@link ContentCard} body.
      */
     public String getBody() {
         return body;
     }
 
     /**
-     * Gets the {@code FeedItem} image url.
+     * Gets the {@code ContentCard} image url.
      *
-     * @return {@link String} containing the {@link FeedItem} image url.
+     * @return {@link String} containing the {@link ContentCard} image url.
      */
     public String getImageUrl() {
         return imageUrl;
     }
 
     /**
-     * Gets the {@code FeedItem} action url.
+     * Gets the {@code ContentCard} action url.
      *
-     * @return {@link String} containing the {@link FeedItem} action url.
+     * @return {@link String} containing the {@link ContentCard} action url.
      */
     public String getActionUrl() {
         return actionUrl;
     }
 
     /**
-     * Gets the {@code FeedItem} action title.
+     * Gets the {@code ContentCard} action title.
      *
-     * @return {@link String} containing the {@link FeedItem} action title.
+     * @return {@link String} containing the {@link ContentCard} action title.
      */
     public String getActionTitle() {
         return actionTitle;

--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/ContentCard.java
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/ContentCard.java
@@ -17,6 +17,8 @@ import com.adobe.marketing.mobile.MessagingEdgeEventType;
 import com.adobe.marketing.mobile.services.Log;
 import com.adobe.marketing.mobile.util.StringUtils;
 
+import java.lang.ref.SoftReference;
+
 /**
  * A {@link ContentCard} object encapsulates the information necessary for a non-disruptive yet
  * interactive offer. Customers can use the Messaging SDK to render the content card in a
@@ -36,7 +38,7 @@ public class ContentCard {
     // Required if actionUrl is provided. Text to be used in title of button or link in content card
     private String actionTitle;
     // Reference to parent ContentCardSchemaData instance
-    ContentCardSchemaData parent;
+    SoftReference<ContentCardSchemaData> parent;
 
     /**
      * Private constructor.
@@ -126,7 +128,7 @@ public class ContentCard {
         public Builder setParent(final ContentCardSchemaData parent) {
             throwIfAlreadyBuilt();
 
-            contentCard.parent = parent;
+            contentCard.parent = new SoftReference<>(parent);
             return this;
         }
 
@@ -216,6 +218,6 @@ public class ContentCard {
                     "Unable to track ContentCard, " + "parent schema object is unavailable.");
             return;
         }
-        parent.track(interaction, eventType);
+        parent.get().track(interaction, eventType);
     }
 }

--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/ContentCard.java
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/ContentCard.java
@@ -14,7 +14,6 @@ package com.adobe.marketing.mobile.messaging;
 import com.adobe.marketing.mobile.MessagingEdgeEventType;
 import com.adobe.marketing.mobile.services.Log;
 import com.adobe.marketing.mobile.util.StringUtils;
-import java.lang.ref.SoftReference;
 
 /**
  * A {@link ContentCard} object encapsulates the information necessary for a non-disruptive yet
@@ -209,9 +208,10 @@ public class ContentCard {
      */
     public void track(final String interaction, final MessagingEdgeEventType eventType) {
         if (parent == null) {
-            Log.debug(MessagingConstants.LOG_TAG, SELF_TAG,
-                    "Unable to track ContentCard, "
-                            + "parent schema object is unavailable.");
+            Log.debug(
+                    MessagingConstants.LOG_TAG,
+                    SELF_TAG,
+                    "Unable to track ContentCard, " + "parent schema object is unavailable.");
             return;
         }
         parent.track(interaction, eventType);

--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/ContentCardRulesEngine.java
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/ContentCardRulesEngine.java
@@ -61,7 +61,8 @@ class ContentCardRulesEngine extends LaunchRulesEngine {
                 continue;
             }
 
-            final ContentCardSchemaData propositionAsContentCard = propositionItem.getContentCardSchemaData();
+            final ContentCardSchemaData propositionAsContentCard =
+                    propositionItem.getContentCardSchemaData();
             if (propositionAsContentCard == null) {
                 continue;
             }

--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/ContentCardRulesEngine.java
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/ContentCardRulesEngine.java
@@ -24,10 +24,10 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-class FeedRulesEngine extends LaunchRulesEngine {
+class ContentCardRulesEngine extends LaunchRulesEngine {
     final ExtensionApi extensionApi;
 
-    FeedRulesEngine(@NonNull final String name, @NonNull final ExtensionApi extensionApi) {
+    ContentCardRulesEngine(@NonNull final String name, @NonNull final ExtensionApi extensionApi) {
         super(name, extensionApi);
         this.extensionApi = extensionApi;
     }
@@ -60,18 +60,18 @@ class FeedRulesEngine extends LaunchRulesEngine {
             if (propositionItem == null) {
                 continue;
             }
-            final FeedItemSchemaData propositionAsFeedItem =
-                    propositionItem.getFeedItemSchemaData();
 
-            if (propositionAsFeedItem == null) {
+            final ContentCardSchemaData propositionAsContentCard = propositionItem.getContentCardSchemaData();
+            if (propositionAsContentCard == null) {
                 continue;
             }
 
-            final Map metadata = propositionAsFeedItem.getMeta();
+            final Map metadata = propositionAsContentCard.getMeta();
             if (MapUtils.isNullOrEmpty(metadata)) {
                 continue;
             }
 
+            // the surface for a content card is automatically added to its meta data
             final Surface surface =
                     Surface.fromUriString(
                             DataReader.optString(

--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/ContentCardSchemaData.java
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/ContentCardSchemaData.java
@@ -1,5 +1,5 @@
 /*
-  Copyright 2023 Adobe. All rights reserved.
+  Copyright 2024 Adobe. All rights reserved.
   This file is licensed to you under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License. You may obtain a copy
   of the License at http://www.apache.org/licenses/LICENSE-2.0
@@ -19,14 +19,14 @@ import com.adobe.marketing.mobile.services.Log;
 import com.adobe.marketing.mobile.util.DataReader;
 import com.adobe.marketing.mobile.util.JSONUtils;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import org.json.JSONException;
 import org.json.JSONObject;
 
-// represents the schema data object for a feed item schema
-@Deprecated
-public class FeedItemSchemaData implements SchemaData {
-    private static final String SELF_TAG = "FeedItemSchemaData";
+// represents the schema data object for a content-card schema
+public class ContentCardSchemaData implements SchemaData {
+    private static final String SELF_TAG = "ContentCardSchemaData";
     private Object content;
     private ContentType contentType;
     private int publishedDate;
@@ -35,7 +35,7 @@ public class FeedItemSchemaData implements SchemaData {
 
     PropositionItem parent;
 
-    FeedItemSchemaData(final JSONObject schemaData) {
+    ContentCardSchemaData(final JSONObject schemaData) {
         try {
             this.contentType =
                     ContentType.fromString(
@@ -89,11 +89,11 @@ public class FeedItemSchemaData implements SchemaData {
     }
 
     @VisibleForTesting
-    static FeedItemSchemaData getEmpty() {
-        return new FeedItemSchemaData(new JSONObject());
+    static ContentCardSchemaData getEmpty() {
+        return new ContentCardSchemaData(new JSONObject());
     }
 
-    @Nullable public FeedItem getFeedItem() {
+    @Nullable public ContentCard getContentCard() {
         if (!contentType.equals(ContentType.APPLICATION_JSON)) {
             return null;
         }
@@ -113,7 +113,7 @@ public class FeedItemSchemaData implements SchemaData {
             final String actionTitle =
                     DataReader.optString(
                             contentMap, MessagingConstants.MessageFeedKeys.ACTION_TITLE, "");
-            return new FeedItem.Builder(title, body)
+            return new ContentCard.Builder(title, body)
                     .setImageUrl(imageUrl)
                     .setActionUrl(actionUrl)
                     .setActionTitle(actionTitle)
@@ -134,7 +134,7 @@ public class FeedItemSchemaData implements SchemaData {
     public void track(final String interaction, final MessagingEdgeEventType eventType) {
         if (parent == null) {
             Log.debug(MessagingConstants.LOG_TAG, SELF_TAG,
-                    "Unable to track FeedItemSchemaData, "
+                    "Unable to track ContentCardSchemaData, "
                             + "parent proposition item is unavailable.");
             return;
         }

--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/ContentCardSchemaData.java
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/ContentCardSchemaData.java
@@ -13,13 +13,11 @@ package com.adobe.marketing.mobile.messaging;
 
 import androidx.annotation.Nullable;
 import androidx.annotation.VisibleForTesting;
-
 import com.adobe.marketing.mobile.MessagingEdgeEventType;
 import com.adobe.marketing.mobile.services.Log;
 import com.adobe.marketing.mobile.util.DataReader;
 import com.adobe.marketing.mobile.util.JSONUtils;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -133,7 +131,9 @@ public class ContentCardSchemaData implements SchemaData {
      */
     public void track(final String interaction, final MessagingEdgeEventType eventType) {
         if (parent == null) {
-            Log.debug(MessagingConstants.LOG_TAG, SELF_TAG,
+            Log.debug(
+                    MessagingConstants.LOG_TAG,
+                    SELF_TAG,
                     "Unable to track ContentCardSchemaData, "
                             + "parent proposition item is unavailable.");
             return;

--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/EdgePersonalizationResponseHandler.java
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/EdgePersonalizationResponseHandler.java
@@ -12,7 +12,6 @@
 package com.adobe.marketing.mobile.messaging;
 
 import androidx.annotation.VisibleForTesting;
-
 import com.adobe.marketing.mobile.AdobeCallbackWithError;
 import com.adobe.marketing.mobile.AdobeError;
 import com.adobe.marketing.mobile.Event;
@@ -87,8 +86,8 @@ class EdgePersonalizationResponseHandler {
      * @param extensionApi {@link ExtensionApi} instance
      * @param rulesEngine {@link LaunchRulesEngine} instance to use for loading in-app message rule
      *     payloads
-     * @param contentCardRulesEngine {@link ContentCardRulesEngine} instance to use for loading message feed rule
-     *     payloads
+     * @param contentCardRulesEngine {@link ContentCardRulesEngine} instance to use for loading
+     *     message feed rule payloads
      */
     EdgePersonalizationResponseHandler(
             final MessagingExtension parent,
@@ -393,7 +392,9 @@ class EdgePersonalizationResponseHandler {
         }
 
         if (requestedSurfaces.isEmpty()) {
-            Log.debug(MessagingConstants.LOG_TAG,SELF_TAG,
+            Log.debug(
+                    MessagingConstants.LOG_TAG,
+                    SELF_TAG,
                     "Unable to retrieve messages, no valid surfaces found.");
             extensionApi.dispatch(
                     InternalMessagingUtils.createErrorResponseEvent(
@@ -614,8 +615,12 @@ class EdgePersonalizationResponseHandler {
                     // process a generic event to see if there are any content cards with:
                     // 1. no client-side qualification requirements, or
                     // 2. prior qualification by this device
-                    final Event event = new Event.Builder("Seed content cards",
-                            EventType.EDGE, EventSource.REQUEST_CONTENT).build();
+                    final Event event =
+                            new Event.Builder(
+                                            "Seed content cards",
+                                            EventType.EDGE,
+                                            EventSource.REQUEST_CONTENT)
+                                    .build();
                     updateQualifiedContentCardsForEvent(event);
 
                     break;
@@ -631,23 +636,26 @@ class EdgePersonalizationResponseHandler {
         }
     }
 
-    /** Checks to see if the user has qualified for any content cards based on provided {@link Event}.
+    /**
+     * Checks to see if the user has qualified for any content cards based on provided {@link
+     * Event}.
      *
      * @param event may result in content card qualification.
      */
     void updateQualifiedContentCardsForEvent(final Event event) {
         final Map<Surface, List<Proposition>> qualifiedContentCardsBySurface =
                 getPropositionsFromContentCardRulesEngine(event);
-        for (final Map.Entry<Surface, List<Proposition>> entry : qualifiedContentCardsBySurface.entrySet()) {
+        for (final Map.Entry<Surface, List<Proposition>> entry :
+                qualifiedContentCardsBySurface.entrySet()) {
             addOrReplaceContentCards(entry.getValue(), entry.getKey());
         }
     }
 
     /**
-     * Manages qualified content cards by surface.
-     * Prevents multiple entries for the same proposition in {@code contentCardsBySurface}.
-     * If an existing entry for a proposition is found, it is replaced with the value in propositions.
-     * If no prior entry exists for a proposition, a `trigger` event will be sent and written to event history).
+     * Manages qualified content cards by surface. Prevents multiple entries for the same
+     * proposition in {@code contentCardsBySurface}. If an existing entry for a proposition is
+     * found, it is replaced with the value in propositions. If no prior entry exists for a
+     * proposition, a `trigger` event will be sent and written to event history).
      *
      * @param propositions list of qualified {@link Proposition}s for the given surface.
      * @param surface {@link Surface} to which qualified propositions belong.
@@ -686,11 +694,18 @@ class EdgePersonalizationResponseHandler {
         int newCount = updatedPropositionsArray == null ? 0 : updatedPropositionsArray.size();
         if (startingCount != newCount) {
             if (newCount > 0) {
-                Log.trace(MessagingConstants.LOG_TAG, SELF_TAG, "User has qualified for %d "
-                        + "content card(s) for surface %s", newCount, surface.getUri());
+                Log.trace(
+                        MessagingConstants.LOG_TAG,
+                        SELF_TAG,
+                        "User has qualified for %d " + "content card(s) for surface %s",
+                        newCount,
+                        surface.getUri());
             } else {
-                Log.trace(MessagingConstants.LOG_TAG, SELF_TAG, "User has not qualified for "
-                        + "any content card(s) for surface %s", surface.getUri());
+                Log.trace(
+                        MessagingConstants.LOG_TAG,
+                        SELF_TAG,
+                        "User has not qualified for " + "any content card(s) for surface %s",
+                        surface.getUri());
             }
         }
     }
@@ -717,7 +732,8 @@ class EdgePersonalizationResponseHandler {
     }
 
     @SuppressWarnings("NestedForDepth")
-    private Map<Surface, List<Proposition>> getPropositionsFromContentCardRulesEngine(final Event event) {
+    private Map<Surface, List<Proposition>> getPropositionsFromContentCardRulesEngine(
+            final Event event) {
         Map<Surface, List<Proposition>> surfacePropositions = new HashMap<>();
         final Map<Surface, List<PropositionItem>> propositionItemsBySurface =
                 contentCardRulesEngine.evaluate(event);

--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/EdgePersonalizationResponseHandler.java
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/EdgePersonalizationResponseHandler.java
@@ -24,6 +24,7 @@ import com.adobe.marketing.mobile.launch.rulesengine.LaunchRule;
 import com.adobe.marketing.mobile.launch.rulesengine.LaunchRulesEngine;
 import com.adobe.marketing.mobile.launch.rulesengine.RuleConsequence;
 import com.adobe.marketing.mobile.services.Log;
+import com.adobe.marketing.mobile.services.ServiceProvider;
 import com.adobe.marketing.mobile.util.DataReader;
 import com.adobe.marketing.mobile.util.DataReaderException;
 import com.adobe.marketing.mobile.util.MapUtils;
@@ -35,6 +36,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 
@@ -59,7 +61,7 @@ class EdgePersonalizationResponseHandler {
     private final LaunchRulesEngine launchRulesEngine;
     private final ContentCardRulesEngine contentCardRulesEngine;
 
-    private Map<Surface, List<Proposition>> propositions = new HashMap<>();
+    private Map<Surface, List<Proposition>> inMemoryPropositions = new HashMap<>();
     private Map<String, PropositionInfo> propositionInfo = new HashMap<>();
 
     // keeps a list of all surfaces requested per personalization request event by event id
@@ -87,7 +89,7 @@ class EdgePersonalizationResponseHandler {
      * @param rulesEngine {@link LaunchRulesEngine} instance to use for loading in-app message rule
      *     payloads
      * @param contentCardRulesEngine {@link ContentCardRulesEngine} instance to use for loading
-     *     message feed rule payloads
+     *     content card rule payloads
      */
     EdgePersonalizationResponseHandler(
             final MessagingExtension parent,
@@ -124,7 +126,7 @@ class EdgePersonalizationResponseHandler {
                         SELF_TAG,
                         "Retrieved cached propositions, attempting to load the propositions into"
                                 + " the rules engine.");
-                propositions = cachedPropositions;
+                inMemoryPropositions = cachedPropositions;
                 final List<Surface> surfaces = new ArrayList<>();
                 // get surfaces
                 for (final Map.Entry<Surface, List<Proposition>> cacheEntry :
@@ -373,15 +375,22 @@ class EdgePersonalizationResponseHandler {
     }
 
     /**
-     * Dispatches an event with previously cached content cards from the SDK for the provided
-     * surfaces.
+     * Dispatches an event with previously cached content cards and code based experiences from the
+     * SDK for the provided surfaces.
      *
      * @param surfaces A {@code List<Surface>} of surfaces to use for retrieving cached content
      * @param event The retrieve message {@link Event}
      */
-    void retrieveCachedContentCards(final List<Surface> surfaces, final Event event) {
+    void retrieveInMemoryPropositions(final List<Surface> surfaces, final Event event) {
         final List<Surface> requestedSurfaces = new ArrayList<>();
-        if (surfaces == null || surfaces.isEmpty()) {
+        if (MessagingUtils.isNullOrEmpty(surfaces)) {
+            Log.debug(
+                    MessagingConstants.LOG_TAG,
+                    SELF_TAG,
+                    "Unable to retrieve messages, no surfaces were requested.");
+            extensionApi.dispatch(
+                    InternalMessagingUtils.createErrorResponseEvent(
+                            event, AdobeErrorExt.INVALID_REQUEST));
             return;
         }
 
@@ -403,9 +412,20 @@ class EdgePersonalizationResponseHandler {
         }
 
         // get a copy of qualified content cards and filter by requested surfaces
-        final Map<Surface, List<Proposition>> requestedPropositions =
+        final Map<Surface, List<Proposition>> requestedContentCards =
                 new HashMap<>(contentCardsBySurface);
-        requestedPropositions.keySet().retainAll(requestedSurfaces);
+        requestedContentCards.keySet().retainAll(requestedSurfaces);
+
+        // get a copy of in memory propositions (cbe)
+        Map<Surface, List<Proposition>> requestedPropositions =
+                retrieveCachedPropositions(requestedSurfaces);
+
+        // merge their entries
+        for (final Map.Entry<Surface, List<Proposition>> entry : requestedContentCards.entrySet()) {
+            requestedPropositions =
+                    MessagingUtils.updatePropositionMapForSurface(
+                            entry.getKey(), entry.getValue(), requestedPropositions);
+        }
 
         // dispatch an event with the cached feed propositions
         final Map<String, Object> eventData = new HashMap<>();
@@ -585,7 +605,6 @@ class EdgePersonalizationResponseHandler {
                     // update rules in in-app engine
                     launchRulesEngine.replaceRules(collectedInAppRules);
                     break;
-                case FEED:
                 case CONTENT_CARD:
                     Log.trace(
                             MessagingConstants.LOG_TAG,
@@ -605,11 +624,11 @@ class EdgePersonalizationResponseHandler {
                     final Collection<List<LaunchRule>> allContentCardRules =
                             contentCardRulesBySurface.values();
                     final List<LaunchRule> collectedContentCardRules = new ArrayList<>();
-                    for (final List<LaunchRule> feedRules : allContentCardRules) {
-                        collectedContentCardRules.addAll(feedRules);
+                    for (final List<LaunchRule> contentCardRules : allContentCardRules) {
+                        collectedContentCardRules.addAll(contentCardRules);
                     }
 
-                    // update rules in feed rules engine
+                    // update rules in content card rules engine
                     contentCardRulesEngine.replaceRules(collectedContentCardRules);
 
                     // process a generic event to see if there are any content cards with:
@@ -618,7 +637,7 @@ class EdgePersonalizationResponseHandler {
                     final Event event =
                             new Event.Builder(
                                             "Seed content cards",
-                                            EventType.EDGE,
+                                            EventType.MESSAGING,
                                             EventSource.REQUEST_CONTENT)
                                     .build();
                     updateQualifiedContentCardsForEvent(event);
@@ -663,52 +682,44 @@ class EdgePersonalizationResponseHandler {
     @SuppressWarnings("NestedIfDepth")
     private void addOrReplaceContentCards(
             final List<Proposition> propositions, final Surface surface) {
-        int startingCount = 0;
-        final List<Proposition> existingPropositionsArray = contentCardsBySurface.get(surface);
-        if (existingPropositionsArray != null) {
-            startingCount = existingPropositionsArray.size();
-            for (final Proposition proposition : propositions) {
-                final int existingIndex = existingPropositionsArray.indexOf(proposition);
-                if (existingIndex >= 0) {
-                    existingPropositionsArray.remove(existingIndex);
-                } else {
-                    final List<PropositionItem> propItems = proposition.getItems();
-                    final PropositionItem item = propItems.isEmpty() ? null : propItems.get(0);
-                    if (item != null) {
-                        item.track(MessagingEdgeEventType.TRIGGER);
-                    }
-                }
-                existingPropositionsArray.add(proposition);
-            }
-            contentCardsBySurface.put(surface, existingPropositionsArray);
-        } else {
-            for (final Proposition proposition : propositions) {
+        List<Proposition> existingPropositionsArray = contentCardsBySurface.get(surface);
+        if (existingPropositionsArray == null) {
+            existingPropositionsArray = new ArrayList<>();
+        }
+
+        int startingCount = existingPropositionsArray.size();
+
+        for (final Proposition proposition : propositions) {
+            if (existingPropositionsArray.contains(proposition)) {
+                existingPropositionsArray.remove(proposition);
+            } else {
                 final List<PropositionItem> propItems = proposition.getItems();
                 final PropositionItem item = propItems.isEmpty() ? null : propItems.get(0);
                 if (item != null) {
                     item.track(MessagingEdgeEventType.TRIGGER);
                 }
             }
-            contentCardsBySurface.put(surface, propositions);
+            existingPropositionsArray.add(proposition);
         }
 
-        final List<Proposition> updatedPropositionsArray = contentCardsBySurface.get(surface);
-        int newCount = updatedPropositionsArray == null ? 0 : updatedPropositionsArray.size();
+        contentCardsBySurface.put(surface, existingPropositionsArray);
+
+        int newCount = existingPropositionsArray.size();
         if (startingCount != newCount) {
-            if (newCount > 0) {
-                Log.trace(
-                        MessagingConstants.LOG_TAG,
-                        SELF_TAG,
-                        "User has qualified for %d " + "content card(s) for surface %s",
-                        newCount,
-                        surface.getUri());
-            } else {
-                Log.trace(
-                        MessagingConstants.LOG_TAG,
-                        SELF_TAG,
-                        "User has not qualified for " + "any content card(s) for surface %s",
-                        surface.getUri());
-            }
+            final Locale locale =
+                    ServiceProvider.getInstance().getDeviceInfoService().getActiveLocale();
+            String message =
+                    newCount > 0
+                            ? String.format(
+                                    locale,
+                                    "User has qualified for %d content card(s) for surface %s",
+                                    newCount,
+                                    surface.getUri())
+                            : String.format(
+                                    locale,
+                                    "User has not qualified for any content card(s) for surface %s",
+                                    surface.getUri());
+            Log.trace(MessagingConstants.LOG_TAG, SELF_TAG, message);
         }
     }
 
@@ -799,7 +810,7 @@ class EdgePersonalizationResponseHandler {
             final Map<Surface, List<Proposition>> newPropositions,
             final List<Surface> surfacesToRemove) {
         // add new surfaces or update replace existing surfaces
-        Map<Surface, List<Proposition>> tempPropositionsMap = new HashMap<>(propositions);
+        Map<Surface, List<Proposition>> tempPropositionsMap = new HashMap<>(inMemoryPropositions);
         for (final Map.Entry<Surface, List<Proposition>> entry : newPropositions.entrySet()) {
             tempPropositionsMap =
                     MessagingUtils.updatePropositionMapForSurface(
@@ -811,7 +822,7 @@ class EdgePersonalizationResponseHandler {
             tempPropositionsMap.remove(surface);
         }
 
-        propositions = tempPropositionsMap;
+        inMemoryPropositions = tempPropositionsMap;
     }
 
     /**
@@ -824,7 +835,7 @@ class EdgePersonalizationResponseHandler {
             final List<Surface> surfaces) {
         Map<Surface, List<Proposition>> propositionMap = new HashMap<>();
         for (final Surface surface : surfaces) {
-            final List<Proposition> propositionsList = propositions.get(surface);
+            final List<Proposition> propositionsList = inMemoryPropositions.get(surface);
             if (!MessagingUtils.isNullOrEmpty(propositionsList)) {
                 propositionMap.put(surface, propositionsList);
             }

--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/EdgePersonalizationResponseHandler.java
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/EdgePersonalizationResponseHandler.java
@@ -658,9 +658,8 @@ class EdgePersonalizationResponseHandler {
         if (existingPropositionsArray != null) {
             startingCount = existingPropositionsArray.size();
             for (final Proposition proposition : propositions) {
-                // TODO: - this method of retrieval may not work
                 final int existingIndex = existingPropositionsArray.indexOf(proposition);
-                if (existingIndex > 0) {
+                if (existingIndex >= 0) {
                     existingPropositionsArray.remove(existingIndex);
                 } else {
                     final List<PropositionItem> propItems = proposition.getItems();

--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/EdgePersonalizationResponseHandler.java
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/EdgePersonalizationResponseHandler.java
@@ -56,7 +56,7 @@ class EdgePersonalizationResponseHandler {
     private final MessagingCacheUtilities messagingCacheUtilities;
     private final ExtensionApi extensionApi;
     private final LaunchRulesEngine launchRulesEngine;
-    private final FeedRulesEngine feedRulesEngine;
+    private final ContentCardRulesEngine contentCardRulesEngine;
 
     private Map<Surface, List<Proposition>> propositions = new HashMap<>();
     private Map<String, PropositionInfo> propositionInfo = new HashMap<>();
@@ -76,15 +76,15 @@ class EdgePersonalizationResponseHandler {
      * @param extensionApi {@link ExtensionApi} instance
      * @param rulesEngine {@link LaunchRulesEngine} instance to use for loading in-app message rule
      *     payloads
-     * @param feedRulesEngine {@link FeedRulesEngine} instance to use for loading message feed rule
+     * @param contentCardRulesEngine {@link ContentCardRulesEngine} instance to use for loading message feed rule
      *     payloads
      */
     EdgePersonalizationResponseHandler(
             final MessagingExtension parent,
             final ExtensionApi extensionApi,
             final LaunchRulesEngine rulesEngine,
-            final FeedRulesEngine feedRulesEngine) {
-        this(parent, extensionApi, rulesEngine, feedRulesEngine, null);
+            final ContentCardRulesEngine contentCardRulesEngine) {
+        this(parent, extensionApi, rulesEngine, contentCardRulesEngine, null);
     }
 
     @SuppressWarnings("NestedIfDepth")
@@ -93,12 +93,12 @@ class EdgePersonalizationResponseHandler {
             final MessagingExtension parent,
             final ExtensionApi extensionApi,
             final LaunchRulesEngine rulesEngine,
-            final FeedRulesEngine feedRulesEngine,
+            final ContentCardRulesEngine contentCardRulesEngine,
             final MessagingCacheUtilities messagingCacheUtilities) {
         this.parent = parent;
         this.extensionApi = extensionApi;
         this.launchRulesEngine = rulesEngine;
-        this.feedRulesEngine = feedRulesEngine;
+        this.contentCardRulesEngine = contentCardRulesEngine;
 
         // load cached propositions (if any) when EdgePersonalizationResponseHandler is instantiated
         this.messagingCacheUtilities =
@@ -605,7 +605,7 @@ class EdgePersonalizationResponseHandler {
                     }
 
                     // update rules in feed rules engine
-                    feedRulesEngine.replaceRules(collectedFeedRules);
+                    contentCardRulesEngine.replaceRules(collectedFeedRules);
                     break;
                 default:
                     // no-op
@@ -644,7 +644,7 @@ class EdgePersonalizationResponseHandler {
     private Map<Surface, List<Proposition>> getPropositionsFromFeedRulesEngine(final Event event) {
         Map<Surface, List<Proposition>> surfacePropositions = new HashMap<>();
         final Map<Surface, List<PropositionItem>> propositionItemsBySurface =
-                feedRulesEngine.evaluate(event);
+                contentCardRulesEngine.evaluate(event);
         if (!MapUtils.isNullOrEmpty(propositionItemsBySurface)) {
             for (final Map.Entry<Surface, List<PropositionItem>> entry :
                     propositionItemsBySurface.entrySet()) {

--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/EdgePersonalizationResponseHandler.java
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/EdgePersonalizationResponseHandler.java
@@ -660,7 +660,9 @@ class EdgePersonalizationResponseHandler {
      * @param propositions list of qualified {@link Proposition}s for the given surface.
      * @param surface {@link Surface} to which qualified propositions belong.
      */
-    private void addOrReplaceContentCards(List<Proposition> propositions, Surface surface) {
+    @SuppressWarnings("NestedIfDepth")
+    private void addOrReplaceContentCards(
+            final List<Proposition> propositions, final Surface surface) {
         int startingCount = 0;
         final List<Proposition> existingPropositionsArray = contentCardsBySurface.get(surface);
         if (existingPropositionsArray != null) {

--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/Feed.java
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/Feed.java
@@ -13,7 +13,11 @@ package com.adobe.marketing.mobile.messaging;
 
 import java.util.List;
 
-/** A {@link Feed} object aggregates one or more {@link FeedItem}s. */
+/**
+ * A {@link Feed} object aggregates one or more {@link FeedItem}s.
+ *
+ * @deprecated This class is unused and will be removed in the next major version.
+ */
 @Deprecated
 public class Feed {
     // Friendly name for the feed, provided in the AJO UI

--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/Feed.java
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/Feed.java
@@ -14,6 +14,7 @@ package com.adobe.marketing.mobile.messaging;
 import java.util.List;
 
 /** A {@link Feed} object aggregates one or more {@link FeedItem}s. */
+@Deprecated
 public class Feed {
     // Friendly name for the feed, provided in the AJO UI
     private final String name;

--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/FeedItem.java
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/FeedItem.java
@@ -14,7 +14,6 @@ package com.adobe.marketing.mobile.messaging;
 import com.adobe.marketing.mobile.MessagingEdgeEventType;
 import com.adobe.marketing.mobile.services.Log;
 import com.adobe.marketing.mobile.util.StringUtils;
-import java.lang.ref.SoftReference;
 
 /**
  * A {@link FeedItem} object encapsulates the information necessary for a non-disruptive yet
@@ -209,9 +208,10 @@ public class FeedItem {
      */
     public void track(final String interaction, final MessagingEdgeEventType eventType) {
         if (parent == null) {
-            Log.debug(MessagingConstants.LOG_TAG, SELF_TAG,
-                    "Unable to track ContentCard, "
-                            + "parent schema object is unavailable.");
+            Log.debug(
+                    MessagingConstants.LOG_TAG,
+                    SELF_TAG,
+                    "Unable to track ContentCard, " + "parent schema object is unavailable.");
             return;
         }
         parent.track(interaction, eventType);

--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/FeedItem.java
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/FeedItem.java
@@ -19,6 +19,8 @@ import com.adobe.marketing.mobile.util.StringUtils;
  * A {@link FeedItem} object encapsulates the information necessary for a non-disruptive yet
  * interactive offer. Customers can use the Messaging SDK to render the feed item data in a
  * pre-defined format or implement their own rendering.
+ *
+ * @deprecated Use {@link ContentCard} instead.
  */
 @Deprecated
 public class FeedItem {

--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/FeedItemSchemaData.java
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/FeedItemSchemaData.java
@@ -22,7 +22,11 @@ import java.util.Map;
 import org.json.JSONException;
 import org.json.JSONObject;
 
-// represents the schema data object for a feed item schema
+/**
+ * Represents the schema data object for a feed item schema.
+ *
+ * @deprecated Use {@link ContentCardSchemaData} instead
+ */
 @Deprecated
 public class FeedItemSchemaData implements SchemaData {
     private static final String SELF_TAG = "FeedItemSchemaData";

--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/FeedItemSchemaData.java
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/FeedItemSchemaData.java
@@ -13,7 +13,6 @@ package com.adobe.marketing.mobile.messaging;
 
 import androidx.annotation.Nullable;
 import androidx.annotation.VisibleForTesting;
-
 import com.adobe.marketing.mobile.MessagingEdgeEventType;
 import com.adobe.marketing.mobile.services.Log;
 import com.adobe.marketing.mobile.util.DataReader;
@@ -133,7 +132,9 @@ public class FeedItemSchemaData implements SchemaData {
      */
     public void track(final String interaction, final MessagingEdgeEventType eventType) {
         if (parent == null) {
-            Log.debug(MessagingConstants.LOG_TAG, SELF_TAG,
+            Log.debug(
+                    MessagingConstants.LOG_TAG,
+                    SELF_TAG,
                     "Unable to track FeedItemSchemaData, "
                             + "parent proposition item is unavailable.");
             return;

--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/InternalMessagingUtils.java
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/InternalMessagingUtils.java
@@ -11,6 +11,8 @@
 
 package com.adobe.marketing.mobile.messaging;
 
+import androidx.annotation.Nullable;
+
 import com.adobe.marketing.mobile.AdobeError;
 import com.adobe.marketing.mobile.Event;
 import com.adobe.marketing.mobile.EventSource;
@@ -397,19 +399,18 @@ class InternalMessagingUtils {
      * @param data a {@link Map} containing the data of the event to be dispatched
      * @param mask a {@link String[]} containing an optional event mask
      * @param extensionApi {@link ExtensionApi} to use for dispatching the event
+     * @param parentEvent {@link Event} used by the new event as the parent for event chaining
      */
-    static void sendEvent(
-            final String eventName,
-            final String eventType,
-            final String eventSource,
-            final Map<String, Object> data,
-            final String[] mask,
-            final ExtensionApi extensionApi) {
-        final Event event =
-                new Event.Builder(eventName, eventType, eventSource, mask)
-                        .setEventData(data)
-                        .build();
-        extensionApi.dispatch(event);
+    static void sendEvent(final String eventName, final String eventType, final String eventSource,
+            final Map<String, Object> data, final String[] mask, final ExtensionApi extensionApi,
+            final @Nullable Event parentEvent) {
+        final Event.Builder builder = new Event.Builder(eventName, eventType, eventSource, mask);
+        builder.setEventData(data);
+        if (parentEvent != null) {
+            builder.chainToParentEvent(parentEvent);
+        }
+
+        extensionApi.dispatch(builder.build());
     }
 
     /**
@@ -420,14 +421,16 @@ class InternalMessagingUtils {
      * @param eventSource a {@code String} containing the source of the event to be dispatched
      * @param data a {@link Map} containing the data of the event to be dispatched
      * @param extensionApi {@link ExtensionApi} to use for dispatching the event
+     * @param parentEvent {@link Event} used by the new event as the parent for event chaining
      */
     static void sendEvent(
             final String eventName,
             final String eventType,
             final String eventSource,
             final Map<String, Object> data,
-            final ExtensionApi extensionApi) {
-        sendEvent(eventName, eventType, eventSource, data, null, extensionApi);
+            final ExtensionApi extensionApi,
+            final @Nullable Event parentEvent) {
+        sendEvent(eventName, eventType, eventSource, data, null, extensionApi, parentEvent);
     }
 
     /**

--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/InternalMessagingUtils.java
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/InternalMessagingUtils.java
@@ -12,7 +12,6 @@
 package com.adobe.marketing.mobile.messaging;
 
 import androidx.annotation.Nullable;
-
 import com.adobe.marketing.mobile.AdobeError;
 import com.adobe.marketing.mobile.Event;
 import com.adobe.marketing.mobile.EventSource;
@@ -401,8 +400,13 @@ class InternalMessagingUtils {
      * @param extensionApi {@link ExtensionApi} to use for dispatching the event
      * @param parentEvent {@link Event} used by the new event as the parent for event chaining
      */
-    static void sendEvent(final String eventName, final String eventType, final String eventSource,
-            final Map<String, Object> data, final String[] mask, final ExtensionApi extensionApi,
+    static void sendEvent(
+            final String eventName,
+            final String eventType,
+            final String eventSource,
+            final Map<String, Object> data,
+            final String[] mask,
+            final ExtensionApi extensionApi,
             final @Nullable Event parentEvent) {
         final Event.Builder builder = new Event.Builder(eventName, eventType, eventSource, mask);
         builder.setEventData(data);

--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/MessagingConstants.java
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/MessagingConstants.java
@@ -40,9 +40,11 @@ public final class MessagingConstants {
         static final String SCHEMA_RULESET_ITEM =
                 "https://ns.adobe.com/personalization/ruleset-item";
         static final String SCHEMA_IAM = "https://ns.adobe.com/personalization/message/in-app";
+
         @Deprecated
         static final String SCHEMA_FEED_ITEM =
                 "https://ns.adobe.com/personalization/message/feed-item";
+
         static final String SCHEMA_CONTENT_CARD =
                 "https://ns.adobe.com/personalization/message/content-card";
         static final String SCHEMA_NATIVE_ALERT =

--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/MessagingConstants.java
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/MessagingConstants.java
@@ -18,7 +18,7 @@ public final class MessagingConstants {
     static final String FRIENDLY_EXTENSION_NAME = "Messaging";
     static final String EXTENSION_NAME = "com.adobe.messaging";
     static final String RULES_ENGINE_NAME = EXTENSION_NAME + ".rulesengine";
-    static final String FEED_RULES_ENGINE_NAME = EXTENSION_NAME + "Feed.rulesengine";
+    static final String CONTENT_CARD_RULES_ENGINE_NAME = EXTENSION_NAME + "ContentCard.rulesengine";
     static final String CACHE_BASE_DIR = "messaging";
     static final String PROPOSITIONS_CACHE_SUBDIRECTORY = "propositions";
     static final String IMAGES_CACHE_SUBDIRECTORY = "images";
@@ -40,8 +40,11 @@ public final class MessagingConstants {
         static final String SCHEMA_RULESET_ITEM =
                 "https://ns.adobe.com/personalization/ruleset-item";
         static final String SCHEMA_IAM = "https://ns.adobe.com/personalization/message/in-app";
+        @Deprecated
         static final String SCHEMA_FEED_ITEM =
                 "https://ns.adobe.com/personalization/message/feed-item";
+        static final String SCHEMA_CONTENT_CARD =
+                "https://ns.adobe.com/personalization/message/content-card";
         static final String SCHEMA_NATIVE_ALERT =
                 "https://ns.adobe.com/personalization/message/native-alert";
         static final String SCHEMA_DEFAULT_CONTENT =

--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/MessagingExtension.java
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/MessagingExtension.java
@@ -161,7 +161,7 @@ public final class MessagingExtension extends Extension {
                             "MessagingEvents",
                             event -> {
                                 if (InternalMessagingUtils.isGetPropositionsEvent(event)) {
-                                    edgePersonalizationResponseHandler.retrieveCachedContentCards(
+                                    edgePersonalizationResponseHandler.retrieveInMemoryPropositions(
                                             InternalMessagingUtils.getSurfaces(event), event);
                                 } else if (event.getType().equals(EventType.EDGE)) {
                                     return !edgePersonalizationResponseHandler

--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/MessagingExtension.java
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/MessagingExtension.java
@@ -42,7 +42,7 @@ public final class MessagingExtension extends Extension {
     final EdgePersonalizationResponseHandler edgePersonalizationResponseHandler;
     private boolean initialMessageFetchComplete = false;
     final LaunchRulesEngine messagingRulesEngine;
-    final FeedRulesEngine feedRulesEngine;
+    final ContentCardRulesEngine contentCardRulesEngine;
     private SerialWorkDispatcher<Event> serialWorkDispatcher;
 
     /**
@@ -72,18 +72,18 @@ public final class MessagingExtension extends Extension {
     MessagingExtension(
             final ExtensionApi extensionApi,
             final LaunchRulesEngine messagingRulesEngine,
-            final FeedRulesEngine feedRulesEngine,
+            final ContentCardRulesEngine contentCardRulesEngine,
             final EdgePersonalizationResponseHandler edgePersonalizationResponseHandler) {
         super(extensionApi);
         this.messagingRulesEngine =
                 messagingRulesEngine != null
                         ? messagingRulesEngine
                         : new LaunchRulesEngine(MessagingConstants.RULES_ENGINE_NAME, extensionApi);
-        this.feedRulesEngine =
-                feedRulesEngine != null
-                        ? feedRulesEngine
-                        : new FeedRulesEngine(
-                                MessagingConstants.FEED_RULES_ENGINE_NAME, extensionApi);
+        this.contentCardRulesEngine =
+                contentCardRulesEngine != null
+                        ? contentCardRulesEngine
+                        : new ContentCardRulesEngine(
+                                MessagingConstants.CONTENT_CARD_RULES_ENGINE_NAME, extensionApi);
         this.edgePersonalizationResponseHandler =
                 edgePersonalizationResponseHandler != null
                         ? edgePersonalizationResponseHandler
@@ -91,7 +91,7 @@ public final class MessagingExtension extends Extension {
                                 this,
                                 extensionApi,
                                 this.messagingRulesEngine,
-                                this.feedRulesEngine);
+                                this.contentCardRulesEngine);
     }
 
     // region Extension interface methods

--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/MessagingExtension.java
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/MessagingExtension.java
@@ -161,7 +161,7 @@ public final class MessagingExtension extends Extension {
                             "MessagingEvents",
                             event -> {
                                 if (InternalMessagingUtils.isGetPropositionsEvent(event)) {
-                                    edgePersonalizationResponseHandler.retrieveMessages(
+                                    edgePersonalizationResponseHandler.retrieveCachedContentCards(
                                             InternalMessagingUtils.getSurfaces(event), event);
                                 } else if (event.getType().equals(EventType.EDGE)) {
                                     return !edgePersonalizationResponseHandler
@@ -202,7 +202,7 @@ public final class MessagingExtension extends Extension {
 
         // fetch propositions on initial launch once we have configuration and identity state set
         if (!initialMessageFetchComplete) {
-            edgePersonalizationResponseHandler.fetchMessages(event, null);
+            edgePersonalizationResponseHandler.fetchPropositions(event, null);
             initialMessageFetchComplete = true;
         }
 
@@ -254,6 +254,7 @@ public final class MessagingExtension extends Extension {
             return;
         }
         messagingRulesEngine.processEvent(event);
+        edgePersonalizationResponseHandler.updateQualifiedContentCardsForEvent(event);
     }
 
     /**
@@ -362,7 +363,7 @@ public final class MessagingExtension extends Extension {
                     SELF_TAG,
                     "Processing manual request to refresh In-App Message definitions from the"
                             + " remote.");
-            edgePersonalizationResponseHandler.fetchMessages(eventToProcess, null);
+            edgePersonalizationResponseHandler.fetchPropositions(eventToProcess, null);
         } else if (InternalMessagingUtils.isUpdatePropositionsEvent(eventToProcess)) {
             // validate update propositions event then retrieve propositions via an Edge extension
             // event
@@ -370,7 +371,7 @@ public final class MessagingExtension extends Extension {
                     MessagingConstants.LOG_TAG,
                     SELF_TAG,
                     "Processing request to retrieve propositions from the remote.");
-            edgePersonalizationResponseHandler.fetchMessages(
+            edgePersonalizationResponseHandler.fetchPropositions(
                     eventToProcess, InternalMessagingUtils.getSurfaces(eventToProcess));
         } else if (InternalMessagingUtils.isGetPropositionsEvent(eventToProcess)) {
             // Queue the get propositions event in the
@@ -495,7 +496,8 @@ public final class MessagingExtension extends Extension {
                 MessagingConstants.EventType.EDGE,
                 MessagingConstants.EventSource.REQUEST_CONTENT,
                 eventData,
-                getApi());
+                getApi(),
+                event);
     }
 
     /**
@@ -589,7 +591,8 @@ public final class MessagingExtension extends Extension {
                 MessagingConstants.EventType.EDGE,
                 MessagingConstants.EventSource.REQUEST_CONTENT,
                 xdmData,
-                getApi());
+                getApi(),
+                event);
     }
 
     /**
@@ -607,7 +610,8 @@ public final class MessagingExtension extends Extension {
                 MessagingConstants.EventType.EDGE,
                 MessagingConstants.EventSource.REQUEST_CONTENT,
                 xdmEventData,
-                getApi());
+                getApi(),
+                null);
     }
     // endregion
 

--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/ParsedPropositions.java
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/ParsedPropositions.java
@@ -106,12 +106,13 @@ public class ParsedPropositions {
                                                 surface, proposition, propositionsToPersist);
                                 mergeRules(parsedRules, surface, SchemaType.INAPP);
                                 break;
+                            case CONTENT_CARD:
                             case FEED:
-                                final PropositionInfo feedPropositionInfo =
+                                final PropositionInfo contentCardPropositionInfo =
                                         PropositionInfo.createFromProposition(proposition);
                                 propositionInfoToCache.put(
-                                        consequence.getId(), feedPropositionInfo);
-                                mergeRules(parsedRules, surface, SchemaType.FEED);
+                                        consequence.getId(), contentCardPropositionInfo);
+                                mergeRules(parsedRules, surface, SchemaType.CONTENT_CARD);
                                 break;
                             default:
                                 break;

--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/PresentableMessageMapper.java
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/PresentableMessageMapper.java
@@ -347,7 +347,7 @@ class PresentableMessageMapper {
                         SELF_TAG,
                         "Unable to write event history event %s, proposition info is "
                                 + "not available for message %s",
-                        eventType.toString(),
+                        eventType != null ? eventType.toString() : "'unknown'",
                         id);
                 return;
             }

--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/PresentableMessageMapper.java
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/PresentableMessageMapper.java
@@ -24,7 +24,6 @@ import com.adobe.marketing.mobile.services.ui.UIService;
 import com.adobe.marketing.mobile.services.ui.message.InAppMessageSettings;
 import com.adobe.marketing.mobile.util.DataReader;
 import com.adobe.marketing.mobile.util.DefaultPresentationUtilityProvider;
-import com.adobe.marketing.mobile.util.MapUtils;
 import com.adobe.marketing.mobile.util.StringUtils;
 import java.util.HashMap;
 import java.util.Map;
@@ -335,18 +334,21 @@ class PresentableMessageMapper {
         }
 
         /**
-         * Dispatches an event to be recorded in Event History.
-         * Does not write to event history if the activity ID cannot be retrieved from
-         * proposition info.
+         * Dispatches an event to be recorded in Event History. Does not write to event history if
+         * the activity ID cannot be retrieved from proposition info.
          *
          * @param interaction {@code String} if provided, adds a custom interaction to the hash
          * @param eventType {@link MessagingEdgeEventType} to be recorded
          */
         void recordEventHistory(final String interaction, final MessagingEdgeEventType eventType) {
             if (propositionInfo == null || StringUtils.isNullOrEmpty(propositionInfo.activityId)) {
-                Log.debug(MessagingConstants.LOG_TAG, SELF_TAG,
-                        "Unable to write event history event %s, proposition info is " +
-                                "not available for message %s", eventType.toString(), id);
+                Log.debug(
+                        MessagingConstants.LOG_TAG,
+                        SELF_TAG,
+                        "Unable to write event history event %s, proposition info is "
+                                + "not available for message %s",
+                        eventType.toString(),
+                        id);
                 return;
             }
 

--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/Proposition.java
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/Proposition.java
@@ -175,16 +175,18 @@ public class Proposition implements Serializable {
         return eventData;
     }
 
-    // TODO: - do we need to update this equals function to look compare ONLY activityId instead?
+    /**
+     * Two propositions are equal if their {@code decisionScope.activity.id} values are the same.
+     *
+     * @param object the other {@link Proposition} object to be checked against.
+     * @return {@code true} if both {@code Proposition}s share the same activityId.
+     */
     public boolean equals(final Object object) {
-        if (object instanceof Proposition) {
-            final Proposition proposition = (Proposition) object;
-            final Map<String, Object> newPropositionContent =
-                    proposition.getItems().get(0).getItemData();
-            final Map<String, Object> propositionContent = this.getItems().get(0).getItemData();
-            return newPropositionContent.equals(propositionContent);
-        } else {
+        if (!(object instanceof Proposition)) {
             return false;
         }
+
+        final Proposition proposition = (Proposition) object;
+        return proposition.getActivityId().equals(getActivityId());
     }
 }

--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/Proposition.java
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/Proposition.java
@@ -13,8 +13,6 @@ package com.adobe.marketing.mobile.messaging;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-
-import com.adobe.marketing.mobile.Messaging;
 import com.adobe.marketing.mobile.services.Log;
 import com.adobe.marketing.mobile.util.DataReader;
 import com.adobe.marketing.mobile.util.DataReaderException;
@@ -112,8 +110,9 @@ public class Proposition implements Serializable {
             return "";
         }
 
-        final Map<String, Object> activity = DataReader.optTypedMap(Object.class, scopeDetails,
-                MessagingConstants.PayloadKeys.ACTIVITY, null);
+        final Map<String, Object> activity =
+                DataReader.optTypedMap(
+                        Object.class, scopeDetails, MessagingConstants.PayloadKeys.ACTIVITY, null);
 
         // return early if we don't have an "activity" map in "scopeDetails"
         if (MapUtils.isNullOrEmpty(activity)) {

--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/Proposition.java
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/Proposition.java
@@ -13,6 +13,8 @@ package com.adobe.marketing.mobile.messaging;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+
+import com.adobe.marketing.mobile.Messaging;
 import com.adobe.marketing.mobile.services.Log;
 import com.adobe.marketing.mobile.util.DataReader;
 import com.adobe.marketing.mobile.util.DataReaderException;
@@ -104,6 +106,23 @@ public class Proposition implements Serializable {
         return scopeDetails;
     }
 
+    String getActivityId() {
+        // return early if we have no "scopeDetails"
+        if (MapUtils.isNullOrEmpty(scopeDetails)) {
+            return "";
+        }
+
+        final Map<String, Object> activity = DataReader.optTypedMap(Object.class, scopeDetails,
+                MessagingConstants.PayloadKeys.ACTIVITY, null);
+
+        // return early if we don't have an "activity" map in "scopeDetails"
+        if (MapUtils.isNullOrEmpty(activity)) {
+            return "";
+        }
+
+        return DataReader.optString(activity, MessagingConstants.PayloadKeys.ID, "");
+    }
+
     /**
      * Creates a {@code Proposition} object from the provided {@code Map<String, Object>}.
      *
@@ -156,6 +175,7 @@ public class Proposition implements Serializable {
         return eventData;
     }
 
+    // TODO: - do we need to update this equals function to look compare ONLY activityId instead?
     public boolean equals(final Object object) {
         if (object instanceof Proposition) {
             final Proposition proposition = (Proposition) object;

--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/PropositionHistory.java
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/PropositionHistory.java
@@ -11,8 +11,6 @@
 
 package com.adobe.marketing.mobile.messaging;
 
-import static com.adobe.marketing.mobile.messaging.MessagingConstants.EventMask.Keys.*;
-
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import com.adobe.marketing.mobile.Event;
@@ -39,7 +37,7 @@ final class PropositionHistory {
     static void record(
             @NonNull final String activityId,
             @NonNull final MessagingEdgeEventType eventType,
-            @Nullable String interaction) {
+            @Nullable final String interaction) {
         if (StringUtils.isNullOrEmpty(activityId)) {
             Log.debug(
                     MessagingConstants.LOG_TAG,
@@ -50,10 +48,12 @@ final class PropositionHistory {
 
         // create map for event history
         final Map<String, String> iamHistoryMap = new HashMap<>();
-        iamHistoryMap.put(EVENT_TYPE, eventType.getPropositionEventType());
-        iamHistoryMap.put(MESSAGE_ID, activityId);
         iamHistoryMap.put(
-                TRACKING_ACTION, (StringUtils.isNullOrEmpty(interaction) ? "" : interaction));
+                MessagingConstants.EventMask.Keys.EVENT_TYPE, eventType.getPropositionEventType());
+        iamHistoryMap.put(MessagingConstants.EventMask.Keys.MESSAGE_ID, activityId);
+        iamHistoryMap.put(
+                MessagingConstants.EventMask.Keys.TRACKING_ACTION,
+                (StringUtils.isNullOrEmpty(interaction) ? "" : interaction));
 
         // wrap history in an "iam" object
         final Map<String, Object> eventHistoryData = new HashMap<>();

--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/PropositionHistory.java
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/PropositionHistory.java
@@ -1,0 +1,72 @@
+/*
+  Copyright 2021 Adobe. All rights reserved.
+  This file is licensed to you under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License. You may obtain a copy
+  of the License at http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software distributed under
+  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+  OF ANY KIND, either express or implied. See the License for the specific language
+  governing permissions and limitations under the License.
+*/
+
+package com.adobe.marketing.mobile.messaging;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import com.adobe.marketing.mobile.Event;
+import com.adobe.marketing.mobile.MessagingEdgeEventType;
+import com.adobe.marketing.mobile.MobileCore;
+import com.adobe.marketing.mobile.services.Log;
+import com.adobe.marketing.mobile.util.StringUtils;
+
+import java.util.HashMap;
+import java.util.Map;
+import static com.adobe.marketing.mobile.messaging.MessagingConstants.EventMask.Keys.*;
+
+final class PropositionHistory {
+    private PropositionHistory() {}
+
+    private static final String SELF_TAG = "PropositionHistory";
+    /**
+     * Dispatches an event to be recorded in Event History.
+     * If `activityId` is an empty string, calling this function results in a no-op
+     *
+     * @param activityId {@link String} the Activity ID of the proposition being recorded.
+     * @param eventType {@link MessagingEdgeEventType} the type of event being recorded.
+     * @param interaction {@code String} optional value containing the specific interaction recorded.
+     */
+    static void record(@NonNull final String activityId, @NonNull final MessagingEdgeEventType eventType, @Nullable String interaction) {
+        if (StringUtils.isNullOrEmpty(activityId)) {
+            Log.debug(MessagingConstants.LOG_TAG, SELF_TAG,
+                    "Ignoring request to record PropositionHistory - activityId is empty.");
+            return;
+        }
+
+        // create map for event history
+        final Map<String, String> iamHistoryMap = new HashMap<>();
+        iamHistoryMap.put(EVENT_TYPE, eventType.getPropositionEventType());
+        iamHistoryMap.put(MESSAGE_ID, activityId);
+        iamHistoryMap.put(TRACKING_ACTION,
+                (StringUtils.isNullOrEmpty(interaction) ? "" : interaction));
+
+        // wrap history in an "iam" object
+        final Map<String, Object> eventHistoryData = new HashMap<>();
+        eventHistoryData.put(MessagingConstants.EventDataKeys.IAM_HISTORY, iamHistoryMap);
+
+        // create the mask for storing event history
+        final String[] mask = {
+                MessagingConstants.EventMask.Mask.EVENT_TYPE,
+                MessagingConstants.EventMask.Mask.MESSAGE_ID,
+                MessagingConstants.EventMask.Mask.TRACKING_ACTION
+        };
+
+        final Event event = new Event.Builder(
+                MessagingConstants.EventName.EVENT_HISTORY_WRITE,
+                MessagingConstants.EventType.MESSAGING,
+                MessagingConstants.EventSource.EVENT_HISTORY_WRITE,
+                mask).setEventData(eventHistoryData).build();
+
+        MobileCore.dispatchEvent(event);
+    }
+}

--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/PropositionHistory.java
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/PropositionHistory.java
@@ -47,17 +47,17 @@ final class PropositionHistory {
         }
 
         // create map for event history
-        final Map<String, String> iamHistoryMap = new HashMap<>();
-        iamHistoryMap.put(
+        final Map<String, String> historyMap = new HashMap<>();
+        historyMap.put(
                 MessagingConstants.EventMask.Keys.EVENT_TYPE, eventType.getPropositionEventType());
-        iamHistoryMap.put(MessagingConstants.EventMask.Keys.MESSAGE_ID, activityId);
-        iamHistoryMap.put(
+        historyMap.put(MessagingConstants.EventMask.Keys.MESSAGE_ID, activityId);
+        historyMap.put(
                 MessagingConstants.EventMask.Keys.TRACKING_ACTION,
                 (StringUtils.isNullOrEmpty(interaction) ? "" : interaction));
 
         // wrap history in an "iam" object
         final Map<String, Object> eventHistoryData = new HashMap<>();
-        eventHistoryData.put(MessagingConstants.EventDataKeys.IAM_HISTORY, iamHistoryMap);
+        eventHistoryData.put(MessagingConstants.EventDataKeys.IAM_HISTORY, historyMap);
 
         // create the mask for storing event history
         final String[] mask = {

--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/PropositionHistory.java
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/PropositionHistory.java
@@ -11,34 +11,39 @@
 
 package com.adobe.marketing.mobile.messaging;
 
+import static com.adobe.marketing.mobile.messaging.MessagingConstants.EventMask.Keys.*;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
-
 import com.adobe.marketing.mobile.Event;
 import com.adobe.marketing.mobile.MessagingEdgeEventType;
 import com.adobe.marketing.mobile.MobileCore;
 import com.adobe.marketing.mobile.services.Log;
 import com.adobe.marketing.mobile.util.StringUtils;
-
 import java.util.HashMap;
 import java.util.Map;
-import static com.adobe.marketing.mobile.messaging.MessagingConstants.EventMask.Keys.*;
 
 final class PropositionHistory {
     private PropositionHistory() {}
 
     private static final String SELF_TAG = "PropositionHistory";
     /**
-     * Dispatches an event to be recorded in Event History.
-     * If `activityId` is an empty string, calling this function results in a no-op
+     * Dispatches an event to be recorded in Event History. If `activityId` is an empty string,
+     * calling this function results in a no-op
      *
      * @param activityId {@link String} the Activity ID of the proposition being recorded.
      * @param eventType {@link MessagingEdgeEventType} the type of event being recorded.
-     * @param interaction {@code String} optional value containing the specific interaction recorded.
+     * @param interaction {@code String} optional value containing the specific interaction
+     *     recorded.
      */
-    static void record(@NonNull final String activityId, @NonNull final MessagingEdgeEventType eventType, @Nullable String interaction) {
+    static void record(
+            @NonNull final String activityId,
+            @NonNull final MessagingEdgeEventType eventType,
+            @Nullable String interaction) {
         if (StringUtils.isNullOrEmpty(activityId)) {
-            Log.debug(MessagingConstants.LOG_TAG, SELF_TAG,
+            Log.debug(
+                    MessagingConstants.LOG_TAG,
+                    SELF_TAG,
                     "Ignoring request to record PropositionHistory - activityId is empty.");
             return;
         }
@@ -47,8 +52,8 @@ final class PropositionHistory {
         final Map<String, String> iamHistoryMap = new HashMap<>();
         iamHistoryMap.put(EVENT_TYPE, eventType.getPropositionEventType());
         iamHistoryMap.put(MESSAGE_ID, activityId);
-        iamHistoryMap.put(TRACKING_ACTION,
-                (StringUtils.isNullOrEmpty(interaction) ? "" : interaction));
+        iamHistoryMap.put(
+                TRACKING_ACTION, (StringUtils.isNullOrEmpty(interaction) ? "" : interaction));
 
         // wrap history in an "iam" object
         final Map<String, Object> eventHistoryData = new HashMap<>();
@@ -56,16 +61,19 @@ final class PropositionHistory {
 
         // create the mask for storing event history
         final String[] mask = {
-                MessagingConstants.EventMask.Mask.EVENT_TYPE,
-                MessagingConstants.EventMask.Mask.MESSAGE_ID,
-                MessagingConstants.EventMask.Mask.TRACKING_ACTION
+            MessagingConstants.EventMask.Mask.EVENT_TYPE,
+            MessagingConstants.EventMask.Mask.MESSAGE_ID,
+            MessagingConstants.EventMask.Mask.TRACKING_ACTION
         };
 
-        final Event event = new Event.Builder(
-                MessagingConstants.EventName.EVENT_HISTORY_WRITE,
-                MessagingConstants.EventType.MESSAGING,
-                MessagingConstants.EventSource.EVENT_HISTORY_WRITE,
-                mask).setEventData(eventHistoryData).build();
+        final Event event =
+                new Event.Builder(
+                                MessagingConstants.EventName.EVENT_HISTORY_WRITE,
+                                MessagingConstants.EventType.MESSAGING,
+                                MessagingConstants.EventSource.EVENT_HISTORY_WRITE,
+                                mask)
+                        .setEventData(eventHistoryData)
+                        .build();
 
         MobileCore.dispatchEvent(event);
     }

--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/PropositionItem.java
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/PropositionItem.java
@@ -148,6 +148,9 @@ public class PropositionItem implements Serializable {
             final String interaction,
             @NonNull final MessagingEdgeEventType eventType,
             final List<String> tokens) {
+        // record the event in event history
+
+
         final Map<String, Object> propositionInteractionXdm =
                 generateInteractionXdm(interaction, eventType, tokens);
         if (propositionInteractionXdm == null) {
@@ -297,15 +300,44 @@ public class PropositionItem implements Serializable {
     }
 
     /**
+     * Returns this {@link PropositionItem}'s content as a {@code ContentCardSchemaData} object.
+     *
+     * @return {@link ContentCardSchemaData} object containing the {@link PropositionItem}'s content.
+     */
+    public ContentCardSchemaData getContentCardSchemaData() {
+        if (!schema.equals(SchemaType.CONTENT_CARD)) {
+            return null;
+        }
+        final ContentCardSchemaData contentCardSchemaData =
+                (ContentCardSchemaData) createSchemaData(SchemaType.CONTENT_CARD);
+
+        if (contentCardSchemaData != null) {
+            contentCardSchemaData.parent = this;
+        }
+
+        return contentCardSchemaData;
+    }
+
+    /**
      * Returns this {@link PropositionItem}'s content as a {@code FeedItemSchemaData} object.
      *
      * @return {@link FeedItemSchemaData} object containing the {@link PropositionItem}'s content.
+     * @deprecated
      */
+    @Deprecated
     public FeedItemSchemaData getFeedItemSchemaData() {
         if (!schema.equals(SchemaType.FEED)) {
             return null;
         }
-        return (FeedItemSchemaData) createSchemaData(SchemaType.FEED);
+
+        final FeedItemSchemaData feedItemSchemaData =
+                (FeedItemSchemaData) createSchemaData(SchemaType.FEED);
+
+        if (feedItemSchemaData != null) {
+            feedItemSchemaData.parent = this;
+        }
+
+        return feedItemSchemaData;
     }
 
     /**
@@ -334,6 +366,8 @@ public class PropositionItem implements Serializable {
                 return new InAppSchemaData(ruleJson);
             case FEED:
                 return new FeedItemSchemaData(ruleJson);
+            case CONTENT_CARD:
+                return new ContentCardSchemaData(ruleJson);
             default:
                 break;
         }

--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/PropositionItem.java
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/PropositionItem.java
@@ -150,7 +150,6 @@ public class PropositionItem implements Serializable {
             final List<String> tokens) {
         // record the event in event history
 
-
         final Map<String, Object> propositionInteractionXdm =
                 generateInteractionXdm(interaction, eventType, tokens);
         if (propositionInteractionXdm == null) {
@@ -302,7 +301,8 @@ public class PropositionItem implements Serializable {
     /**
      * Returns this {@link PropositionItem}'s content as a {@code ContentCardSchemaData} object.
      *
-     * @return {@link ContentCardSchemaData} object containing the {@link PropositionItem}'s content.
+     * @return {@link ContentCardSchemaData} object containing the {@link PropositionItem}'s
+     *     content.
      */
     public ContentCardSchemaData getContentCardSchemaData() {
         if (!schema.equals(SchemaType.CONTENT_CARD)) {

--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/SchemaType.java
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/SchemaType.java
@@ -19,9 +19,11 @@ public enum SchemaType {
     JSON_CONTENT(2),
     RULESET(3),
     INAPP(4),
+    @Deprecated
     FEED(5),
     NATIVE_ALERT(6),
-    DEFAULT_CONTENT(7);
+    DEFAULT_CONTENT(7),
+    CONTENT_CARD(8);
 
     private final int value;
 
@@ -50,6 +52,8 @@ public enum SchemaType {
                 return MessagingConstants.SchemaValues.SCHEMA_NATIVE_ALERT;
             case DEFAULT_CONTENT:
                 return MessagingConstants.SchemaValues.SCHEMA_DEFAULT_CONTENT;
+            case CONTENT_CARD:
+                return MessagingConstants.SchemaValues.SCHEMA_CONTENT_CARD;
             default:
                 return "";
         }
@@ -81,6 +85,9 @@ public enum SchemaType {
                 break;
             case MessagingConstants.SchemaValues.SCHEMA_DEFAULT_CONTENT:
                 schemaType = SchemaType.DEFAULT_CONTENT;
+                break;
+            case MessagingConstants.SchemaValues.SCHEMA_CONTENT_CARD:
+                schemaType = SchemaType.CONTENT_CARD;
                 break;
             default:
                 schemaType = SchemaType.UNKNOWN;

--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/SchemaType.java
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/SchemaType.java
@@ -19,6 +19,9 @@ public enum SchemaType {
     JSON_CONTENT(2),
     RULESET(3),
     INAPP(4),
+    /**
+     * @deprecated Use {@link #CONTENT_CARD} instead.
+     */
     @Deprecated
     FEED(5),
     NATIVE_ALERT(6),

--- a/code/messaging/src/test/java/com/adobe/marketing/mobile/messaging/ContentCardRulesEngineTests.java
+++ b/code/messaging/src/test/java/com/adobe/marketing/mobile/messaging/ContentCardRulesEngineTests.java
@@ -107,7 +107,7 @@ public class ContentCardRulesEngineTests {
                 propositionItemsBySurface.get(Surface.fromUriString("mobileapp://mockPackageName"));
         Assert.assertNotNull(inboundMessageList);
         Assert.assertEquals(1, inboundMessageList.size());
-        Assert.assertEquals(SchemaType.FEED, inboundMessageList.get(0).getSchema());
+        Assert.assertEquals(SchemaType.CONTENT_CARD, inboundMessageList.get(0).getSchema());
     }
 
     @Test

--- a/code/messaging/src/test/java/com/adobe/marketing/mobile/messaging/ContentCardRulesEngineTests.java
+++ b/code/messaging/src/test/java/com/adobe/marketing/mobile/messaging/ContentCardRulesEngineTests.java
@@ -28,11 +28,11 @@ import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.Silent.class)
-public class FeedRulesEngineTests {
+public class ContentCardRulesEngineTests {
 
     @Mock private ExtensionApi mockExtensionApi;
 
-    private FeedRulesEngine feedRulesEngine;
+    private ContentCardRulesEngine contentCardRulesEngine;
 
     private Event defaultEvent =
             new Event.Builder("event", EventType.GENERIC_TRACK, EventSource.REQUEST_CONTENT)
@@ -46,13 +46,13 @@ public class FeedRulesEngineTests {
 
     @Before
     public void setup() {
-        feedRulesEngine = new FeedRulesEngine("mockRulesEngine", mockExtensionApi);
+        contentCardRulesEngine = new ContentCardRulesEngine("mockRulesEngine", mockExtensionApi);
     }
 
     @Test(expected = IllegalArgumentException.class)
     public void test_evaluate_WithNullEvent() {
         // test
-        feedRulesEngine.evaluate(null);
+        contentCardRulesEngine.evaluate(null);
     }
 
     @Test
@@ -61,11 +61,11 @@ public class FeedRulesEngineTests {
         String rulesJson = MessagingTestUtils.loadStringFromFile("ruleWithNoConsequence.json");
         Assert.assertNotNull(rulesJson);
         List<LaunchRule> rules = JSONRulesParser.parse(rulesJson, mockExtensionApi);
-        feedRulesEngine.replaceRules(rules);
+        contentCardRulesEngine.replaceRules(rules);
 
         // test
         Map<Surface, List<PropositionItem>> propositionItemsBySurface =
-                feedRulesEngine.evaluate(defaultEvent);
+                contentCardRulesEngine.evaluate(defaultEvent);
 
         // verify
         Assert.assertNull(propositionItemsBySurface);
@@ -77,11 +77,11 @@ public class FeedRulesEngineTests {
         String rulesJson = MessagingTestUtils.loadStringFromFile("inappPropositionV2Content.json");
         Assert.assertNotNull(rulesJson);
         List<LaunchRule> rules = JSONRulesParser.parse(rulesJson, mockExtensionApi);
-        feedRulesEngine.replaceRules(rules);
+        contentCardRulesEngine.replaceRules(rules);
 
         // test
         Map<Surface, List<PropositionItem>> propositionItemsBySurface =
-                feedRulesEngine.evaluate(defaultEvent);
+                contentCardRulesEngine.evaluate(defaultEvent);
 
         // verify
         Assert.assertNotNull(propositionItemsBySurface);
@@ -94,11 +94,11 @@ public class FeedRulesEngineTests {
         String rulesJson = MessagingTestUtils.loadStringFromFile("feedPropositionContent.json");
         Assert.assertNotNull(rulesJson);
         List<LaunchRule> rules = JSONRulesParser.parse(rulesJson, mockExtensionApi);
-        feedRulesEngine.replaceRules(rules);
+        contentCardRulesEngine.replaceRules(rules);
 
         // test
         Map<Surface, List<PropositionItem>> propositionItemsBySurface =
-                feedRulesEngine.evaluate(defaultEvent);
+                contentCardRulesEngine.evaluate(defaultEvent);
 
         // verify
         Assert.assertNotNull(propositionItemsBySurface);
@@ -118,11 +118,11 @@ public class FeedRulesEngineTests {
                         "feedPropositionContentFeedItemConsequences.json");
         Assert.assertNotNull(rulesJson);
         List<LaunchRule> rules = JSONRulesParser.parse(rulesJson, mockExtensionApi);
-        feedRulesEngine.replaceRules(rules);
+        contentCardRulesEngine.replaceRules(rules);
 
         // test
         Map<Surface, List<PropositionItem>> propositionItemsBySurface =
-                feedRulesEngine.evaluate(defaultEvent);
+                contentCardRulesEngine.evaluate(defaultEvent);
 
         // verify
         Assert.assertNotNull(propositionItemsBySurface);
@@ -141,11 +141,11 @@ public class FeedRulesEngineTests {
                 MessagingTestUtils.loadStringFromFile("feedPropositionContentMissingData.json");
         Assert.assertNotNull(rulesJson);
         List<LaunchRule> rules = JSONRulesParser.parse(rulesJson, mockExtensionApi);
-        feedRulesEngine.replaceRules(rules);
+        contentCardRulesEngine.replaceRules(rules);
 
         // test
         Map<Surface, List<PropositionItem>> propositionItemsBySurface =
-                feedRulesEngine.evaluate(defaultEvent);
+                contentCardRulesEngine.evaluate(defaultEvent);
 
         // verify
         Assert.assertTrue(propositionItemsBySurface.isEmpty());
@@ -159,11 +159,11 @@ public class FeedRulesEngineTests {
                         "feedPropositionContentMissingSurfaceMetadata.json");
         Assert.assertNotNull(rulesJson);
         List<LaunchRule> rules = JSONRulesParser.parse(rulesJson, mockExtensionApi);
-        feedRulesEngine.replaceRules(rules);
+        contentCardRulesEngine.replaceRules(rules);
 
         // test
         Map<Surface, List<PropositionItem>> propositionItemsBySurface =
-                feedRulesEngine.evaluate(defaultEvent);
+                contentCardRulesEngine.evaluate(defaultEvent);
 
         // verify
         Assert.assertTrue(propositionItemsBySurface.isEmpty());

--- a/code/messaging/src/test/java/com/adobe/marketing/mobile/messaging/EdgePersonalizationResponseHandlerTests.java
+++ b/code/messaging/src/test/java/com/adobe/marketing/mobile/messaging/EdgePersonalizationResponseHandlerTests.java
@@ -98,7 +98,8 @@ public class EdgePersonalizationResponseHandlerTests {
     @Mock CacheResult mockCacheResult;
     @Mock MessagingExtension mockMessagingExtension;
     @Mock LaunchRulesEngine mockMessagingRulesEngine;
-    @Mock FeedRulesEngine mockFeedRulesEngine;
+    @Mock
+    ContentCardRulesEngine mockContentCardRulesEngine;
     @Mock MessagingCacheUtilities mockMessagingCacheUtilities;
     @Mock SerialWorkDispatcher<Event> mockSerialWorkDispatcher;
     @Mock PresentableMessageMapper mockPresentableMessageMapper;
@@ -131,7 +132,7 @@ public class EdgePersonalizationResponseHandlerTests {
         reset(mockMessagingExtension);
         reset(mockMessagingCacheUtilities);
         reset(mockMessagingRulesEngine);
-        reset(mockFeedRulesEngine);
+        reset(mockContentCardRulesEngine);
         reset(mockSerialWorkDispatcher);
         reset(mockPresentableMessageMapper);
         reset(mockInternalMessage);
@@ -168,7 +169,7 @@ public class EdgePersonalizationResponseHandlerTests {
                             mockMessagingExtension,
                             mockExtensionApi,
                             mockMessagingRulesEngine,
-                            mockFeedRulesEngine,
+                            mockContentCardRulesEngine,
                             mockMessagingCacheUtilities);
             edgePersonalizationResponseHandler.setMessagesRequestEventId(
                     "TESTING_ID", Collections.singletonList(new Surface()));
@@ -729,7 +730,7 @@ public class EdgePersonalizationResponseHandlerTests {
                                 MessagingTestUtils.createMessagingPropositionItemList(4));
                         when(JSONRulesParser.parse(anyString(), any(ExtensionApi.class)))
                                 .thenCallRealMethod();
-                        when(mockFeedRulesEngine.evaluate(any(Event.class)))
+                        when(mockContentCardRulesEngine.evaluate(any(Event.class)))
                                 .thenReturn(matchedFeedRules);
 
                         // setup in progress in-app propositions
@@ -779,7 +780,7 @@ public class EdgePersonalizationResponseHandlerTests {
                         assertEquals(3, inAppRulesListCaptor.getValue().size());
 
                         // verify parsed rules replaced in feed rules engine
-                        verify(mockFeedRulesEngine, times(1))
+                        verify(mockContentCardRulesEngine, times(1))
                                 .replaceRules(feedRulesListCaptor.capture());
                         assertEquals(4, feedRulesListCaptor.getValue().size());
 
@@ -889,7 +890,7 @@ public class EdgePersonalizationResponseHandlerTests {
                         assertEquals(3, inAppRulesListCaptor.getValue().size());
 
                         // verify parsed rules replaced in feed rules engine for both responses
-                        verify(mockFeedRulesEngine, times(2))
+                        verify(mockContentCardRulesEngine, times(2))
                                 .replaceRules(feedRulesListCaptor.capture());
                         assertEquals(4, feedRulesListCaptor.getAllValues().get(0).size());
                         assertEquals(4, feedRulesListCaptor.getAllValues().get(1).size());
@@ -966,7 +967,7 @@ public class EdgePersonalizationResponseHandlerTests {
                         verifyNoInteractions(mockMessagingRulesEngine);
 
                         // verify feed rules engine not called
-                        verifyNoInteractions(mockFeedRulesEngine);
+                        verifyNoInteractions(mockContentCardRulesEngine);
 
                         // verify received propositions event is dispatched
                         ArgumentCaptor<Event> dispatchEventArgumentCaptor =
@@ -1028,7 +1029,7 @@ public class EdgePersonalizationResponseHandlerTests {
                         verify(mockMessagingRulesEngine, times(0)).replaceRules(anyList());
 
                         // verify rules not replaced in feed rules engine
-                        verify(mockFeedRulesEngine, times(0)).replaceRules(anyList());
+                        verify(mockContentCardRulesEngine, times(0)).replaceRules(anyList());
 
                         // verify received propositions event not dispatched
                         verify(mockExtensionApi, times(0)).dispatch(any(Event.class));
@@ -1049,7 +1050,7 @@ public class EdgePersonalizationResponseHandlerTests {
                                 surface, MessagingTestUtils.createMessagingPropositionItemList(4));
                         when(JSONRulesParser.parse(anyString(), any(ExtensionApi.class)))
                                 .thenCallRealMethod();
-                        when(mockFeedRulesEngine.evaluate(any(Event.class)))
+                        when(mockContentCardRulesEngine.evaluate(any(Event.class)))
                                 .thenReturn(matchedFeedRules);
 
                         // setup in progress in-app propositions
@@ -1080,7 +1081,7 @@ public class EdgePersonalizationResponseHandlerTests {
                         verify(mockMessagingRulesEngine, times(0)).replaceRules(anyList());
 
                         // verify rules not replaced in feed rules engine
-                        verify(mockFeedRulesEngine, times(0)).replaceRules(anyList());
+                        verify(mockContentCardRulesEngine, times(0)).replaceRules(anyList());
 
                         // verify received propositions event not dispatched
                         verify(mockExtensionApi, times(0)).dispatch(any(Event.class));
@@ -1131,7 +1132,7 @@ public class EdgePersonalizationResponseHandlerTests {
                         verify(mockMessagingRulesEngine, times(0)).replaceRules(anyList());
 
                         // verify rules not replaced in feed rules engine
-                        verify(mockFeedRulesEngine, times(0)).replaceRules(anyList());
+                        verify(mockContentCardRulesEngine, times(0)).replaceRules(anyList());
 
                         // verify received propositions event not dispatched
                         verify(mockExtensionApi, times(0)).dispatch(any(Event.class));
@@ -1167,7 +1168,7 @@ public class EdgePersonalizationResponseHandlerTests {
                                 MessagingTestUtils.createMessagingPropositionItemList(3));
                         when(JSONRulesParser.parse(anyString(), any(ExtensionApi.class)))
                                 .thenCallRealMethod();
-                        when(mockFeedRulesEngine.evaluate(any(Event.class)))
+                        when(mockContentCardRulesEngine.evaluate(any(Event.class)))
                                 .thenReturn(matchedFeedRules);
 
                         // setup in progress feed propositions
@@ -1251,7 +1252,7 @@ public class EdgePersonalizationResponseHandlerTests {
                                         mockMessagingExtension,
                                         mockExtensionApi,
                                         mockMessagingRulesEngine,
-                                        mockFeedRulesEngine,
+                                        mockContentCardRulesEngine,
                                         mockMessagingCacheUtilities);
                         edgePersonalizationResponseHandler.setSerialWorkDispatcher(
                                 mockSerialWorkDispatcher);
@@ -1274,7 +1275,7 @@ public class EdgePersonalizationResponseHandlerTests {
                                 MessagingTestUtils.createMessagingPropositionItemList(3));
                         when(JSONRulesParser.parse(anyString(), any(ExtensionApi.class)))
                                 .thenCallRealMethod();
-                        when(mockFeedRulesEngine.evaluate(any(Event.class)))
+                        when(mockContentCardRulesEngine.evaluate(any(Event.class)))
                                 .thenReturn(matchedFeedRules);
 
                         // setup in progress feed propositions
@@ -1345,7 +1346,7 @@ public class EdgePersonalizationResponseHandlerTests {
                                 MessagingTestUtils.createMessagingPropositionItemList(3));
                         when(JSONRulesParser.parse(anyString(), any(ExtensionApi.class)))
                                 .thenCallRealMethod();
-                        when(mockFeedRulesEngine.evaluate(any(Event.class)))
+                        when(mockContentCardRulesEngine.evaluate(any(Event.class)))
                                 .thenReturn(matchedFeedRules);
 
                         // setup in progress feed propositions
@@ -1408,7 +1409,7 @@ public class EdgePersonalizationResponseHandlerTests {
                                 MessagingTestUtils.createMessagingPropositionItemList(3));
                         when(JSONRulesParser.parse(anyString(), any(ExtensionApi.class)))
                                 .thenCallRealMethod();
-                        when(mockFeedRulesEngine.evaluate(any(Event.class)))
+                        when(mockContentCardRulesEngine.evaluate(any(Event.class)))
                                 .thenReturn(matchedFeedRules);
 
                         // setup in progress feed propositions
@@ -1486,7 +1487,7 @@ public class EdgePersonalizationResponseHandlerTests {
                                         mockMessagingExtension,
                                         mockExtensionApi,
                                         mockMessagingRulesEngine,
-                                        mockFeedRulesEngine,
+                                        mockContentCardRulesEngine,
                                         mockMessagingCacheUtilities);
 
                         // verify cached rules replaced in rules engine
@@ -1514,7 +1515,7 @@ public class EdgePersonalizationResponseHandlerTests {
                                         mockMessagingExtension,
                                         mockExtensionApi,
                                         mockMessagingRulesEngine,
-                                        mockFeedRulesEngine,
+                                        mockContentCardRulesEngine,
                                         mockMessagingCacheUtilities);
 
                         // verify cached rules not replaced in rules engine
@@ -1540,7 +1541,7 @@ public class EdgePersonalizationResponseHandlerTests {
                                         mockMessagingExtension,
                                         mockExtensionApi,
                                         mockMessagingRulesEngine,
-                                        mockFeedRulesEngine,
+                                        mockContentCardRulesEngine,
                                         mockMessagingCacheUtilities);
 
                         // verify cached rules not replaced in rules engine
@@ -1567,7 +1568,7 @@ public class EdgePersonalizationResponseHandlerTests {
                                         mockMessagingExtension,
                                         mockExtensionApi,
                                         mockMessagingRulesEngine,
-                                        mockFeedRulesEngine,
+                                        mockContentCardRulesEngine,
                                         mockMessagingCacheUtilities);
 
                         // verify cached rules not replaced in rules engine
@@ -1615,7 +1616,7 @@ public class EdgePersonalizationResponseHandlerTests {
                                         mockMessagingExtension,
                                         mockExtensionApi,
                                         mockMessagingRulesEngine,
-                                        mockFeedRulesEngine,
+                                        mockContentCardRulesEngine,
                                         mockMessagingCacheUtilities);
 
                         // verify cached rules replaced in rules engine

--- a/code/messaging/src/test/java/com/adobe/marketing/mobile/messaging/EdgePersonalizationResponseHandlerTests.java
+++ b/code/messaging/src/test/java/com/adobe/marketing/mobile/messaging/EdgePersonalizationResponseHandlerTests.java
@@ -209,7 +209,7 @@ public class EdgePersonalizationResponseHandlerTests {
                         fail(e.getMessage());
                     }
                     // test
-                    edgePersonalizationResponseHandler.fetchMessages(mockEvent, null);
+                    edgePersonalizationResponseHandler.fetchPropositions(mockEvent, null);
 
                     // verify edge request event dispatched
                     Event edgeRequestEvent = eventArgumentCaptor.getValue();
@@ -258,7 +258,7 @@ public class EdgePersonalizationResponseHandlerTests {
                         fail(e.getMessage());
                     }
                     // test
-                    edgePersonalizationResponseHandler.fetchMessages(mockEvent, null);
+                    edgePersonalizationResponseHandler.fetchPropositions(mockEvent, null);
 
                     // verify edge request event dispatched
                     Event edgeRequestEvent = eventArgumentCaptor.getValue();
@@ -293,7 +293,7 @@ public class EdgePersonalizationResponseHandlerTests {
                     when(mockDeviceInfoService.getApplicationPackageName()).thenReturn("");
 
                     // test
-                    edgePersonalizationResponseHandler.fetchMessages(mockEvent, null);
+                    edgePersonalizationResponseHandler.fetchPropositions(mockEvent, null);
 
                     // verify edge request event not dispatched
                     assertEquals(0, eventArgumentCaptor.getAllValues().size());
@@ -328,7 +328,7 @@ public class EdgePersonalizationResponseHandlerTests {
                         fail(e.getMessage());
                     }
                     // test
-                    edgePersonalizationResponseHandler.fetchMessages(mockEvent, surfacePaths);
+                    edgePersonalizationResponseHandler.fetchPropositions(mockEvent, surfacePaths);
 
                     // verify edge request event dispatched
                     Event edgeRequestEvent = eventArgumentCaptor.getValue();
@@ -383,7 +383,7 @@ public class EdgePersonalizationResponseHandlerTests {
                         fail(e.getMessage());
                     }
                     // test
-                    edgePersonalizationResponseHandler.fetchMessages(mockEvent, surfacePaths);
+                    edgePersonalizationResponseHandler.fetchPropositions(mockEvent, surfacePaths);
 
                     // verify edge request event dispatched
                     Event edgeRequestEvent = eventArgumentCaptor.getValue();
@@ -421,7 +421,7 @@ public class EdgePersonalizationResponseHandlerTests {
                     surfacePaths.add(new Surface("alsoinvalid##"));
 
                     // test
-                    edgePersonalizationResponseHandler.fetchMessages(mockEvent, surfacePaths);
+                    edgePersonalizationResponseHandler.fetchPropositions(mockEvent, surfacePaths);
 
                     // verify edge request event not dispatched
                     assertEquals(0, eventArgumentCaptor.getAllValues().size());
@@ -453,7 +453,7 @@ public class EdgePersonalizationResponseHandlerTests {
                         fail(e.getMessage());
                     }
                     // test
-                    edgePersonalizationResponseHandler.fetchMessages(mockEvent, surfacePaths);
+                    edgePersonalizationResponseHandler.fetchPropositions(mockEvent, surfacePaths);
 
                     // verify edge request event dispatched
                     Event edgeRequestEvent = eventArgumentCaptor.getValue();
@@ -1197,7 +1197,7 @@ public class EdgePersonalizationResponseHandlerTests {
                         reset(mockExtensionApi);
 
                         // test retrieveMessages
-                        edgePersonalizationResponseHandler.retrieveMessages(surfaces, mockEvent);
+                        edgePersonalizationResponseHandler.retrieveCachedContentCards(surfaces, mockEvent);
 
                         // verify message propositions response event dispatched with 1 feed
                         // proposition
@@ -1305,7 +1305,7 @@ public class EdgePersonalizationResponseHandlerTests {
                         reset(mockExtensionApi);
 
                         // test retrieveMessages
-                        edgePersonalizationResponseHandler.retrieveMessages(surfaces, mockEvent);
+                        edgePersonalizationResponseHandler.retrieveCachedContentCards(surfaces, mockEvent);
 
                         // verify message propositions response event dispatched with 1 feed
                         // proposition
@@ -1372,7 +1372,7 @@ public class EdgePersonalizationResponseHandlerTests {
                         reset(mockExtensionApi);
 
                         // test retrieveMessages
-                        edgePersonalizationResponseHandler.retrieveMessages(surfaces, mockEvent);
+                        edgePersonalizationResponseHandler.retrieveCachedContentCards(surfaces, mockEvent);
 
                         // verify error response event dispatched
                         verify(mockExtensionApi, times(1)).dispatch(eventArgumentCaptor.capture());
@@ -1435,7 +1435,7 @@ public class EdgePersonalizationResponseHandlerTests {
                         reset(mockExtensionApi);
 
                         // test retrieveMessages
-                        edgePersonalizationResponseHandler.retrieveMessages(surfaces, mockEvent);
+                        edgePersonalizationResponseHandler.retrieveCachedContentCards(surfaces, mockEvent);
 
                         // verify no response event dispatched
                         verify(mockExtensionApi, times(0)).dispatch(any(Event.class));

--- a/code/messaging/src/test/java/com/adobe/marketing/mobile/messaging/EdgePersonalizationResponseHandlerTests.java
+++ b/code/messaging/src/test/java/com/adobe/marketing/mobile/messaging/EdgePersonalizationResponseHandlerTests.java
@@ -1196,7 +1196,7 @@ public class EdgePersonalizationResponseHandlerTests {
                         reset(mockExtensionApi);
 
                         // test retrieveMessages
-                        edgePersonalizationResponseHandler.retrieveCachedContentCards(
+                        edgePersonalizationResponseHandler.retrieveInMemoryPropositions(
                                 surfaces, mockEvent);
 
                         // verify message propositions response event dispatched with 1 feed
@@ -1305,7 +1305,7 @@ public class EdgePersonalizationResponseHandlerTests {
                         reset(mockExtensionApi);
 
                         // test retrieveMessages
-                        edgePersonalizationResponseHandler.retrieveCachedContentCards(
+                        edgePersonalizationResponseHandler.retrieveInMemoryPropositions(
                                 surfaces, mockEvent);
 
                         // verify message propositions response event dispatched with 1 feed
@@ -1373,7 +1373,7 @@ public class EdgePersonalizationResponseHandlerTests {
                         reset(mockExtensionApi);
 
                         // test retrieveMessages
-                        edgePersonalizationResponseHandler.retrieveCachedContentCards(
+                        edgePersonalizationResponseHandler.retrieveInMemoryPropositions(
                                 surfaces, mockEvent);
 
                         // verify error response event dispatched
@@ -1437,11 +1437,23 @@ public class EdgePersonalizationResponseHandlerTests {
                         reset(mockExtensionApi);
 
                         // test retrieveMessages
-                        edgePersonalizationResponseHandler.retrieveCachedContentCards(
+                        edgePersonalizationResponseHandler.retrieveInMemoryPropositions(
                                 surfaces, mockEvent);
 
-                        // verify no response event dispatched
-                        verify(mockExtensionApi, times(0)).dispatch(any(Event.class));
+                        // verify one response event dispatched
+                        verify(mockExtensionApi, times(1)).dispatch(eventArgumentCaptor.capture());
+                        Event propositionsResponseEvent = eventArgumentCaptor.getValue();
+                        assertEquals(
+                                MESSAGE_PROPOSITIONS_RESPONSE, propositionsResponseEvent.getName());
+                        assertEquals(EventType.MESSAGING, propositionsResponseEvent.getType());
+                        assertEquals(
+                                EventSource.RESPONSE_CONTENT,
+                                propositionsResponseEvent.getSource());
+                        eventData = propositionsResponseEvent.getEventData();
+                        assertEquals(RESPONSE_ERROR, eventData.keySet().stream().findFirst().get());
+                        assertEquals(
+                                AdobeErrorExt.INVALID_REQUEST.getErrorName(),
+                                eventData.get(RESPONSE_ERROR));
                     }
                 });
     }

--- a/code/messaging/src/test/java/com/adobe/marketing/mobile/messaging/EdgePersonalizationResponseHandlerTests.java
+++ b/code/messaging/src/test/java/com/adobe/marketing/mobile/messaging/EdgePersonalizationResponseHandlerTests.java
@@ -98,8 +98,7 @@ public class EdgePersonalizationResponseHandlerTests {
     @Mock CacheResult mockCacheResult;
     @Mock MessagingExtension mockMessagingExtension;
     @Mock LaunchRulesEngine mockMessagingRulesEngine;
-    @Mock
-    ContentCardRulesEngine mockContentCardRulesEngine;
+    @Mock ContentCardRulesEngine mockContentCardRulesEngine;
     @Mock MessagingCacheUtilities mockMessagingCacheUtilities;
     @Mock SerialWorkDispatcher<Event> mockSerialWorkDispatcher;
     @Mock PresentableMessageMapper mockPresentableMessageMapper;
@@ -1197,7 +1196,8 @@ public class EdgePersonalizationResponseHandlerTests {
                         reset(mockExtensionApi);
 
                         // test retrieveMessages
-                        edgePersonalizationResponseHandler.retrieveCachedContentCards(surfaces, mockEvent);
+                        edgePersonalizationResponseHandler.retrieveCachedContentCards(
+                                surfaces, mockEvent);
 
                         // verify message propositions response event dispatched with 1 feed
                         // proposition
@@ -1305,7 +1305,8 @@ public class EdgePersonalizationResponseHandlerTests {
                         reset(mockExtensionApi);
 
                         // test retrieveMessages
-                        edgePersonalizationResponseHandler.retrieveCachedContentCards(surfaces, mockEvent);
+                        edgePersonalizationResponseHandler.retrieveCachedContentCards(
+                                surfaces, mockEvent);
 
                         // verify message propositions response event dispatched with 1 feed
                         // proposition
@@ -1372,7 +1373,8 @@ public class EdgePersonalizationResponseHandlerTests {
                         reset(mockExtensionApi);
 
                         // test retrieveMessages
-                        edgePersonalizationResponseHandler.retrieveCachedContentCards(surfaces, mockEvent);
+                        edgePersonalizationResponseHandler.retrieveCachedContentCards(
+                                surfaces, mockEvent);
 
                         // verify error response event dispatched
                         verify(mockExtensionApi, times(1)).dispatch(eventArgumentCaptor.capture());
@@ -1435,7 +1437,8 @@ public class EdgePersonalizationResponseHandlerTests {
                         reset(mockExtensionApi);
 
                         // test retrieveMessages
-                        edgePersonalizationResponseHandler.retrieveCachedContentCards(surfaces, mockEvent);
+                        edgePersonalizationResponseHandler.retrieveCachedContentCards(
+                                surfaces, mockEvent);
 
                         // verify no response event dispatched
                         verify(mockExtensionApi, times(0)).dispatch(any(Event.class));

--- a/code/messaging/src/test/java/com/adobe/marketing/mobile/messaging/InternalMessagingUtilsTests.java
+++ b/code/messaging/src/test/java/com/adobe/marketing/mobile/messaging/InternalMessagingUtilsTests.java
@@ -1292,7 +1292,7 @@ public class InternalMessagingUtilsTests {
 
         // test
         InternalMessagingUtils.sendEvent(
-                eventName, eventType, eventSource, data, mask, extensionApi);
+                eventName, eventType, eventSource, data, mask, extensionApi, null);
 
         // verify
         ArgumentCaptor<Event> eventCaptor = ArgumentCaptor.forClass(Event.class);
@@ -1316,7 +1316,7 @@ public class InternalMessagingUtilsTests {
         ExtensionApi extensionApi = mock(ExtensionApi.class);
 
         // test
-        InternalMessagingUtils.sendEvent(eventName, eventType, eventSource, data, extensionApi);
+        InternalMessagingUtils.sendEvent(eventName, eventType, eventSource, data, extensionApi, null);
 
         // verify
         ArgumentCaptor<Event> eventCaptor = ArgumentCaptor.forClass(Event.class);

--- a/code/messaging/src/test/java/com/adobe/marketing/mobile/messaging/InternalMessagingUtilsTests.java
+++ b/code/messaging/src/test/java/com/adobe/marketing/mobile/messaging/InternalMessagingUtilsTests.java
@@ -1316,7 +1316,8 @@ public class InternalMessagingUtilsTests {
         ExtensionApi extensionApi = mock(ExtensionApi.class);
 
         // test
-        InternalMessagingUtils.sendEvent(eventName, eventType, eventSource, data, extensionApi, null);
+        InternalMessagingUtils.sendEvent(
+                eventName, eventType, eventSource, data, extensionApi, null);
 
         // verify
         ArgumentCaptor<Event> eventCaptor = ArgumentCaptor.forClass(Event.class);

--- a/code/messaging/src/test/java/com/adobe/marketing/mobile/messaging/MessagingExtensionTests.java
+++ b/code/messaging/src/test/java/com/adobe/marketing/mobile/messaging/MessagingExtensionTests.java
@@ -268,7 +268,7 @@ public class MessagingExtensionTests {
 
                     // verify EdgePersonalizationResponseHandler.retrieveMessages called
                     verify(mockEdgePersonalizationResponseHandler, times(1))
-                            .retrieveCachedContentCards(any(), any());
+                            .retrieveInMemoryPropositions(any(), any());
                 });
     }
 

--- a/code/messaging/src/test/java/com/adobe/marketing/mobile/messaging/MessagingExtensionTests.java
+++ b/code/messaging/src/test/java/com/adobe/marketing/mobile/messaging/MessagingExtensionTests.java
@@ -77,8 +77,7 @@ public class MessagingExtensionTests {
     @Mock CacheService mockCacheService;
     @Mock DeviceInforming mockDeviceInfoService;
     @Mock LaunchRulesEngine mockMessagingRulesEngine;
-    @Mock
-    ContentCardRulesEngine mockContentCardRulesEngine;
+    @Mock ContentCardRulesEngine mockContentCardRulesEngine;
     @Mock EdgePersonalizationResponseHandler mockEdgePersonalizationResponseHandler;
     @Mock SharedStateResult mockConfigData;
     @Mock SharedStateResult mockEdgeIdentityData;

--- a/code/messaging/src/test/java/com/adobe/marketing/mobile/messaging/MessagingExtensionTests.java
+++ b/code/messaging/src/test/java/com/adobe/marketing/mobile/messaging/MessagingExtensionTests.java
@@ -77,7 +77,8 @@ public class MessagingExtensionTests {
     @Mock CacheService mockCacheService;
     @Mock DeviceInforming mockDeviceInfoService;
     @Mock LaunchRulesEngine mockMessagingRulesEngine;
-    @Mock FeedRulesEngine mockFeedRulesEngine;
+    @Mock
+    ContentCardRulesEngine mockContentCardRulesEngine;
     @Mock EdgePersonalizationResponseHandler mockEdgePersonalizationResponseHandler;
     @Mock SharedStateResult mockConfigData;
     @Mock SharedStateResult mockEdgeIdentityData;
@@ -116,7 +117,7 @@ public class MessagingExtensionTests {
         reset(mockServiceProvider);
         reset(mockCacheService);
         reset(mockMessagingRulesEngine);
-        reset(mockFeedRulesEngine);
+        reset(mockContentCardRulesEngine);
         reset(mockEdgePersonalizationResponseHandler);
         reset(mockConfigData);
         reset(mockEdgeIdentityData);
@@ -157,7 +158,7 @@ public class MessagingExtensionTests {
                     new MessagingExtension(
                             mockExtensionApi,
                             mockMessagingRulesEngine,
-                            mockFeedRulesEngine,
+                            mockContentCardRulesEngine,
                             mockEdgePersonalizationResponseHandler);
 
             runnable.run();
@@ -291,7 +292,7 @@ public class MessagingExtensionTests {
                             new MessagingExtension(
                                     mockExtensionApi,
                                     mockMessagingRulesEngine,
-                                    mockFeedRulesEngine,
+                                    mockContentCardRulesEngine,
                                     mockEdgePersonalizationResponseHandler);
 
                     Event event = Mockito.mock(Event.class);

--- a/code/messaging/src/test/java/com/adobe/marketing/mobile/messaging/MessagingExtensionTests.java
+++ b/code/messaging/src/test/java/com/adobe/marketing/mobile/messaging/MessagingExtensionTests.java
@@ -269,7 +269,7 @@ public class MessagingExtensionTests {
 
                     // verify EdgePersonalizationResponseHandler.retrieveMessages called
                     verify(mockEdgePersonalizationResponseHandler, times(1))
-                            .retrieveMessages(any(), any());
+                            .retrieveCachedContentCards(any(), any());
                 });
     }
 
@@ -1752,7 +1752,7 @@ public class MessagingExtensionTests {
 
                     // verify
                     verify(mockEdgePersonalizationResponseHandler, times(1))
-                            .fetchMessages(mockEvent, null);
+                            .fetchPropositions(mockEvent, null);
                 });
     }
 
@@ -1815,7 +1815,7 @@ public class MessagingExtensionTests {
 
                     // verify
                     verify(mockEdgePersonalizationResponseHandler, times(1))
-                            .fetchMessages(any(Event.class), listArgumentCaptor.capture());
+                            .fetchPropositions(any(Event.class), listArgumentCaptor.capture());
                     List<Surface> capturedSurfaces = listArgumentCaptor.getValue();
                     assertEquals(2, capturedSurfaces.size());
                     List<String> sortedList = new ArrayList<>();

--- a/code/messaging/src/test/java/com/adobe/marketing/mobile/messaging/MessagingUtilsTests.java
+++ b/code/messaging/src/test/java/com/adobe/marketing/mobile/messaging/MessagingUtilsTests.java
@@ -33,11 +33,13 @@ public class MessagingUtilsTests {
             new HashMap<String, Object>() {
                 {
                     put("key", "value");
-                    put("activity", new HashMap<String, Object>() {
-                        {
-                            put("id", "mockActivityId");
-                        }
-                    });
+                    put(
+                            "activity",
+                            new HashMap<String, Object>() {
+                                {
+                                    put("id", "mockActivityId");
+                                }
+                            });
                 }
             };
 
@@ -77,11 +79,13 @@ public class MessagingUtilsTests {
                         new HashMap<String, Object>() {
                             {
                                 put("key", "value");
-                                put("activity", new HashMap<String, Object>() {
-                                    {
-                                        put("id", "mockActivityId2");
-                                    }
-                                });
+                                put(
+                                        "activity",
+                                        new HashMap<String, Object>() {
+                                            {
+                                                put("id", "mockActivityId2");
+                                            }
+                                        });
                             }
                         },
                         new ArrayList<PropositionItem>() {
@@ -99,11 +103,13 @@ public class MessagingUtilsTests {
                         new HashMap<String, Object>() {
                             {
                                 put("key", "value");
-                                put("activity", new HashMap<String, Object>() {
-                                    {
-                                        put("id", "mockActivityId3");
-                                    }
-                                });
+                                put(
+                                        "activity",
+                                        new HashMap<String, Object>() {
+                                            {
+                                                put("id", "mockActivityId3");
+                                            }
+                                        });
                             }
                         },
                         new ArrayList<PropositionItem>() {

--- a/code/messaging/src/test/java/com/adobe/marketing/mobile/messaging/MessagingUtilsTests.java
+++ b/code/messaging/src/test/java/com/adobe/marketing/mobile/messaging/MessagingUtilsTests.java
@@ -33,6 +33,11 @@ public class MessagingUtilsTests {
             new HashMap<String, Object>() {
                 {
                     put("key", "value");
+                    put("activity", new HashMap<String, Object>() {
+                        {
+                            put("id", "mockActivityId");
+                        }
+                    });
                 }
             };
 
@@ -69,7 +74,16 @@ public class MessagingUtilsTests {
                 new Proposition(
                         "mockId1",
                         mockSurface.getUri(),
-                        mockScopeDetails,
+                        new HashMap<String, Object>() {
+                            {
+                                put("key", "value");
+                                put("activity", new HashMap<String, Object>() {
+                                    {
+                                        put("id", "mockActivityId2");
+                                    }
+                                });
+                            }
+                        },
                         new ArrayList<PropositionItem>() {
                             {
                                 add(mockPropositionItemToAdd1);
@@ -82,7 +96,16 @@ public class MessagingUtilsTests {
                 new Proposition(
                         "mockId2",
                         mockSurface.getUri(),
-                        mockScopeDetails,
+                        new HashMap<String, Object>() {
+                            {
+                                put("key", "value");
+                                put("activity", new HashMap<String, Object>() {
+                                    {
+                                        put("id", "mockActivityId3");
+                                    }
+                                });
+                            }
+                        },
                         new ArrayList<PropositionItem>() {
                             {
                                 add(propositionItemToAdd2);

--- a/code/messaging/src/test/java/com/adobe/marketing/mobile/messaging/ParsedPropositionsTests.java
+++ b/code/messaging/src/test/java/com/adobe/marketing/mobile/messaging/ParsedPropositionsTests.java
@@ -266,7 +266,7 @@ public class ParsedPropositionsTests {
         Assert.assertEquals(0, parsedPropositions.propositionsToPersist.size());
         Assert.assertEquals(1, parsedPropositions.surfaceRulesBySchemaType.size());
         Map<Surface, List<LaunchRule>> feedRules =
-                parsedPropositions.surfaceRulesBySchemaType.get(SchemaType.FEED);
+                parsedPropositions.surfaceRulesBySchemaType.get(SchemaType.CONTENT_CARD);
         Assert.assertNotNull(feedRules);
         Assert.assertEquals(1, feedRules.size());
     }

--- a/code/messaging/src/test/java/com/adobe/marketing/mobile/messaging/PresentableMessageMapperTests.java
+++ b/code/messaging/src/test/java/com/adobe/marketing/mobile/messaging/PresentableMessageMapperTests.java
@@ -770,88 +770,91 @@ public class PresentableMessageMapperTests {
     // ========================================================================================
     // recordEventHistory
     // ========================================================================================
-    @Test
-    public void test_recordEventHistory_withValidParameters_recordsEventHistory() {
-        // setup
-        runUsingMockedServiceProvider(
-                () -> {
-                    ArgumentCaptor<Event> recordEventCapture = ArgumentCaptor.forClass(Event.class);
-                    try {
-                        internalMessage =
-                                (PresentableMessageMapper.InternalMessage)
-                                        PresentableMessageMapper.getInstance()
-                                                .createMessage(
-                                                        mockMessagingExtension,
-                                                        createPropositionItem(),
-                                                        new HashMap<>(),
-                                                        mockPropositionInfo);
-                    } catch (Exception exception) {
-                        fail(exception.getMessage());
-                    }
 
-                    // test
-                    internalMessage.recordEventHistory(
-                            "mock track", MessagingEdgeEventType.INTERACT);
-
-                    // verify tracking event
-                    verify(mockExtensionApi, times(1)).dispatch(recordEventCapture.capture());
-                    Event recordEvent = recordEventCapture.getValue();
-                    assertEquals(
-                            MessagingTestConstants.EventName.EVENT_HISTORY_WRITE,
-                            recordEvent.getName());
-                    assertEquals(MessagingTestConstants.EventType.MESSAGING, recordEvent.getType());
-                    assertEquals(
-                            MessagingTestConstants.EventSource.EVENT_HISTORY_WRITE,
-                            recordEvent.getSource());
-                    Map<String, Object> eventData = recordEvent.getEventData();
-                    Map<String, String> inAppHistoryData =
-                            (Map<String, String>)
-                                    eventData.get(MessagingTestConstants.EventDataKeys.IAM_HISTORY);
-                    assertNotNull(inAppHistoryData);
-                    assertEquals(
-                            MessagingEdgeEventType.INTERACT.getPropositionEventType(),
-                            inAppHistoryData.get(MessagingTestConstants.EventMask.Keys.EVENT_TYPE));
-                    assertEquals(
-                            mockPropositionInfo.activityId,
-                            inAppHistoryData.get(MessagingTestConstants.EventMask.Keys.MESSAGE_ID));
-                    assertEquals(
-                            "mock track",
-                            inAppHistoryData.get(
-                                    MessagingTestConstants.EventMask.Keys.TRACKING_ACTION));
-                    final String[] mask = {
-                        MessagingTestConstants.EventMask.Mask.EVENT_TYPE,
-                        MessagingTestConstants.EventMask.Mask.MESSAGE_ID,
-                        MessagingTestConstants.EventMask.Mask.TRACKING_ACTION
-                    };
-                    assertEquals(mask, recordEvent.getMask());
-                });
-    }
-
-    @Test
-    public void test_recordEventHistory_MissingMessagingEdgeEventType() {
-        // setup
-        runUsingMockedServiceProvider(
-                () -> {
-                    try {
-                        internalMessage =
-                                (PresentableMessageMapper.InternalMessage)
-                                        PresentableMessageMapper.getInstance()
-                                                .createMessage(
-                                                        mockMessagingExtension,
-                                                        createPropositionItem(),
-                                                        new HashMap<>(),
-                                                        null);
-                    } catch (Exception exception) {
-                        fail(exception.getMessage());
-                    }
-
-                    // test
-                    internalMessage.recordEventHistory("mock track", null);
-
-                    // verify no tracking event
-                    verify(mockExtensionApi, times(0)).dispatch(any());
-                });
-    }
+    // TODO: - event history no longer uses Messaging extension's API - it uses MobileCore.dispatch
+//    @Test
+//    public void test_recordEventHistory_withValidParameters_recordsEventHistory() {
+//        // setup
+//        runUsingMockedServiceProvider(
+//                () -> {
+//                    ArgumentCaptor<Event> recordEventCapture = ArgumentCaptor.forClass(Event.class);
+//                    try {
+//                        internalMessage =
+//                                (PresentableMessageMapper.InternalMessage)
+//                                        PresentableMessageMapper.getInstance()
+//                                                .createMessage(
+//                                                        mockMessagingExtension,
+//                                                        createPropositionItem(),
+//                                                        new HashMap<>(),
+//                                                        mockPropositionInfo);
+//                    } catch (Exception exception) {
+//                        fail(exception.getMessage());
+//                    }
+//
+//                    // test
+//                    internalMessage.recordEventHistory(
+//                            "mock track", MessagingEdgeEventType.INTERACT);
+//
+//                    // verify tracking event
+//                    verify(mockExtensionApi, times(1)).dispatch(recordEventCapture.capture());
+//                    Event recordEvent = recordEventCapture.getValue();
+//                    assertEquals(
+//                            MessagingTestConstants.EventName.EVENT_HISTORY_WRITE,
+//                            recordEvent.getName());
+//                    assertEquals(MessagingTestConstants.EventType.MESSAGING, recordEvent.getType());
+//                    assertEquals(
+//                            MessagingTestConstants.EventSource.EVENT_HISTORY_WRITE,
+//                            recordEvent.getSource());
+//                    Map<String, Object> eventData = recordEvent.getEventData();
+//                    Map<String, String> inAppHistoryData =
+//                            (Map<String, String>)
+//                                    eventData.get(MessagingTestConstants.EventDataKeys.IAM_HISTORY);
+//                    assertNotNull(inAppHistoryData);
+//                    assertEquals(
+//                            MessagingEdgeEventType.INTERACT.getPropositionEventType(),
+//                            inAppHistoryData.get(MessagingTestConstants.EventMask.Keys.EVENT_TYPE));
+//                    assertEquals(
+//                            mockPropositionInfo.activityId,
+//                            inAppHistoryData.get(MessagingTestConstants.EventMask.Keys.MESSAGE_ID));
+//                    assertEquals(
+//                            "mock track",
+//                            inAppHistoryData.get(
+//                                    MessagingTestConstants.EventMask.Keys.TRACKING_ACTION));
+//                    final String[] mask = {
+//                        MessagingTestConstants.EventMask.Mask.EVENT_TYPE,
+//                        MessagingTestConstants.EventMask.Mask.MESSAGE_ID,
+//                        MessagingTestConstants.EventMask.Mask.TRACKING_ACTION
+//                    };
+//                    assertEquals(mask, recordEvent.getMask());
+//                });
+//    }
+//
+//    // TODO: - event history no longer uses Messaging extension's API - it uses MobileCore.dispatch
+//    @Test
+//    public void test_recordEventHistory_MissingMessagingEdgeEventType() {
+//        // setup
+//        runUsingMockedServiceProvider(
+//                () -> {
+//                    try {
+//                        internalMessage =
+//                                (PresentableMessageMapper.InternalMessage)
+//                                        PresentableMessageMapper.getInstance()
+//                                                .createMessage(
+//                                                        mockMessagingExtension,
+//                                                        createPropositionItem(),
+//                                                        new HashMap<>(),
+//                                                        null);
+//                    } catch (Exception exception) {
+//                        fail(exception.getMessage());
+//                    }
+//
+//                    // test
+//                    internalMessage.recordEventHistory("mock track", null);
+//
+//                    // verify no tracking event
+//                    verify(mockExtensionApi, times(0)).dispatch(any());
+//                });
+//    }
 
     @Test
     public void test_recordEventHistory_MissingPropositionInfo() {

--- a/code/messaging/src/test/java/com/adobe/marketing/mobile/messaging/PresentableMessageMapperTests.java
+++ b/code/messaging/src/test/java/com/adobe/marketing/mobile/messaging/PresentableMessageMapperTests.java
@@ -13,7 +13,6 @@ package com.adobe.marketing.mobile.messaging;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -24,7 +23,6 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import com.adobe.marketing.mobile.Event;
 import com.adobe.marketing.mobile.ExtensionApi;
 import com.adobe.marketing.mobile.Message;
 import com.adobe.marketing.mobile.MessagingEdgeEventType;
@@ -772,89 +770,95 @@ public class PresentableMessageMapperTests {
     // ========================================================================================
 
     // TODO: - event history no longer uses Messaging extension's API - it uses MobileCore.dispatch
-//    @Test
-//    public void test_recordEventHistory_withValidParameters_recordsEventHistory() {
-//        // setup
-//        runUsingMockedServiceProvider(
-//                () -> {
-//                    ArgumentCaptor<Event> recordEventCapture = ArgumentCaptor.forClass(Event.class);
-//                    try {
-//                        internalMessage =
-//                                (PresentableMessageMapper.InternalMessage)
-//                                        PresentableMessageMapper.getInstance()
-//                                                .createMessage(
-//                                                        mockMessagingExtension,
-//                                                        createPropositionItem(),
-//                                                        new HashMap<>(),
-//                                                        mockPropositionInfo);
-//                    } catch (Exception exception) {
-//                        fail(exception.getMessage());
-//                    }
-//
-//                    // test
-//                    internalMessage.recordEventHistory(
-//                            "mock track", MessagingEdgeEventType.INTERACT);
-//
-//                    // verify tracking event
-//                    verify(mockExtensionApi, times(1)).dispatch(recordEventCapture.capture());
-//                    Event recordEvent = recordEventCapture.getValue();
-//                    assertEquals(
-//                            MessagingTestConstants.EventName.EVENT_HISTORY_WRITE,
-//                            recordEvent.getName());
-//                    assertEquals(MessagingTestConstants.EventType.MESSAGING, recordEvent.getType());
-//                    assertEquals(
-//                            MessagingTestConstants.EventSource.EVENT_HISTORY_WRITE,
-//                            recordEvent.getSource());
-//                    Map<String, Object> eventData = recordEvent.getEventData();
-//                    Map<String, String> inAppHistoryData =
-//                            (Map<String, String>)
-//                                    eventData.get(MessagingTestConstants.EventDataKeys.IAM_HISTORY);
-//                    assertNotNull(inAppHistoryData);
-//                    assertEquals(
-//                            MessagingEdgeEventType.INTERACT.getPropositionEventType(),
-//                            inAppHistoryData.get(MessagingTestConstants.EventMask.Keys.EVENT_TYPE));
-//                    assertEquals(
-//                            mockPropositionInfo.activityId,
-//                            inAppHistoryData.get(MessagingTestConstants.EventMask.Keys.MESSAGE_ID));
-//                    assertEquals(
-//                            "mock track",
-//                            inAppHistoryData.get(
-//                                    MessagingTestConstants.EventMask.Keys.TRACKING_ACTION));
-//                    final String[] mask = {
-//                        MessagingTestConstants.EventMask.Mask.EVENT_TYPE,
-//                        MessagingTestConstants.EventMask.Mask.MESSAGE_ID,
-//                        MessagingTestConstants.EventMask.Mask.TRACKING_ACTION
-//                    };
-//                    assertEquals(mask, recordEvent.getMask());
-//                });
-//    }
-//
-//    // TODO: - event history no longer uses Messaging extension's API - it uses MobileCore.dispatch
-//    @Test
-//    public void test_recordEventHistory_MissingMessagingEdgeEventType() {
-//        // setup
-//        runUsingMockedServiceProvider(
-//                () -> {
-//                    try {
-//                        internalMessage =
-//                                (PresentableMessageMapper.InternalMessage)
-//                                        PresentableMessageMapper.getInstance()
-//                                                .createMessage(
-//                                                        mockMessagingExtension,
-//                                                        createPropositionItem(),
-//                                                        new HashMap<>(),
-//                                                        null);
-//                    } catch (Exception exception) {
-//                        fail(exception.getMessage());
-//                    }
-//
-//                    // test
-//                    internalMessage.recordEventHistory("mock track", null);
-//
-//                    // verify no tracking event
-//                    verify(mockExtensionApi, times(0)).dispatch(any());
-//                });
-//    }
+    //    @Test
+    //    public void test_recordEventHistory_withValidParameters_recordsEventHistory() {
+    //        // setup
+    //        runUsingMockedServiceProvider(
+    //                () -> {
+    //                    ArgumentCaptor<Event> recordEventCapture =
+    // ArgumentCaptor.forClass(Event.class);
+    //                    try {
+    //                        internalMessage =
+    //                                (PresentableMessageMapper.InternalMessage)
+    //                                        PresentableMessageMapper.getInstance()
+    //                                                .createMessage(
+    //                                                        mockMessagingExtension,
+    //                                                        createPropositionItem(),
+    //                                                        new HashMap<>(),
+    //                                                        mockPropositionInfo);
+    //                    } catch (Exception exception) {
+    //                        fail(exception.getMessage());
+    //                    }
+    //
+    //                    // test
+    //                    internalMessage.recordEventHistory(
+    //                            "mock track", MessagingEdgeEventType.INTERACT);
+    //
+    //                    // verify tracking event
+    //                    verify(mockExtensionApi, times(1)).dispatch(recordEventCapture.capture());
+    //                    Event recordEvent = recordEventCapture.getValue();
+    //                    assertEquals(
+    //                            MessagingTestConstants.EventName.EVENT_HISTORY_WRITE,
+    //                            recordEvent.getName());
+    //                    assertEquals(MessagingTestConstants.EventType.MESSAGING,
+    // recordEvent.getType());
+    //                    assertEquals(
+    //                            MessagingTestConstants.EventSource.EVENT_HISTORY_WRITE,
+    //                            recordEvent.getSource());
+    //                    Map<String, Object> eventData = recordEvent.getEventData();
+    //                    Map<String, String> inAppHistoryData =
+    //                            (Map<String, String>)
+    //
+    // eventData.get(MessagingTestConstants.EventDataKeys.IAM_HISTORY);
+    //                    assertNotNull(inAppHistoryData);
+    //                    assertEquals(
+    //                            MessagingEdgeEventType.INTERACT.getPropositionEventType(),
+    //
+    // inAppHistoryData.get(MessagingTestConstants.EventMask.Keys.EVENT_TYPE));
+    //                    assertEquals(
+    //                            mockPropositionInfo.activityId,
+    //
+    // inAppHistoryData.get(MessagingTestConstants.EventMask.Keys.MESSAGE_ID));
+    //                    assertEquals(
+    //                            "mock track",
+    //                            inAppHistoryData.get(
+    //                                    MessagingTestConstants.EventMask.Keys.TRACKING_ACTION));
+    //                    final String[] mask = {
+    //                        MessagingTestConstants.EventMask.Mask.EVENT_TYPE,
+    //                        MessagingTestConstants.EventMask.Mask.MESSAGE_ID,
+    //                        MessagingTestConstants.EventMask.Mask.TRACKING_ACTION
+    //                    };
+    //                    assertEquals(mask, recordEvent.getMask());
+    //                });
+    //    }
+    //
+    //    // TODO: - event history no longer uses Messaging extension's API - it uses
+    // MobileCore.dispatch
+    //    @Test
+    //    public void test_recordEventHistory_MissingMessagingEdgeEventType() {
+    //        // setup
+    //        runUsingMockedServiceProvider(
+    //                () -> {
+    //                    try {
+    //                        internalMessage =
+    //                                (PresentableMessageMapper.InternalMessage)
+    //                                        PresentableMessageMapper.getInstance()
+    //                                                .createMessage(
+    //                                                        mockMessagingExtension,
+    //                                                        createPropositionItem(),
+    //                                                        new HashMap<>(),
+    //                                                        null);
+    //                    } catch (Exception exception) {
+    //                        fail(exception.getMessage());
+    //                    }
+    //
+    //                    // test
+    //                    internalMessage.recordEventHistory("mock track", null);
+    //
+    //                    // verify no tracking event
+    //                    verify(mockExtensionApi, times(0)).dispatch(any());
+    //                });
+    //    }
 
     @Test
     public void test_recordEventHistory_MissingPropositionInfo() {

--- a/code/messaging/src/test/java/com/adobe/marketing/mobile/messaging/PropositionItemTests.java
+++ b/code/messaging/src/test/java/com/adobe/marketing/mobile/messaging/PropositionItemTests.java
@@ -170,7 +170,8 @@ public class PropositionItemTests {
             spyPropositionItem.track(MessagingEdgeEventType.DISPLAY);
 
             // verify
-            verify(spyPropositionItem).generateInteractionXdm(MessagingEdgeEventType.DISPLAY);
+            verify(spyPropositionItem)
+                    .generateInteractionXdm(null, MessagingEdgeEventType.DISPLAY, null);
             assertEquals(1, propositionInteractionMockedConstruction.constructed().size());
             ArgumentCaptor<Event> trackingEventCaptor = ArgumentCaptor.forClass(Event.class);
             mobileCoreMockedStatic.verify(
@@ -229,7 +230,8 @@ public class PropositionItemTests {
             spyPropositionItem.track(MessagingEdgeEventType.DISPLAY);
 
             // verify
-            verify(spyPropositionItem).generateInteractionXdm(MessagingEdgeEventType.DISPLAY);
+            verify(spyPropositionItem)
+                    .generateInteractionXdm(null, MessagingEdgeEventType.DISPLAY, null);
             assertEquals(0, propositionInteractionMockedConstruction.constructed().size());
             mobileCoreMockedStatic.verifyNoInteractions();
         }

--- a/code/messaging/src/test/java/com/adobe/marketing/mobile/messaging/PropositionItemTests.java
+++ b/code/messaging/src/test/java/com/adobe/marketing/mobile/messaging/PropositionItemTests.java
@@ -776,7 +776,7 @@ public class PropositionItemTests {
 
         // verify
         assertNotNull(propositionItem);
-        FeedItemSchemaData schemaData = propositionItem.getFeedItemSchemaData();
+        ContentCardSchemaData schemaData = propositionItem.getContentCardSchemaData();
         assertNotNull(schemaData);
         Map<String, Object> inAppPropositionItemData =
                 (Map<String, Object>) ruleConsequences.get(0).getDetail().get("data");

--- a/code/messaging/src/test/java/com/adobe/marketing/mobile/messaging/PropositionTests.java
+++ b/code/messaging/src/test/java/com/adobe/marketing/mobile/messaging/PropositionTests.java
@@ -282,7 +282,7 @@ public class PropositionTests {
                                         + "                        \"detail\": {\n"
                                         + "                            \"id\": \"uniqueId\",\n"
                                         + "                            \"schema\":"
-                                        + " \"https://ns.adobe.com/personalization/message/feed-item\",\n"
+                                        + " \"https://ns.adobe.com/personalization/message/content-card\",\n"
                                         + "                            \"data\": {\n"
                                         + "                                \"expiryDate\":"
                                         + " 1717688797,\n"
@@ -326,13 +326,40 @@ public class PropositionTests {
         // test
         Proposition proposition1 =
                 new Proposition(
-                        "uniqueId", "mobileapp://mockScope", scopeDetails, propositionItems);
+                        "uniqueId", "mobileapp://mockScope", new HashMap<String, Object>() {
+                    {
+                        put("key", "value");
+                        put("activity", new HashMap<String, Object>() {
+                            {
+                                put("id", "mockActivityId");
+                            }
+                        });
+                    }
+                }, propositionItems);
         Proposition proposition2 =
                 new Proposition(
-                        "uniqueId", "mobileapp://mockScope", scopeDetails, propositionItems);
+                        "uniqueId", "mobileapp://mockScope", new HashMap<String, Object>() {
+                    {
+                        put("key", "value");
+                        put("activity", new HashMap<String, Object>() {
+                            {
+                                put("id", "mockActivityId");
+                            }
+                        });
+                    }
+                }, propositionItems);
         Proposition proposition3 =
                 new Proposition(
-                        "uniqueId2", "mobileapp://mockScope2", scopeDetails, propositionItems2);
+                        "uniqueId2", "mobileapp://mockScope2", new HashMap<String, Object>() {
+                    {
+                        put("key", "value");
+                        put("activity", new HashMap<String, Object>() {
+                            {
+                                put("id", "mockActivityId2");
+                            }
+                        });
+                    }
+                }, propositionItems2);
 
         Object notAMessagingProposition = new Object();
         // verify

--- a/code/messaging/src/test/java/com/adobe/marketing/mobile/messaging/PropositionTests.java
+++ b/code/messaging/src/test/java/com/adobe/marketing/mobile/messaging/PropositionTests.java
@@ -326,40 +326,55 @@ public class PropositionTests {
         // test
         Proposition proposition1 =
                 new Proposition(
-                        "uniqueId", "mobileapp://mockScope", new HashMap<String, Object>() {
-                    {
-                        put("key", "value");
-                        put("activity", new HashMap<String, Object>() {
+                        "uniqueId",
+                        "mobileapp://mockScope",
+                        new HashMap<String, Object>() {
                             {
-                                put("id", "mockActivityId");
+                                put("key", "value");
+                                put(
+                                        "activity",
+                                        new HashMap<String, Object>() {
+                                            {
+                                                put("id", "mockActivityId");
+                                            }
+                                        });
                             }
-                        });
-                    }
-                }, propositionItems);
+                        },
+                        propositionItems);
         Proposition proposition2 =
                 new Proposition(
-                        "uniqueId", "mobileapp://mockScope", new HashMap<String, Object>() {
-                    {
-                        put("key", "value");
-                        put("activity", new HashMap<String, Object>() {
+                        "uniqueId",
+                        "mobileapp://mockScope",
+                        new HashMap<String, Object>() {
                             {
-                                put("id", "mockActivityId");
+                                put("key", "value");
+                                put(
+                                        "activity",
+                                        new HashMap<String, Object>() {
+                                            {
+                                                put("id", "mockActivityId");
+                                            }
+                                        });
                             }
-                        });
-                    }
-                }, propositionItems);
+                        },
+                        propositionItems);
         Proposition proposition3 =
                 new Proposition(
-                        "uniqueId2", "mobileapp://mockScope2", new HashMap<String, Object>() {
-                    {
-                        put("key", "value");
-                        put("activity", new HashMap<String, Object>() {
+                        "uniqueId2",
+                        "mobileapp://mockScope2",
+                        new HashMap<String, Object>() {
                             {
-                                put("id", "mockActivityId2");
+                                put("key", "value");
+                                put(
+                                        "activity",
+                                        new HashMap<String, Object>() {
+                                            {
+                                                put("id", "mockActivityId2");
+                                            }
+                                        });
                             }
-                        });
-                    }
-                }, propositionItems2);
+                        },
+                        propositionItems2);
 
         Object notAMessagingProposition = new Object();
         // verify

--- a/code/messaging/src/test/resources/feedProposition.json
+++ b/code/messaging/src/test/resources/feedProposition.json
@@ -53,7 +53,7 @@
                                 "type": "schema",
                                 "detail": {
                                     "id": "183639c4-cb37-458e-a8ef-4e130d767ebf",
-                                    "schema": "https://ns.adobe.com/personalization/message/feed-item",
+                                    "schema": "https://ns.adobe.com/personalization/message/content-card",
                                     "data": {
                                         "expiryDate": 1723163897,
                                         "meta": {

--- a/code/messaging/src/test/resources/feedPropositionContent.json
+++ b/code/messaging/src/test/resources/feedPropositionContent.json
@@ -36,7 +36,7 @@
                     "type": "schema",
                     "detail": {
                         "id": "183639c4-cb37-458e-a8ef-4e130d767ebf",
-                        "schema": "https://ns.adobe.com/personalization/message/feed-item",
+                        "schema": "https://ns.adobe.com/personalization/message/content-card",
                         "data": {
                             "expiryDate": 1723163897,
                             "meta": {

--- a/code/messaging/src/test/resources/feedPropositionContentFeedItemConsequences.json
+++ b/code/messaging/src/test/resources/feedPropositionContentFeedItemConsequences.json
@@ -61,7 +61,7 @@
                     "type": "schema",
                     "detail": {
                         "id": "183639c4-cb37-458e-a8ef-4e130d767ebf",
-                        "schema": "https://ns.adobe.com/personalization/message/feed-item",
+                        "schema": "https://ns.adobe.com/personalization/message/content-card",
                         "data": {
                             "expiryDate": 1723163897,
                             "meta": {
@@ -86,7 +86,7 @@
                     "type": "schema",
                     "detail": {
                         "id": "e24c7416-31c2-4734-8c87-ffb8269d28bf",
-                        "schema": "https://ns.adobe.com/personalization/message/feed-item",
+                        "schema": "https://ns.adobe.com/personalization/message/content-card",
                         "data": {
                             "publishedDate": 1701538942,
                             "expiryDate": 1712190456,

--- a/code/messaging/src/test/resources/feedPropositionContentMissingData.json
+++ b/code/messaging/src/test/resources/feedPropositionContentMissingData.json
@@ -36,7 +36,7 @@
                     "type": "schema",
                     "detail": {
                         "id": "183639c4-cb37-458e-a8ef-4e130d767ebf",
-                        "schema": "https://ns.adobe.com/personalization/message/feed-item"
+                        "schema": "https://ns.adobe.com/personalization/message/content-card"
                     }
                 }
             ]

--- a/code/messaging/src/test/resources/feedPropositionContentMissingSurfaceMetadata.json
+++ b/code/messaging/src/test/resources/feedPropositionContentMissingSurfaceMetadata.json
@@ -36,7 +36,7 @@
                     "type": "schema",
                     "detail": {
                         "id": "183639c4-cb37-458e-a8ef-4e130d767ebf",
-                        "schema": "https://ns.adobe.com/personalization/message/feed-item",
+                        "schema": "https://ns.adobe.com/personalization/message/content-card",
                         "data": {
                             "expiryDate": 1723163897,
                             "meta": {

--- a/code/messaging/src/test/resources/feedPropositionItem.json
+++ b/code/messaging/src/test/resources/feedPropositionItem.json
@@ -39,7 +39,7 @@
                         "type": "schema",
                         "detail": {
                             "id": "uniqueId",
-                            "schema": "https://ns.adobe.com/personalization/message/feed-item",
+                            "schema": "https://ns.adobe.com/personalization/message/content-card",
                             "data": {
                                 "expiryDate": 1717688797,
                                 "meta": {

--- a/code/messaging/src/test/resources/feedPropositionItem2.json
+++ b/code/messaging/src/test/resources/feedPropositionItem2.json
@@ -39,7 +39,7 @@
             "type": "schema",
             "detail": {
               "id": "uniqueDetailId",
-              "schema": "https://ns.adobe.com/personalization/message/feed-item",
+              "schema": "https://ns.adobe.com/personalization/message/content-card",
               "data": {
                 "expiryDate": 1717688797,
                 "meta": {

--- a/code/messagingtestutils/src/main/java/com/adobe/marketing/mobile/messaging/MessagingTestUtils.java
+++ b/code/messagingtestutils/src/main/java/com/adobe/marketing/mobile/messaging/MessagingTestUtils.java
@@ -555,7 +555,7 @@ public class MessagingTestUtils {
             try {
                 JSONObject feedDetails = new JSONObject("{\n" +
                         "\"id\": \"183639c4-cb37-458e-a8ef-4e130d767ebf\",\n" +
-                        "\"schema\": \"https://ns.adobe.com/personalization/message/feed-item\",\n" +
+                        "\"schema\": \"https://ns.adobe.com/personalization/message/content-card\",\n" +
                         "\"data\": {\n" +
                         "\"expiryDate\": 1723163897,\n" +
                         "\"meta\": {\n" +

--- a/code/testapp/src/main/java/com/adobe/marketing/mobile/messagingsample/CodeBasedExperienceActivity.kt
+++ b/code/testapp/src/main/java/com/adobe/marketing/mobile/messagingsample/CodeBasedExperienceActivity.kt
@@ -31,6 +31,7 @@ class CodeBasedExperienceActivity : AppCompatActivity() {
         // create list of code based surface paths
         var propositions = mutableListOf<Proposition>()
         val surfaces = mutableListOf<Surface>()
+        surfaces.add(Surface("cbe/json"))
         surfaces.add(Surface("cbe-path1"))
         surfaces.add(Surface("cbe-path2"))
 

--- a/code/testapp/src/main/java/com/adobe/marketing/mobile/messagingsample/FeedCardAdapter.kt
+++ b/code/testapp/src/main/java/com/adobe/marketing/mobile/messagingsample/FeedCardAdapter.kt
@@ -38,7 +38,9 @@ class FeedCardAdapter(propositions: MutableList<Proposition>) :
             val inboundContent = item.contentCardSchemaData
             val contentCard = inboundContent.contentCard
             if (contentCard != null) {
-                holder.feedItemImage.setImageBitmap(ImageDownloader.getImage(contentCard.imageUrl))
+                if (!contentCard.imageUrl.isNullOrEmpty()) {
+                    holder.feedItemImage.setImageBitmap(ImageDownloader.getImage(contentCard.imageUrl!!))
+                }
                 holder.feedItemImage.refreshDrawableState()
                 holder.feedItemTitle.text = contentCard.title
                 holder.feedBody.text = contentCard.body

--- a/code/testapp/src/main/java/com/adobe/marketing/mobile/messagingsample/FeedCardAdapter.kt
+++ b/code/testapp/src/main/java/com/adobe/marketing/mobile/messagingsample/FeedCardAdapter.kt
@@ -35,13 +35,13 @@ class FeedCardAdapter(propositions: MutableList<Proposition>) :
     override fun onBindViewHolder(holder: ViewHolder, position: Int) {
         val proposition = propositions[position]
         for (item in proposition.items) {
-            val inboundContent = item.feedItemSchemaData
-            val feedItem = inboundContent.feedItem
-            if (feedItem != null) {
-                holder.feedItemImage.setImageBitmap(ImageDownloader.getImage(feedItem.imageUrl))
+            val inboundContent = item.contentCardSchemaData
+            val contentCard = inboundContent.contentCard
+            if (contentCard != null) {
+                holder.feedItemImage.setImageBitmap(ImageDownloader.getImage(contentCard.imageUrl))
                 holder.feedItemImage.refreshDrawableState()
-                holder.feedItemTitle.text = feedItem.title
-                holder.feedBody.text = feedItem.body
+                holder.feedItemTitle.text = contentCard.title
+                holder.feedBody.text = contentCard.body
                 item.track(MessagingEdgeEventType.DISPLAY)
                 holder.itemView.setOnClickListener {
                     item.track(MessagingEdgeEventType.INTERACT)

--- a/code/testapp/src/main/java/com/adobe/marketing/mobile/messagingsample/MessagingApplication.kt
+++ b/code/testapp/src/main/java/com/adobe/marketing/mobile/messagingsample/MessagingApplication.kt
@@ -24,6 +24,8 @@ import com.google.firebase.messaging.FirebaseMessaging
 class MessagingApplication : Application() {
     private val ENVIRONMENT_FILE_ID = "3149c49c3910/aade5cbb52e4/launch-365a8d4bb1e7-development"
     private val ASSURANCE_SESSION_ID = "messagingsampleapp://?adb_validation_sessionid=f3fbb3fb-45a8-49a6-ab1f-e729521a82d8"
+    private val STAGING_APP_ID = "staging/1b50a869c4a2/bcd1a623883f/launch-e44d085fc760-development"
+    private val STAGING = true
 
     override fun onCreate() {
         super.onCreate()
@@ -31,12 +33,18 @@ class MessagingApplication : Application() {
         MobileCore.setApplication(this)
         MobileCore.setLogLevel(LoggingMode.VERBOSE)
         // Assurance.startSession(ASSURANCE_SESSION_ID)
-        val extensions = listOf(Messaging.EXTENSION, Identity.EXTENSION, Lifecycle.EXTENSION, Edge.EXTENSION, Assurance.EXTENSION)
+        val extensions = listOf(Messaging.EXTENSION, Identity.EXTENSION, Lifecycle.EXTENSION, Edge.EXTENSION)//, Assurance.EXTENSION)
         MobileCore.registerExtensions(extensions) {
             // Necessary property id which has the edge configuration id needed by aep sdk
-            MobileCore.configureWithAppID(ENVIRONMENT_FILE_ID)
+            if (STAGING) {
+                MobileCore.configureWithAppID(STAGING_APP_ID)
+                MobileCore.updateConfiguration(
+                    hashMapOf("edge.environment" to "int") as Map<String, Any>)
+            } else {
+                MobileCore.configureWithAppID(ENVIRONMENT_FILE_ID)
+            }
             MobileCore.lifecycleStart(null)
-            Assurance.startSession(ASSURANCE_SESSION_ID)
+//            Assurance.startSession(ASSURANCE_SESSION_ID)
         }
 
         FirebaseMessaging.getInstance().token.addOnCompleteListener { task ->

--- a/code/testapp/src/main/java/com/adobe/marketing/mobile/messagingsample/ScrollingFeedActivity.kt
+++ b/code/testapp/src/main/java/com/adobe/marketing/mobile/messagingsample/ScrollingFeedActivity.kt
@@ -32,7 +32,13 @@ class ScrollingFeedActivity : AppCompatActivity() {
         // retrieve any cached feed propositions
         var propositions = mutableListOf<Proposition>()
         val surfaces = mutableListOf<Surface>()
-        val surface = Surface("feeds/apifeed")
+
+        // staging environment - CJM Stage, AJO Web (VA7)
+        // surface for content card -
+        // mobileapp://com.adobe.marketing.mobile.messagingsample/card/ms
+        val surface = Surface("card/ms")
+
+//        val surface = Surface("feeds/apifeed")
         surfaces.add(surface)
         Messaging.updatePropositionsForSurfaces(surfaces)
         Messaging.getPropositionsForSurfaces(surfaces) {


### PR DESCRIPTION
- rebranding for content cards (formerly feed items)
- content cards rules engine is now global (listens for all events)
- simplified proposition tracking for content cards
- automatically send proposition trigger event when a user qualifies for a content card (used in conjunction with the content card's rule to keep a user qualified in future sessions)

ios pr equivalent: https://github.com/adobe/aepsdk-messaging-ios/pull/270