### PR TITLE
Add remaining platform tests for content cards and code based experiences

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,9 +24,9 @@ workflows:
       - build-and-unit-test:
           requires:
             - validate-code
-      # - functional-test:
-      #     requires:
-      #       - validate-code
+      - functional-test:
+          requires:
+            - validate-code
       - build-test-app:
           requires:
             - validate-code

--- a/code/messaging/build.gradle.kts
+++ b/code/messaging/build.gradle.kts
@@ -33,6 +33,11 @@ aepLibrary {
             buildConfigField("java.util.concurrent.atomic.AtomicBoolean", "IS_E2E_TEST", "new java.util.concurrent.atomic.AtomicBoolean(false)")
             buildConfigField("java.util.concurrent.atomic.AtomicBoolean", "IS_FUNCTIONAL_TEST", "new java.util.concurrent.atomic.AtomicBoolean(false)")
         }
+
+        sourceSets {
+            named("test").configure { resources.srcDir("src/test/resources") }
+            named("androidTest").configure { resources.srcDir("src/test/resources") }
+        }
     }
 }
 

--- a/code/messaging/src/androidTest/java/com/adobe/marketing/mobile/messaging/E2EFunctionalTests.java
+++ b/code/messaging/src/androidTest/java/com/adobe/marketing/mobile/messaging/E2EFunctionalTests.java
@@ -46,10 +46,12 @@ import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.RuleChain;
 
