### PR TITLE
Replace inMemoryPropositions instead of appending for every updatePropositionsForSurface call

### DIFF
--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/ContentCard.java
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/ContentCard.java
@@ -47,7 +47,7 @@ public class ContentCard {
     private ContentCard() {}
 
     /** {@code FeedItem} Builder. */
-    public static class Builder {
+    static class Builder {
         private boolean didBuild;
         private final ContentCard contentCard;
 
@@ -60,7 +60,7 @@ public class ContentCard {
          * @param body required {@code String} plain-text body representing the content for the
          *     content card
          */
-        public Builder(@NonNull final String title, @NonNull final String body) {
+        Builder(@NonNull final String title, @NonNull final String body) {
             contentCard = new ContentCard();
             contentCard.title = StringUtils.isNullOrEmpty(title) ? "" : title;
             contentCard.body = StringUtils.isNullOrEmpty(body) ? "" : body;
@@ -78,7 +78,7 @@ public class ContentCard {
          * @throws UnsupportedOperationException if this method is invoked after {@link
          *     Builder#build()}.
          */
-        public Builder setImageUrl(final String imageUrl) {
+        Builder setImageUrl(final String imageUrl) {
             throwIfAlreadyBuilt();
 
             contentCard.imageUrl = imageUrl;
@@ -93,7 +93,7 @@ public class ContentCard {
          * @throws UnsupportedOperationException if this method is invoked after {@link
          *     Builder#build()}.
          */
-        public Builder setActionUrl(final String actionUrl) {
+        Builder setActionUrl(final String actionUrl) {
             throwIfAlreadyBuilt();
 
             contentCard.actionUrl = actionUrl;
@@ -108,7 +108,7 @@ public class ContentCard {
          * @throws UnsupportedOperationException if this method is invoked after {@link
          *     Builder#build()}.
          */
-        public Builder setActionTitle(final String actionTitle) {
+        Builder setActionTitle(final String actionTitle) {
             throwIfAlreadyBuilt();
 
             contentCard.actionTitle = actionTitle;
@@ -124,7 +124,7 @@ public class ContentCard {
          * @throws UnsupportedOperationException if this method is invoked after {@link
          *     Builder#build()}.
          */
-        public Builder setParent(final ContentCardSchemaData parent) {
+        Builder setParent(final ContentCardSchemaData parent) {
             throwIfAlreadyBuilt();
 
             contentCard.parent = new SoftReference<>(parent);
@@ -136,7 +136,7 @@ public class ContentCard {
          *
          * @return {@link ContentCard} object or null.
          */
-        @Nullable public ContentCard build() {
+        @Nullable ContentCard build() {
             // title and body are required
             if (StringUtils.isNullOrEmpty(contentCard.title)
                     || StringUtils.isNullOrEmpty(contentCard.body)) {

--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/EdgePersonalizationResponseHandler.java
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/EdgePersonalizationResponseHandler.java
@@ -809,13 +809,9 @@ class EdgePersonalizationResponseHandler {
     private void updatePropositions(
             final Map<Surface, List<Proposition>> newPropositions,
             final List<Surface> surfacesToRemove) {
-        // add new surfaces or update replace existing surfaces
+        // add new surfaces or replace existing surfaces
         Map<Surface, List<Proposition>> tempPropositionsMap = new HashMap<>(inMemoryPropositions);
-        for (final Map.Entry<Surface, List<Proposition>> entry : newPropositions.entrySet()) {
-            tempPropositionsMap =
-                    MessagingUtils.updatePropositionMapForSurface(
-                            entry.getKey(), entry.getValue(), tempPropositionsMap);
-        }
+        tempPropositionsMap.putAll(newPropositions);
 
         // remove any surfaces if necessary
         for (final Surface surface : surfacesToRemove) {

--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/PropositionItem.java
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/PropositionItem.java
@@ -12,6 +12,7 @@
 package com.adobe.marketing.mobile.messaging;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import com.adobe.marketing.mobile.Event;
 import com.adobe.marketing.mobile.MessagingEdgeEventType;
 import com.adobe.marketing.mobile.MobileCore;
@@ -210,7 +211,7 @@ public class PropositionItem implements Serializable {
      *
      * @return {@link Map<String, Object>} object containing the {@link PropositionItem}'s content.
      */
-    public Map<String, Object> getJsonContentMap() {
+    @Nullable public Map<String, Object> getJsonContentMap() {
         if (!schema.equals(SchemaType.JSON_CONTENT)) {
             return null;
         }
@@ -226,7 +227,7 @@ public class PropositionItem implements Serializable {
      * @return {@link List<Map<String, Object>>} object containing the {@link PropositionItem}'s
      *     content.
      */
-    public List<Map<String, Object>> getJsonContentArrayList() {
+    @Nullable public List<Map<String, Object>> getJsonContentArrayList() {
         if (!schema.equals(SchemaType.JSON_CONTENT)) {
             return null;
         }
@@ -240,7 +241,7 @@ public class PropositionItem implements Serializable {
      *
      * @return {@link String} containing the {@link PropositionItem}'s content.
      */
-    public String getHtmlContent() {
+    @Nullable public String getHtmlContent() {
         if (!schema.equals(SchemaType.HTML_CONTENT)) {
             return null;
         }
@@ -254,7 +255,7 @@ public class PropositionItem implements Serializable {
      *
      * @return {@link InAppSchemaData} object containing the {@link PropositionItem}'s content.
      */
-    public InAppSchemaData getInAppSchemaData() {
+    @Nullable public InAppSchemaData getInAppSchemaData() {
         if (!schema.equals(SchemaType.INAPP)) {
             return null;
         }
@@ -267,7 +268,7 @@ public class PropositionItem implements Serializable {
      * @return {@link ContentCardSchemaData} object containing the {@link PropositionItem}'s
      *     content.
      */
-    public ContentCardSchemaData getContentCardSchemaData() {
+    @Nullable public ContentCardSchemaData getContentCardSchemaData() {
         if (!schema.equals(SchemaType.CONTENT_CARD)) {
             return null;
         }
@@ -288,7 +289,7 @@ public class PropositionItem implements Serializable {
      * @deprecated Use {@link #getContentCardSchemaData()} instead.
      */
     @Deprecated
-    public FeedItemSchemaData getFeedItemSchemaData() {
+    @Nullable public FeedItemSchemaData getFeedItemSchemaData() {
         if (!schema.equals(SchemaType.FEED)) {
             return null;
         }

--- a/code/messaging/src/phone/java/com/adobe/marketing/mobile/messaging/MessagingUtils.java
+++ b/code/messaging/src/phone/java/com/adobe/marketing/mobile/messaging/MessagingUtils.java
@@ -87,7 +87,10 @@ public class MessagingUtils {
                 existingList != null ? existingList : createMutableList(propositionsToAdd);
         if (existingList != null) {
             for (final Proposition proposition : propositionsToAdd) {
-                if (!updatedList.contains(proposition)) {
+                if (updatedList.contains(proposition)) {
+                    int index = updatedList.indexOf(proposition);
+                    updatedList.set(index, proposition);
+                } else {
                     updatedList.add(proposition);
                 }
             }

--- a/code/testapp/src/main/java/com/adobe/marketing/mobile/messagingsample/CodeBasedCardAdapter.kt
+++ b/code/testapp/src/main/java/com/adobe/marketing/mobile/messagingsample/CodeBasedCardAdapter.kt
@@ -47,20 +47,23 @@ class CodeBasedCardAdapter(propositions: MutableList<Proposition>) :
             // show code based experiences with html content in a webview
             if (mimeType == "text/html") {
                 val contentString = item.htmlContent
-                holder.webView.loadData(
+                contentString?.let {
+                    holder.webView.loadData(
                         contentString,
                         mimeType,
-                        StandardCharsets.UTF_8.toString())
-                item.track(MessagingEdgeEventType.DISPLAY)
-                holder.webView.setOnTouchListener(object: View.OnTouchListener {
-                    override fun onTouch(p0: View?, event: MotionEvent?): Boolean {
-                        if (event?.action == MotionEvent.ACTION_UP) {
-                            item.track(MessagingEdgeEventType.INTERACT)
-                            return true
+                        StandardCharsets.UTF_8.toString()
+                    )
+                    item.track(MessagingEdgeEventType.DISPLAY)
+                    holder.webView.setOnTouchListener(object : View.OnTouchListener {
+                        override fun onTouch(p0: View?, event: MotionEvent?): Boolean {
+                            if (event?.action == MotionEvent.ACTION_UP) {
+                                item.track(MessagingEdgeEventType.INTERACT)
+                                return true
+                            }
+                            return false
                         }
-                        return false
-                    }
-                })
+                    })
+                }
             } else if (mimeType == "application/json") {
                 var contentString = item.jsonContentArrayList
                 if (contentString != null) { // we have a json array

--- a/code/testapp/src/main/java/com/adobe/marketing/mobile/messagingsample/CodeBasedExperienceActivity.kt
+++ b/code/testapp/src/main/java/com/adobe/marketing/mobile/messagingsample/CodeBasedExperienceActivity.kt
@@ -60,8 +60,7 @@ class CodeBasedExperienceActivity : AppCompatActivity() {
     }
 
     private fun isCBEProposition(proposition: Proposition): Boolean {
-        return proposition.items.isNotEmpty() && (
-                proposition.items[0].schema == SchemaType.HTML_CONTENT ||
-                        proposition.items[0].schema == SchemaType.JSON_CONTENT)
+        return proposition.items[0].schema == SchemaType.HTML_CONTENT ||
+                        proposition.items[0].schema == SchemaType.JSON_CONTENT
     }
 }

--- a/code/testapp/src/main/java/com/adobe/marketing/mobile/messagingsample/CodeBasedExperienceActivity.kt
+++ b/code/testapp/src/main/java/com/adobe/marketing/mobile/messagingsample/CodeBasedExperienceActivity.kt
@@ -17,6 +17,7 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.adobe.marketing.mobile.Messaging
 import com.adobe.marketing.mobile.messaging.Proposition
+import com.adobe.marketing.mobile.messaging.SchemaType
 import com.adobe.marketing.mobile.messaging.Surface
 import com.adobe.marketing.mobile.messagingsample.databinding.ActivityCodebasedBinding
 
@@ -32,8 +33,7 @@ class CodeBasedExperienceActivity : AppCompatActivity() {
         var propositions = mutableListOf<Proposition>()
         val surfaces = mutableListOf<Surface>()
         surfaces.add(Surface("cbe/json"))
-        surfaces.add(Surface("cbe-path1"))
-        surfaces.add(Surface("cbe-path2"))
+        surfaces.add(Surface("android-cbe-preview"))
 
         // fetch code based experiences
         Messaging.updatePropositionsForSurfaces(surfaces)
@@ -41,8 +41,11 @@ class CodeBasedExperienceActivity : AppCompatActivity() {
         Messaging.getPropositionsForSurfaces(surfaces) {
             println("getPropositionsForSurfaces callback contained ${it.entries.size} entry/entries")
             for (entry in it.entries) {
-                println("Adding ${entry.value.size} proposition(s) from surface ${entry.key.uri}")
-                propositions.addAll(entry.value)
+                for (proposition in entry.value) {
+                    if(isCBEProposition(proposition)) {
+                        propositions.add(proposition)
+                    }
+                }
             }
 
             // show code based experiences
@@ -54,5 +57,11 @@ class CodeBasedExperienceActivity : AppCompatActivity() {
                 codeBasedRecyclerView.adapter = codeBasedCardAdapter
             }
         }
+    }
+
+    private fun isCBEProposition(proposition: Proposition): Boolean {
+        return proposition.items.isNotEmpty() && (
+                proposition.items[0].schema == SchemaType.HTML_CONTENT ||
+                        proposition.items[0].schema == SchemaType.JSON_CONTENT)
     }
 }

--- a/code/testapp/src/main/java/com/adobe/marketing/mobile/messagingsample/FeedCardAdapter.kt
+++ b/code/testapp/src/main/java/com/adobe/marketing/mobile/messagingsample/FeedCardAdapter.kt
@@ -36,18 +36,21 @@ class FeedCardAdapter(propositions: MutableList<Proposition>) :
         val proposition = propositions[position]
         for (item in proposition.items) {
             val inboundContent = item.contentCardSchemaData
-            val contentCard = inboundContent.contentCard
-            if (contentCard != null) {
-                if (!contentCard.imageUrl.isNullOrEmpty()) {
-                    holder.feedItemImage.setImageBitmap(ImageDownloader.getImage(contentCard.imageUrl!!))
+            val contentCard = inboundContent?.contentCard
+            contentCard?.let {
+                it.imageUrl?.let {
+                    holder.feedItemImage.setImageBitmap(ImageDownloader.getImage(it))
                 }
                 holder.feedItemImage.refreshDrawableState()
-                holder.feedItemTitle.text = contentCard.title
-                holder.feedBody.text = contentCard.body
+                holder.feedItemTitle.text = it.title
+                holder.feedBody.text = it.body
                 item.track(MessagingEdgeEventType.DISPLAY)
                 holder.itemView.setOnClickListener {
                     item.track(MessagingEdgeEventType.INTERACT)
-                    val intent = Intent(ServiceProvider.getInstance().appContextService.applicationContext, SingleFeedActivity::class.java)
+                    val intent = Intent(
+                        ServiceProvider.getInstance().appContextService.applicationContext,
+                        SingleFeedActivity::class.java
+                    )
                     intent.flags = Intent.FLAG_ACTIVITY_NEW_TASK
                     MobileCore.getApplication()?.startActivity(intent.apply {
                         val contentMap = inboundContent.content as HashMap<*, *>

--- a/code/testapp/src/main/java/com/adobe/marketing/mobile/messagingsample/MessagingApplication.kt
+++ b/code/testapp/src/main/java/com/adobe/marketing/mobile/messagingsample/MessagingApplication.kt
@@ -22,8 +22,8 @@ import com.adobe.marketing.mobile.edge.identity.Identity
 import com.google.firebase.messaging.FirebaseMessaging
 
 class MessagingApplication : Application() {
-    private val ENVIRONMENT_FILE_ID = "3149c49c3910/aade5cbb52e4/launch-365a8d4bb1e7-development"
-    private val ASSURANCE_SESSION_ID = "messagingsampleapp://?adb_validation_sessionid=f3fbb3fb-45a8-49a6-ab1f-e729521a82d8"
+    private val ENVIRONMENT_FILE_ID = ""
+    private val ASSURANCE_SESSION_ID = ""
     private val STAGING_APP_ID = "staging/1b50a869c4a2/bcd1a623883f/launch-e44d085fc760-development"
     private val STAGING = true
 
@@ -32,8 +32,7 @@ class MessagingApplication : Application() {
 
         MobileCore.setApplication(this)
         MobileCore.setLogLevel(LoggingMode.VERBOSE)
-        // Assurance.startSession(ASSURANCE_SESSION_ID)
-        val extensions = listOf(Messaging.EXTENSION, Identity.EXTENSION, Lifecycle.EXTENSION, Edge.EXTENSION)//, Assurance.EXTENSION)
+        val extensions = listOf(Messaging.EXTENSION, Identity.EXTENSION, Lifecycle.EXTENSION, Edge.EXTENSION, Assurance.EXTENSION)
         MobileCore.registerExtensions(extensions) {
             // Necessary property id which has the edge configuration id needed by aep sdk
             if (STAGING) {
@@ -44,8 +43,8 @@ class MessagingApplication : Application() {
                 MobileCore.configureWithAppID(ENVIRONMENT_FILE_ID)
             }
             MobileCore.lifecycleStart(null)
-//            Assurance.startSession(ASSURANCE_SESSION_ID)
         }
+        // Assurance.startSession(ASSURANCE_SESSION_ID)
 
         FirebaseMessaging.getInstance().token.addOnCompleteListener { task ->
             // Log and toast

--- a/code/testapp/src/main/java/com/adobe/marketing/mobile/messagingsample/ScrollingFeedActivity.kt
+++ b/code/testapp/src/main/java/com/adobe/marketing/mobile/messagingsample/ScrollingFeedActivity.kt
@@ -37,7 +37,7 @@ class ScrollingFeedActivity : AppCompatActivity() {
         // staging environment - CJM Stage, AJO Web (VA7)
         // surface for content card -
         // mobileapp://com.adobe.marketing.mobile.messagingsample/card/ms
-        val surface = Surface("android-cbe-preview")
+        val surface = Surface("card/ms")
 
 //        val surface = Surface("feeds/apifeed")
         surfaces.add(surface)

--- a/code/testapp/src/main/java/com/adobe/marketing/mobile/messagingsample/ScrollingFeedActivity.kt
+++ b/code/testapp/src/main/java/com/adobe/marketing/mobile/messagingsample/ScrollingFeedActivity.kt
@@ -17,6 +17,7 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.adobe.marketing.mobile.Messaging
 import com.adobe.marketing.mobile.messaging.Proposition
+import com.adobe.marketing.mobile.messaging.SchemaType
 import com.adobe.marketing.mobile.messaging.Surface
 import com.adobe.marketing.mobile.messagingsample.databinding.ActivityScrollingBinding
 
@@ -36,7 +37,7 @@ class ScrollingFeedActivity : AppCompatActivity() {
         // staging environment - CJM Stage, AJO Web (VA7)
         // surface for content card -
         // mobileapp://com.adobe.marketing.mobile.messagingsample/card/ms
-        val surface = Surface("card/ms")
+        val surface = Surface("android-cbe-preview")
 
 //        val surface = Surface("feeds/apifeed")
         surfaces.add(surface)
@@ -44,7 +45,11 @@ class ScrollingFeedActivity : AppCompatActivity() {
         Messaging.getPropositionsForSurfaces(surfaces) {
             println("getPropositionsForSurfaces callback contained ${it.entries.size} entry/entries for surface ${surface.uri}")
             for (entry in it.entries) {
-                propositions = entry.value
+                for (proposition in entry.value) {
+                    if (isContentCard(proposition)) {
+                        propositions.add(proposition)
+                    }
+                }
             }
 
             // show feed items
@@ -56,5 +61,9 @@ class ScrollingFeedActivity : AppCompatActivity() {
                 feedInboxRecyclerView.adapter = feedCardAdapter
             }
         }
+    }
+
+    private fun isContentCard(proposition: Proposition): Boolean {
+        return proposition.items[0].schema == SchemaType.CONTENT_CARD
     }
 }

--- a/code/testapp/src/main/java/com/adobe/marketing/mobile/messagingsample/SingleFeedActivity.kt
+++ b/code/testapp/src/main/java/com/adobe/marketing/mobile/messagingsample/SingleFeedActivity.kt
@@ -24,28 +24,31 @@ class SingleFeedActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_singlefeed)
 
-        val feedActivityItemTitle: TextView
-        val feedActivityItemImage: ImageView
-        val feedActivityBody: TextView
-        val feedActivityButton: Button
-
-        feedActivityItemImage = findViewById(R.id.feedActivityImage)
-        feedActivityItemTitle = findViewById(R.id.feedActivityTitle)
-        feedActivityBody = findViewById(R.id.feedActivityBody)
-        feedActivityButton = findViewById(R.id.feedActivityActionButton)
+        val feedActivityItemImage: ImageView = findViewById(R.id.feedActivityImage)
+        val feedActivityItemTitle: TextView = findViewById(R.id.feedActivityTitle)
+        val feedActivityBody: TextView = findViewById(R.id.feedActivityBody)
+        val feedActivityButton: Button = findViewById(R.id.feedActivityActionButton)
 
         // retrieve feed content from the intent
-        val contentMap = intent.extras?.get("content") as HashMap<String, String>
+        val contentMap = intent.getSerializableExtra("content") as HashMap<String, String?>
 
         // show single feed item
-        feedActivityItemTitle.text = contentMap.get("title")
-        feedActivityItemImage.setImageBitmap(contentMap.get("imageUrl")
+        feedActivityItemTitle.text = contentMap["title"]
+        feedActivityItemImage.setImageBitmap(
+            contentMap["imageUrl"]
             ?.let { ImageDownloader.getImage(it) })
         feedActivityItemImage.refreshDrawableState()
-        feedActivityBody.text = contentMap.get("body")
-        feedActivityButton.text = contentMap.get("actionTitle")
-        feedActivityButton.setOnClickListener {
-            contentMap.get("actionUrl")?.let { it1 -> ServiceProvider.getInstance().uriService.openUri(it1) }
+        feedActivityBody.text = contentMap["body"]
+        val feedbackButtonText = contentMap["actionTitle"]
+        if (feedbackButtonText.isNullOrEmpty()) {
+            feedActivityButton.visibility = Button.GONE
+        }
+        else {
+            feedActivityButton.text = feedbackButtonText
+            feedActivityButton.setOnClickListener {
+                contentMap["actionUrl"]
+                    ?.let { it1 -> ServiceProvider.getInstance().uriService.openUri(it1) }
+            }
         }
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

1. Every time updatePropositionsForSurface is called, logic is now changed to completely replace the propositions in inMemoryPropositions with the ones returned in AEP Response Event for each corresponding surface.
2. Marked public API of `PropositionItem` class with `@Nullable` 
3. Made `Builder` in `ContentCard` package-protected
4. Changed the test app to only load CBE or Feed items based on the screen loaded.

## Related Issue

https://jira.corp.adobe.com/browse/MOB-21212

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

When the content for a CBE campaign was changed server side (either manually or using ExD), the cached client side propositions would append the modified proposition while continuing to retain the old proposition with outdated content. This causes confusion on what the most current CBE content is.

## How Has This Been Tested?

Manual testing

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