+@Ignore
 public class E2EFunctionalTests {
     static {
         BuildConfig.IS_E2E_TEST.set(true);

--- a/code/messaging/src/androidTest/java/com/adobe/marketing/mobile/messaging/MessageCachingFunctionalTests.java
+++ b/code/messaging/src/androidTest/java/com/adobe/marketing/mobile/messaging/MessageCachingFunctionalTests.java
@@ -72,9 +72,14 @@ public class MessageCachingFunctionalTests {
         MobileCore.registerExtensions(
                 extensions,
                 o -> {
-                    Map<String, Object> testConfig =
-                            MessagingTestUtils.getMapFromFile("functionalTestConfig.json");
-                    MobileCore.updateConfiguration(testConfig);
+                    HashMap<String, Object> config =
+                            new HashMap<String, Object>() {
+                                {
+                                    put("messaging.eventDataset", "somedatasetid");
+                                    put("edge.configId", "someedgeconfigid");
+                                }
+                            };
+                    MobileCore.updateConfiguration(config);
                     // wait for configuration to be set
                     try {
                         Thread.sleep(1000);
@@ -99,13 +104,13 @@ public class MessageCachingFunctionalTests {
     }
 
     @Test
-    public void testMessageCaching_CachePropositions() {
+    public void testMessageCaching_CacheThenRetrieveV1Propositions() {
         final Surface surface = new Surface();
         final Map<Surface, List<Proposition>> propositions = new HashMap<>();
         final List<Proposition> propositionList = new ArrayList<>();
+        final Map<String, Object> propositionEventData = MessagingTestUtils.getMapFromFile("personalizationPayloadV1.json");
         propositionList.add(
-                Proposition.fromEventData(
-                        MessagingTestUtils.getMapFromFile("personalizationPayloadV1.json")));
+                Proposition.fromEventData(propositionEventData));
         propositions.put(surface, propositionList);
         // add a messaging payload to the cache
         messagingCacheUtilities.cachePropositions(propositions, Collections.EMPTY_LIST);
@@ -116,7 +121,34 @@ public class MessageCachingFunctionalTests {
         final Map<Surface, List<Proposition>> cachedPropositions =
                 messagingCacheUtilities.getCachedPropositions();
         final List<Map<String, Object>> expectedPropositions = new ArrayList<>();
-        expectedPropositions.add(MessagingTestUtils.getMapFromFile("personalization_payload.json"));
+        expectedPropositions.add(propositionEventData);
+        final String expectedPropositionString =
+                MessagingTestUtils.convertPropositionsToString(
+                        InternalMessagingUtils.getPropositionsFromPayloads(expectedPropositions));
+        assertEquals(
+                expectedPropositionString,
+                MessagingTestUtils.convertPropositionsToString(cachedPropositions.get(surface)));
+    }
+
+    @Test
+    public void testMessageCaching_CacheThenRetrieveV2Propositions() {
+        final Surface surface = new Surface();
+        final Map<Surface, List<Proposition>> propositions = new HashMap<>();
+        final List<Proposition> propositionList = new ArrayList<>();
+        final Map<String, Object> propositionEventData = MessagingTestUtils.getMapFromFile("inappPropositionV2.json");
+        propositionList.add(
+                Proposition.fromEventData(propositionEventData));
+        propositions.put(surface, propositionList);
+        // add a messaging payload to the cache
+        messagingCacheUtilities.cachePropositions(propositions, Collections.EMPTY_LIST);
+        // wait for event and rules processing
+        TestHelper.sleep(1000);
+        // verify message payload was cached
+        assertTrue(messagingCacheUtilities.arePropositionsCached());
+        final Map<Surface, List<Proposition>> cachedPropositions =
+                messagingCacheUtilities.getCachedPropositions();
+        final List<Map<String, Object>> expectedPropositions = new ArrayList<>();
+        expectedPropositions.add(propositionEventData);
         final String expectedPropositionString =
                 MessagingTestUtils.convertPropositionsToString(
                         InternalMessagingUtils.getPropositionsFromPayloads(expectedPropositions));

--- a/code/messaging/src/androidTest/java/com/adobe/marketing/mobile/messaging/MessageCachingFunctionalTests.java
+++ b/code/messaging/src/androidTest/java/com/adobe/marketing/mobile/messaging/MessageCachingFunctionalTests.java
@@ -108,9 +108,9 @@ public class MessageCachingFunctionalTests {
         final Surface surface = new Surface();
         final Map<Surface, List<Proposition>> propositions = new HashMap<>();
         final List<Proposition> propositionList = new ArrayList<>();
-        final Map<String, Object> propositionEventData = MessagingTestUtils.getMapFromFile("personalizationPayloadV1.json");
-        propositionList.add(
-                Proposition.fromEventData(propositionEventData));
+        final Map<String, Object> propositionEventData =
+                MessagingTestUtils.getMapFromFile("personalizationPayloadV1.json");
+        propositionList.add(Proposition.fromEventData(propositionEventData));
         propositions.put(surface, propositionList);
         // add a messaging payload to the cache
         messagingCacheUtilities.cachePropositions(propositions, Collections.EMPTY_LIST);
@@ -135,9 +135,9 @@ public class MessageCachingFunctionalTests {
         final Surface surface = new Surface();
         final Map<Surface, List<Proposition>> propositions = new HashMap<>();
         final List<Proposition> propositionList = new ArrayList<>();
-        final Map<String, Object> propositionEventData = MessagingTestUtils.getMapFromFile("inappPropositionV2.json");
-        propositionList.add(
-                Proposition.fromEventData(propositionEventData));
+        final Map<String, Object> propositionEventData =
+                MessagingTestUtils.getMapFromFile("inappPropositionV2.json");
+        propositionList.add(Proposition.fromEventData(propositionEventData));
         propositions.put(surface, propositionList);
         // add a messaging payload to the cache
         messagingCacheUtilities.cachePropositions(propositions, Collections.EMPTY_LIST);

--- a/code/messaging/src/androidTest/java/com/adobe/marketing/mobile/util/TestRetryRule.java
+++ b/code/messaging/src/androidTest/java/com/adobe/marketing/mobile/util/TestRetryRule.java
@@ -1,0 +1,69 @@
+/*
+  Copyright 2024 Adobe. All rights reserved.
+  This file is licensed to you under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License. You may obtain a copy
+  of the License at http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software distributed under
+  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+  OF ANY KIND, either express or implied. See the License for the specific language
+  governing permissions and limitations under the License.
+*/
+
+package com.adobe.marketing.mobile.util;
+
+import org.junit.rules.TestRule;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
+
+/**
+ * Test retry rule for functional testing. This rule allows a failed test to be automatically
+ * retried a specified number of times.
+ */
+public class TestRetryRule implements TestRule {
+    private int numberOfTestAttempts;
+    private int currentTestRun;
+
+    public TestRetryRule(final int numberOfTestAttempts) {
+        this.numberOfTestAttempts = numberOfTestAttempts;
+    }
+
+    public Statement apply(final Statement base, final Description description) {
+        return statement(base, description);
+    }
+
+    private Statement statement(final Statement base, final Description description) {
+        return new Statement() {
+            @Override
+            public void evaluate() throws Throwable {
+                Throwable caughtThrowable = null;
+
+                for (int i = 0; i < numberOfTestAttempts; i++) {
+                    currentTestRun = i + 1;
+
+                    try {
+                        base.evaluate();
+                        return;
+                    } catch (Throwable t) {
+                        caughtThrowable = t;
+                        System.err.println(
+                                description.getDisplayName()
+                                        + ": run "
+                                        + currentTestRun
+                                        + " failed, "
+                                        + (numberOfTestAttempts - currentTestRun)
+                                        + " retries remain.");
+                        System.err.println(
+                                "test failure caused by: " + caughtThrowable.getLocalizedMessage());
+                    }
+                }
+
+                System.err.println(
+                        description.getDisplayName()
+                                + ": giving up after "
+                                + numberOfTestAttempts
+                                + " failures");
+                throw caughtThrowable;
+            }
+        };
+    }
+}

--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/EdgePersonalizationResponseHandler.java
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/EdgePersonalizationResponseHandler.java
@@ -41,8 +41,9 @@ import java.util.Map;
 import java.util.Set;
 
 /**
- * This class is used to handle the retrieval and processing of AJO payloads containing in-app or
- * feed messages. It is also responsible for the display of AJO in-app messages.
+ * This class is used to handle the retrieval and processing of AJO payloads containing in-app,
+ * content card, or code based messages. It is also responsible for the display of AJO in-app
+ * messages.
  */
 class EdgePersonalizationResponseHandler {
     private static final String SELF_TAG = "EdgePersonalizationResponseHandler";
@@ -427,7 +428,7 @@ class EdgePersonalizationResponseHandler {
                             entry.getKey(), entry.getValue(), requestedPropositions);
         }
 
-        // dispatch an event with the cached feed propositions
+        // dispatch an event with the cached content card propositions
         final Map<String, Object> eventData = new HashMap<>();
         final List<Map<String, Object>> convertedPropositions = new ArrayList<>();
         for (final Map.Entry<Surface, List<Proposition>> propositionEntry :
@@ -612,10 +613,10 @@ class EdgePersonalizationResponseHandler {
                             "Updating content card definitions for surfaces %s",
                             newSurfaces);
 
-                    // replace rules for each feed surface we got back
+                    // replace rules for each content card surface we got back
                     contentCardRulesBySurface.putAll(rulesMaps);
 
-                    // remove any surfaces that were requested but had no feed content returned
+                    // remove any surfaces that were requested but had no content card content returned
                     for (final Surface surface : surfacesToRemove) {
                         contentCardRulesBySurface.remove(surface);
                     }

--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/EdgePersonalizationResponseHandler.java
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/EdgePersonalizationResponseHandler.java
@@ -616,7 +616,8 @@ class EdgePersonalizationResponseHandler {
                     // replace rules for each content card surface we got back
                     contentCardRulesBySurface.putAll(rulesMaps);
 
-                    // remove any surfaces that were requested but had no content card content returned
+                    // remove any surfaces that were requested but had no content card content
+                    // returned
                     for (final Surface surface : surfacesToRemove) {
                         contentCardRulesBySurface.remove(surface);
                     }

--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/MessagingConstants.java
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/MessagingConstants.java
@@ -26,7 +26,6 @@ public final class MessagingConstants {
     static final String HTTP_HEADER_LAST_MODIFIED = "Last-Modified";
     static final String HTTP_HEADER_IF_NONE_MATCH = "If-None-Match";
     static final String HTTP_HEADER_ETAG = "Etag";
-    static final String METADATA_PATH = "pathToFile";
     static final int DEFAULT_TIMEOUT = 5;
     static final long RESPONSE_CALLBACK_TIMEOUT = 10000; // 10 seconds
 
@@ -102,21 +101,12 @@ public final class MessagingConstants {
     final class MessageFeedKeys {
         static final String TITLE = "title";
         static final String BODY = "body";
-        static final String CONTENT = "content";
         static final String IMAGE_URL = "imageUrl";
         static final String ACTION_TITLE = "actionTitle";
         static final String ACTION_URL = "actionUrl";
-        static final String FEEDS = "feeds";
-        static final String FEED_NAME = "feedName";
         static final String SURFACE = "surface";
 
         private MessageFeedKeys() {}
-    }
-
-    final class MessageFeedValues {
-        static final String SCHEMA = "schema";
-
-        private MessageFeedValues() {}
     }
 
     final class TrackingKeys {
@@ -246,25 +236,12 @@ public final class MessagingConstants {
                 static final String DENY_LISTED = "denylisted";
 
                 private PushNotificationDetailsDataKeys() {}
-
-                final class EventType {
-                    static final String OPENED = "pushTracking.applicationOpened";
-                    static final String CUSTOM_ACTION = "pushTracking.customAction";
-
-                    private EventType() {}
-                }
             }
 
             final class Inbound {
-                static final String SURFACE_BASE = "mobileapp://";
-
                 private Inbound() {}
 
                 final class EventType {
-                    static final String DISMISS = "decisioning.propositionDismiss";
-                    static final String INTERACT = "decisioning.propositionInteract";
-                    static final String TRIGGER = "decisioning.propositionTrigger";
-                    static final String DISPLAY = "decisioning.propositionDisplay";
                     static final String PERSONALIZATION_REQUEST = "personalization.request";
 
                     private EventType() {}

--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/MessagingConstants.java
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/MessagingConstants.java
@@ -14,7 +14,7 @@ package com.adobe.marketing.mobile.messaging;
 public final class MessagingConstants {
 
     public static final String LOG_TAG = "Messaging";
-    static final String EXTENSION_VERSION = "3.1.0";
+    static final String EXTENSION_VERSION = "3.1.1";
     static final String FRIENDLY_EXTENSION_NAME = "Messaging";
     static final String EXTENSION_NAME = "com.adobe.messaging";
     static final String RULES_ENGINE_NAME = EXTENSION_NAME + ".rulesengine";

--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/ParsedPropositions.java
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/ParsedPropositions.java
@@ -34,7 +34,7 @@ public class ParsedPropositions {
     // also need to store tracking info for in-app propositions as `PropositionInfo`
     Map<Surface, List<Proposition>> propositionsToPersist = new HashMap<>();
 
-    // in-app and feed rules that need to be applied to their respective rules engines
+    // in-app and content card rules need to be applied to their respective rules engines
     final Map<SchemaType, Map<Surface, List<LaunchRule>>> surfaceRulesBySchemaType =
             new HashMap<>();
 
@@ -79,7 +79,7 @@ public class ParsedPropositions {
                                 new JSONObject(firstPropositionItem.getItemData());
                         final List<LaunchRule> parsedRules =
                                 JSONRulesParser.parse(content.toString(), extensionApi);
-                        // iam and feed items will be wrapped in a valid rules engine rule -
+                        // iam and feed / content card items will be wrapped in a valid rules engine rule -
                         // code-based experiences are not
                         if (MessagingUtils.isNullOrEmpty(parsedRules)) {
                             break;

--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/ParsedPropositions.java
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/ParsedPropositions.java
@@ -79,7 +79,8 @@ public class ParsedPropositions {
                                 new JSONObject(firstPropositionItem.getItemData());
                         final List<LaunchRule> parsedRules =
                                 JSONRulesParser.parse(content.toString(), extensionApi);
-                        // iam and feed / content card items will be wrapped in a valid rules engine rule -
+                        // iam and feed / content card items will be wrapped in a valid rules engine
+                        // rule -
                         // code-based experiences are not
                         if (MessagingUtils.isNullOrEmpty(parsedRules)) {
                             break;

--- a/code/messaging/src/phone/java/com/adobe/marketing/mobile/Messaging.java
+++ b/code/messaging/src/phone/java/com/adobe/marketing/mobile/Messaging.java
@@ -31,7 +31,7 @@ import java.util.List;
 import java.util.Map;
 
 public final class Messaging {
-    private static final String EXTENSION_VERSION = "3.1.0";
+    private static final String EXTENSION_VERSION = "3.1.1";
     private static final String LOG_TAG = "Messaging";
     private static final String CLASS_NAME = "Messaging";
 

--- a/code/messaging/src/phone/java/com/adobe/marketing/mobile/Messaging.java
+++ b/code/messaging/src/phone/java/com/adobe/marketing/mobile/Messaging.java
@@ -271,15 +271,15 @@ public final class Messaging {
     }
 
     /**
-     * Dispatches an event to retrieve the previously fetched (and cached) feeds content from the
-     * SDK for the provided surfaces. If the feeds content for one or more surfaces isn't previously
-     * cached in the SDK, it will not be retrieved from Adobe Journey Optimizer via the Experience
-     * Edge network.
+     * Dispatches an event to retrieve the previously fetched (and cached) content card or code
+     * based content from the SDK for the provided surfaces. If the content for one or more surfaces
+     * isn't previously cached in the SDK, it will not be retrieved from Adobe Journey Optimizer via
+     * the Experience Edge network.
      *
      * @param surfaces A {@link List<Surface>} containing {@link Surface}s to be used for retrieving
      *     previously fetched propositions
      * @param callback A {@link AdobeCallback} which will be invoked with a {@link Map<Surface,
-     *     List< Proposition >>} containing previously fetched feeds content
+     *     List< Proposition >>} containing previously fetched content card or code based content
      */
     public static void getPropositionsForSurfaces(
             @NonNull final List<Surface> surfaces,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- bump version to 3.1.1
- Adds missing tests for `getPropositionsForSurfaces`
- Re-enable platform tests on CI
- Adds test retry for platform tests. Platform tests have some startup overhead that has a variable run time. Test retry allows these tests to still run even if they are sometimes flaky.
- Fix resource files accessibility for the platform tests
- Ignore E2E test as it relies on an in-app campaign which is no longer available
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
