### PR TITLE
SmallImageCard: Card, Rows and Columns

### DIFF
--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/aepcomposeui/AepUIConstants.kt
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/aepcomposeui/AepUIConstants.kt
@@ -26,4 +26,6 @@ internal object AepUIConstants {
             const val SPACING = 8
         }
     }
+
+    const val TEXT_MAX_LINES = 3
 }

--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/aepcomposeui/components/AepButtonComposable.kt
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/aepcomposeui/components/AepButtonComposable.kt
@@ -28,36 +28,29 @@ import com.adobe.marketing.mobile.aepcomposeui.uimodels.AepText
  *
  * @param model The [AepButton] model that contains the button properties.
  * @param onClick Method that is called when this button is clicked
- * @param defaultButtonStyle The default [AepButtonStyle] to be applied to the button element.
- * @param overridingButtonStyle The [AepButtonStyle] provided by the app that overrides the default button style.
- * @param defaultButtonTextStyle The default [AepTextStyle] to be applied to the button text.
- * @param overridingButtonTextStyle The [AepTextStyle] provided by the app that overrides the default button text style.
+ * @param buttonStyle The [AepButtonStyle] to be applied to the button element.
+ * @param buttonTextStyle The [AepTextStyle] to be applied to the button text element.
  */
 @Composable
 internal fun AepButtonComposable(
     model: AepButton,
     onClick: () -> Unit,
-    defaultButtonStyle: AepButtonStyle? = null,
-    overridingButtonStyle: AepButtonStyle? = null,
-    defaultButtonTextStyle: AepTextStyle? = null,
-    overridingButtonTextStyle: AepTextStyle? = null,
+    buttonStyle: AepButtonStyle = AepButtonStyle(),
+    buttonTextStyle: AepTextStyle = AepTextStyle(),
 ) {
-    val mergedStyle = AepButtonStyle.merge(defaultButtonStyle, overridingButtonStyle)
     Button(
         onClick = onClick,
-        modifier = mergedStyle.modifier ?: Modifier,
-        enabled = mergedStyle.enabled ?: true,
-        shape = mergedStyle.shape ?: ButtonDefaults.shape,
-        colors = mergedStyle.colors ?: ButtonDefaults.buttonColors(),
-        elevation = mergedStyle.elevation,
-        border = mergedStyle.border,
-        contentPadding = mergedStyle.contentPadding ?: ButtonDefaults.ContentPadding,
+        modifier = buttonStyle.modifier ?: Modifier,
+        enabled = buttonStyle.enabled ?: true,
+        shape = buttonStyle.shape ?: ButtonDefaults.shape,
+        colors = buttonStyle.colors ?: ButtonDefaults.buttonColors(),
+        elevation = buttonStyle.elevation,
+        border = buttonStyle.border,
+        contentPadding = buttonStyle.contentPadding ?: ButtonDefaults.ContentPadding,
     ) {
-        // Use AEPText.Composable for button text
         AepTextComposable(
             model.text,
-            defaultStyle = defaultButtonTextStyle,
-            overridingStyle = overridingButtonTextStyle
+            buttonTextStyle
         )
     }
 }

--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/aepcomposeui/components/AepCardComposable.kt
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/aepcomposeui/components/AepCardComposable.kt
@@ -13,7 +13,6 @@ package com.adobe.marketing.mobile.aepcomposeui.components
 
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.ColumnScope
-import androidx.compose.material.MaterialTheme.colors
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.runtime.Composable
@@ -23,23 +22,22 @@ import com.adobe.marketing.mobile.aepcomposeui.style.AepCardStyle
 /**
  * A composable function that displays a card element with customizable properties.
  *
- * @param defaultCardStyle The default [AepCardStyle] to be applied to the card element.
- * @param overriddenCardStyle The [AepCardStyle] provided by the app that overrides the default card style.
+ * @param cardStyle The [AepCardStyle] to be applied to the card element.
+ * @param onClick Method that is called when this card is clicked
+ * @param content The content of the card.
  */
 @Composable
 internal fun AepCardComposable(
-    onClick: () -> Unit,
-    defaultCardStyle: AepCardStyle? = null,
-    overriddenCardStyle: AepCardStyle? = null,
+    cardStyle: AepCardStyle = AepCardStyle(),
+    onClick: () -> Unit = {},
     content: @Composable ColumnScope.() -> Unit
 ) {
-    val mergedStyle = AepCardStyle.merge(defaultCardStyle, overriddenCardStyle)
     Card(
-        modifier = (mergedStyle.modifier ?: Modifier).then(Modifier.clickable { onClick() }),
-        shape = mergedStyle.shape ?: CardDefaults.shape,
-        colors = mergedStyle.colors ?: CardDefaults.cardColors(),
-        elevation = mergedStyle.elevation ?: CardDefaults.elevatedCardElevation(),
-        border = mergedStyle.border,
+        modifier = (cardStyle.modifier ?: Modifier).then(Modifier.clickable { onClick() }),
+        shape = cardStyle.shape ?: CardDefaults.shape,
+        colors = cardStyle.colors ?: CardDefaults.cardColors(),
+        elevation = cardStyle.elevation ?: CardDefaults.elevatedCardElevation(),
+        border = cardStyle.border,
         content = content
     )
 }

--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/aepcomposeui/components/AepCardComposable.kt
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/aepcomposeui/components/AepCardComposable.kt
@@ -1,0 +1,45 @@
+/*
+  Copyright 2024 Adobe. All rights reserved.
+  This file is licensed to you under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License. You may obtain a copy
+  of the License at http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software distributed under
+  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+  OF ANY KIND, either express or implied. See the License for the specific language
+  governing permissions and limitations under the License.
+*/
+
+package com.adobe.marketing.mobile.aepcomposeui.components
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.material.MaterialTheme.colors
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import com.adobe.marketing.mobile.aepcomposeui.style.AepCardStyle
+
+/**
+ * A composable function that displays a card element with customizable properties.
+ *
+ * @param defaultCardStyle The default [AepCardStyle] to be applied to the card element.
+ * @param overriddenCardStyle The [AepCardStyle] provided by the app that overrides the default card style.
+ */
+@Composable
+internal fun AepCardComposable(
+    onClick: () -> Unit,
+    defaultCardStyle: AepCardStyle? = null,
+    overriddenCardStyle: AepCardStyle? = null,
+    content: @Composable ColumnScope.() -> Unit
+) {
+    val mergedStyle = AepCardStyle.merge(defaultCardStyle, overriddenCardStyle)
+    Card(
+        modifier = (mergedStyle.modifier ?: Modifier).then(Modifier.clickable { onClick() }),
+        shape = mergedStyle.shape ?: CardDefaults.shape,
+        colors = mergedStyle.colors ?: CardDefaults.cardColors(),
+        elevation = mergedStyle.elevation ?: CardDefaults.elevatedCardElevation(),
+        border = mergedStyle.border,
+        content = content
+    )
+}

--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/aepcomposeui/components/AepColumnComposable.kt
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/aepcomposeui/components/AepColumnComposable.kt
@@ -11,7 +11,6 @@
 
 package com.adobe.marketing.mobile.aepcomposeui.components
 
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ColumnScope
@@ -23,21 +22,18 @@ import com.adobe.marketing.mobile.aepcomposeui.style.AepColumnStyle
 /**
  * A composable function that displays a column element with customizable properties.
  *
- * @param defaultColumnStyle The default [AepColumnStyle] to be applied to the column element.
- * @param overriddenColumnStyle The [AepColumnStyle] provided by the app that overrides the default column style.
+ * @param columnStyle The [AepColumnStyle] to be applied to the column element.
+ * @param content The content of the column.
  */
 @Composable
 internal fun AepColumnComposable(
-    defaultColumnStyle: AepColumnStyle? = null,
-    overriddenColumnStyle: AepColumnStyle? = null,
-    onClick: () -> Unit = {},
-    content: @Composable ColumnScope.() -> Unit
+    columnStyle: AepColumnStyle = AepColumnStyle(),
+    content: @Composable (ColumnScope.() -> Unit)
 ) {
-    val mergedStyle = AepColumnStyle.merge(defaultColumnStyle, overriddenColumnStyle)
     Column(
-        modifier = (mergedStyle.modifier ?: Modifier).clickable { onClick() },
-        verticalArrangement = mergedStyle.verticalArrangement ?: Arrangement.Top,
-        horizontalAlignment = mergedStyle.horizontalAlignment ?: Alignment.Start,
+        modifier = columnStyle.modifier ?: Modifier,
+        verticalArrangement = columnStyle.verticalArrangement ?: Arrangement.Top,
+        horizontalAlignment = columnStyle.horizontalAlignment ?: Alignment.Start,
         content = content
     )
 }

--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/aepcomposeui/components/AepColumnComposable.kt
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/aepcomposeui/components/AepColumnComposable.kt
@@ -1,0 +1,43 @@
+/*
+  Copyright 2024 Adobe. All rights reserved.
+  This file is licensed to you under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License. You may obtain a copy
+  of the License at http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software distributed under
+  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+  OF ANY KIND, either express or implied. See the License for the specific language
+  governing permissions and limitations under the License.
+*/
+
+package com.adobe.marketing.mobile.aepcomposeui.components
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import com.adobe.marketing.mobile.aepcomposeui.style.AepColumnStyle
+
+/**
+ * A composable function that displays a column element with customizable properties.
+ *
+ * @param defaultColumnStyle The default [AepColumnStyle] to be applied to the column element.
+ * @param overriddenColumnStyle The [AepColumnStyle] provided by the app that overrides the default column style.
+ */
+@Composable
+internal fun AepColumnComposable(
+    defaultColumnStyle: AepColumnStyle? = null,
+    overriddenColumnStyle: AepColumnStyle? = null,
+    onClick: () -> Unit = {},
+    content: @Composable ColumnScope.() -> Unit
+) {
+    val mergedStyle = AepColumnStyle.merge(defaultColumnStyle, overriddenColumnStyle)
+    Column(
+        modifier = (mergedStyle.modifier ?: Modifier).clickable { onClick() },
+        verticalArrangement = mergedStyle.verticalArrangement ?: Arrangement.Top,
+        horizontalAlignment = mergedStyle.horizontalAlignment ?: Alignment.Start,
+        content = content
+    )
+}

--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/aepcomposeui/components/AepRowComposable.kt
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/aepcomposeui/components/AepRowComposable.kt
@@ -1,0 +1,43 @@
+/*
+  Copyright 2024 Adobe. All rights reserved.
+  This file is licensed to you under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License. You may obtain a copy
+  of the License at http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software distributed under
+  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+  OF ANY KIND, either express or implied. See the License for the specific language
+  governing permissions and limitations under the License.
+*/
+
+package com.adobe.marketing.mobile.aepcomposeui.components
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.RowScope
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import com.adobe.marketing.mobile.aepcomposeui.style.AepRowStyle
+
+/**
+ * A composable function that displays a row element with customizable properties.
+ *
+ * @param defaultRowStyle The default [AepRowStyle] to be applied to the row element.
+ * @param overriddenRowStyle The [AepRowStyle] provided by the app that overrides the default row style.
+ */
+@Composable
+internal fun AepRowComposable(
+    defaultRowStyle: AepRowStyle? = null,
+    overriddenRowStyle: AepRowStyle? = null,
+    onClick: () -> Unit = {},
+    content: @Composable RowScope.() -> Unit
+) {
+    val mergedStyle = AepRowStyle.merge(defaultRowStyle, overriddenRowStyle)
+    Row(
+        modifier = (mergedStyle.modifier ?: Modifier).then(Modifier.clickable { onClick() }),
+        horizontalArrangement = mergedStyle.horizontalArrangement ?: Arrangement.Start,
+        verticalAlignment = mergedStyle.verticalAlignment ?: defaultRowStyle?.verticalAlignment ?: Alignment.Top,
+        content = content
+    )
+}

--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/aepcomposeui/components/AepRowComposable.kt
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/aepcomposeui/components/AepRowComposable.kt
@@ -11,7 +11,6 @@
 
 package com.adobe.marketing.mobile.aepcomposeui.components
 
-import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.RowScope
@@ -23,21 +22,18 @@ import com.adobe.marketing.mobile.aepcomposeui.style.AepRowStyle
 /**
  * A composable function that displays a row element with customizable properties.
  *
- * @param defaultRowStyle The default [AepRowStyle] to be applied to the row element.
- * @param overriddenRowStyle The [AepRowStyle] provided by the app that overrides the default row style.
+ * @param rowStyle The [AepRowStyle] to be applied to the row element.
+ * @param content The content of the row.
  */
 @Composable
 internal fun AepRowComposable(
-    defaultRowStyle: AepRowStyle? = null,
-    overriddenRowStyle: AepRowStyle? = null,
-    onClick: () -> Unit = {},
+    rowStyle: AepRowStyle = AepRowStyle(),
     content: @Composable RowScope.() -> Unit
 ) {
-    val mergedStyle = AepRowStyle.merge(defaultRowStyle, overriddenRowStyle)
     Row(
-        modifier = (mergedStyle.modifier ?: Modifier).then(Modifier.clickable { onClick() }),
-        horizontalArrangement = mergedStyle.horizontalArrangement ?: Arrangement.Start,
-        verticalAlignment = mergedStyle.verticalAlignment ?: defaultRowStyle?.verticalAlignment ?: Alignment.Top,
+        modifier = (rowStyle.modifier ?: Modifier),
+        horizontalArrangement = rowStyle.horizontalArrangement ?: Arrangement.Start,
+        verticalAlignment = rowStyle.verticalAlignment ?: Alignment.Top,
         content = content
     )
 }

--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/aepcomposeui/components/AepTextComposable.kt
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/aepcomposeui/components/AepTextComposable.kt
@@ -31,24 +31,21 @@ import com.adobe.marketing.mobile.aepcomposeui.uimodels.AepText
  * A composable function that displays a text element with customizable properties.
  *
  * @param model The [AepText] model that contains the text properties.
- * @param defaultStyle The default [AepTextStyle] to be applied to the text element.
- * @param overridingStyle The [AepTextStyle] provided by the app that overrides the default text style.
+ * @param textStyle The [AepTextStyle] to be applied to the text element.
  */
 @Composable
 internal fun AepTextComposable(
     model: AepText,
-    defaultStyle: AepTextStyle? = null,
-    overridingStyle: AepTextStyle? = null
+    textStyle: AepTextStyle = AepTextStyle()
 ) {
-    val mergedStyle = AepTextStyle.merge(defaultStyle, overridingStyle)
     Text(
         text = model.content,
-        style = mergedStyle.textStyle ?: TextStyle(),
-        modifier = mergedStyle.modifier ?: Modifier,
-        overflow = mergedStyle.overflow ?: TextOverflow.Clip,
-        softWrap = mergedStyle.softWrap ?: true,
-        maxLines = mergedStyle.maxLines ?: Int.MAX_VALUE,
-        minLines = mergedStyle.minLines ?: 1
+        style = textStyle.textStyle ?: TextStyle(),
+        modifier = textStyle.modifier ?: Modifier,
+        overflow = textStyle.overflow ?: TextOverflow.Clip,
+        softWrap = textStyle.softWrap ?: true,
+        maxLines = textStyle.maxLines ?: Int.MAX_VALUE,
+        minLines = textStyle.minLines ?: 1
     )
 }
 

--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/aepcomposeui/components/AepTextComposable.kt
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/aepcomposeui/components/AepTextComposable.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.adobe.marketing.mobile.aepcomposeui.AepUIConstants
 import com.adobe.marketing.mobile.aepcomposeui.style.AepTextStyle
 import com.adobe.marketing.mobile.aepcomposeui.uimodels.AepColor
 import com.adobe.marketing.mobile.aepcomposeui.uimodels.AepFont
@@ -42,9 +43,9 @@ internal fun AepTextComposable(
         text = model.content,
         style = textStyle.textStyle ?: TextStyle(),
         modifier = textStyle.modifier ?: Modifier,
-        overflow = textStyle.overflow ?: TextOverflow.Clip,
+        overflow = textStyle.overflow ?: TextOverflow.Ellipsis,
         softWrap = textStyle.softWrap ?: true,
-        maxLines = textStyle.maxLines ?: Int.MAX_VALUE,
+        maxLines = textStyle.maxLines ?: AepUIConstants.TEXT_MAX_LINES,
         minLines = textStyle.minLines ?: 1
     )
 }

--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/aepcomposeui/components/SmallImageCard.kt
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/aepcomposeui/components/SmallImageCard.kt
@@ -47,38 +47,32 @@ fun SmallImageCard(
     }
 
     AepCardComposable(
-        defaultCardStyle = style.defaultCardStyle,
-        overriddenCardStyle = style.smallImageCardStyle,
+        cardStyle = style.smallImageCardStyle,
         onClick = {
             observer?.onEvent(UIEvent.Interact(ui, UIAction.CLICK))
         }
     ) {
         AepRowComposable(
-            defaultRowStyle = style.defaultRootRowStyle,
-            overriddenRowStyle = style.rootRowStyle
+            rowStyle = style.rootRowStyle
         ) {
             // TODO - Add image support
             AepColumnComposable(
-                defaultColumnStyle = style.defaultTextColumnStyle,
-                overriddenColumnStyle = style.textColumnStyle
+                columnStyle = style.textColumnStyle
             ) {
                 ui.getTemplate().title.let {
                     AepTextComposable(
-                        it,
-                        style.defaultTitleTextStyle,
-                        style.titleAepTextStyle
+                        model = it,
+                        textStyle = style.titleAepTextStyle
                     )
                 }
                 ui.getTemplate().body?.let {
                     AepTextComposable(
-                        it,
-                        defaultStyle = style.defaultBodyTextStyle,
-                        overridingStyle = style.bodyAepTextStyle
+                        model = it,
+                        textStyle = style.bodyAepTextStyle
                     )
                 }
                 AepRowComposable(
-                    defaultRowStyle = style.defaultButtonRowStyle,
-                    overriddenRowStyle = style.buttonRowStyle
+                    rowStyle = style.buttonRowStyle
                 ) {
                     ui.getTemplate().buttons?.forEachIndexed { index, button ->
                         AepButtonComposable(
@@ -86,9 +80,8 @@ fun SmallImageCard(
                             onClick = {
                                 observer?.onEvent(UIEvent.Interact(ui, UIAction.CLICK))
                             },
-                            overridingButtonStyle = style.buttonStyle[index]?.first,
-                            defaultButtonTextStyle = style.defaultButtonTextStyle,
-                            overridingButtonTextStyle = style.buttonStyle[index]?.second
+                            buttonStyle = style.buttonStyle[index].first,
+                            buttonTextStyle = style.buttonStyle[index].second
                         )
                     }
                 }

--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/aepcomposeui/components/SmallImageCard.kt
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/aepcomposeui/components/SmallImageCard.kt
@@ -11,14 +11,9 @@
 
 package com.adobe.marketing.mobile.aepcomposeui.components
 
-import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.material3.Card
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.ui.Modifier
 import com.adobe.marketing.mobile.aepcomposeui.SmallImageUI
 import com.adobe.marketing.mobile.aepcomposeui.interactions.UIEvent
 import com.adobe.marketing.mobile.aepcomposeui.observers.AepUIEventObserver
@@ -51,15 +46,22 @@ fun SmallImageCard(
         }
     }
 
-    Card(
-        modifier = Modifier
-            .clickable {
-                observer?.onEvent(UIEvent.Interact(ui, UIAction.CLICK))
-            }
+    AepCardComposable(
+        defaultCardStyle = style.defaultCardStyle,
+        overriddenCardStyle = style.smallImageCardStyle,
+        onClick = {
+            observer?.onEvent(UIEvent.Interact(ui, UIAction.CLICK))
+        }
     ) {
-        Row {
+        AepRowComposable(
+            defaultRowStyle = style.defaultRootRowStyle,
+            overriddenRowStyle = style.rootRowStyle
+        ) {
             // TODO - Add image support
-            Column {
+            AepColumnComposable(
+                defaultColumnStyle = style.defaultTextColumnStyle,
+                overriddenColumnStyle = style.textColumnStyle
+            ) {
                 ui.getTemplate().title.let {
                     AepTextComposable(
                         it,
@@ -74,7 +76,10 @@ fun SmallImageCard(
                         overridingStyle = style.bodyAepTextStyle
                     )
                 }
-                Row {
+                AepRowComposable(
+                    defaultRowStyle = style.defaultButtonRowStyle,
+                    overriddenRowStyle = style.buttonRowStyle
+                ) {
                     ui.getTemplate().buttons?.forEachIndexed { index, button ->
                         AepButtonComposable(
                             button,

--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/aepcomposeui/components/SmallImageCard.kt
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/aepcomposeui/components/SmallImageCard.kt
@@ -47,7 +47,7 @@ fun SmallImageCard(
     }
 
     AepCardComposable(
-        cardStyle = style.smallImageCardStyle,
+        cardStyle = style.cardStyle,
         onClick = {
             observer?.onEvent(UIEvent.Interact(ui, UIAction.CLICK))
         }

--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/aepcomposeui/style/AepButtonStyle.kt
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/aepcomposeui/style/AepButtonStyle.kt
@@ -52,19 +52,22 @@ class AepButtonStyle(
          * @return The merged [AepButtonStyle]
          */
         internal fun merge(
-            defaultStyle: AepButtonStyle? = null,
+            defaultStyle: AepButtonStyle = AepButtonStyle(),
             overridingStyle: AepButtonStyle? = null
         ): AepButtonStyle {
+            if (overridingStyle == null) {
+                return defaultStyle
+            }
             return AepButtonStyle(
-                modifier = (defaultStyle?.modifier ?: Modifier).then(
-                    overridingStyle?.modifier ?: Modifier
+                modifier = (defaultStyle.modifier ?: Modifier).then(
+                    overridingStyle.modifier ?: Modifier
                 ),
-                enabled = overridingStyle?.enabled ?: defaultStyle?.enabled,
-                elevation = overridingStyle?.elevation ?: defaultStyle?.elevation,
-                shape = overridingStyle?.shape ?: defaultStyle?.shape,
-                border = overridingStyle?.border ?: defaultStyle?.border,
-                colors = overridingStyle?.colors ?: defaultStyle?.colors,
-                contentPadding = overridingStyle?.contentPadding ?: defaultStyle?.contentPadding
+                enabled = overridingStyle.enabled ?: defaultStyle.enabled,
+                elevation = overridingStyle.elevation ?: defaultStyle.elevation,
+                shape = overridingStyle.shape ?: defaultStyle.shape,
+                border = overridingStyle.border ?: defaultStyle.border,
+                colors = overridingStyle.colors ?: defaultStyle.colors,
+                contentPadding = overridingStyle.contentPadding ?: defaultStyle.contentPadding
             )
         }
     }

--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/aepcomposeui/style/AepCardStyle.kt
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/aepcomposeui/style/AepCardStyle.kt
@@ -47,17 +47,20 @@ class AepCardStyle(
          *
          */
         internal fun merge(
-            defaultStyle: AepCardStyle? = null,
+            defaultStyle: AepCardStyle = AepCardStyle(),
             overridingStyle: AepCardStyle? = null
         ): AepCardStyle {
+            if (overridingStyle == null) {
+                return defaultStyle
+            }
             return AepCardStyle(
-                modifier = (defaultStyle?.modifier ?: Modifier).then(
-                    overridingStyle?.modifier ?: Modifier
+                modifier = (defaultStyle.modifier ?: Modifier).then(
+                    overridingStyle.modifier ?: Modifier
                 ),
-                shape = overridingStyle?.shape ?: defaultStyle?.shape,
-                colors = overridingStyle?.colors ?: defaultStyle?.colors,
-                elevation = overridingStyle?.elevation ?: defaultStyle?.elevation,
-                border = overridingStyle?.border ?: defaultStyle?.border
+                shape = overridingStyle.shape ?: defaultStyle.shape,
+                colors = overridingStyle.colors ?: defaultStyle.colors,
+                elevation = overridingStyle.elevation ?: defaultStyle.elevation,
+                border = overridingStyle.border ?: defaultStyle.border
             )
         }
     }

--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/aepcomposeui/style/AepCardStyle.kt
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/aepcomposeui/style/AepCardStyle.kt
@@ -12,59 +12,52 @@
 package com.adobe.marketing.mobile.aepcomposeui.style
 
 import androidx.compose.foundation.BorderStroke
-import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.material3.ButtonColors
-import androidx.compose.material3.ButtonElevation
+import androidx.compose.material3.CardColors
+import androidx.compose.material3.CardElevation
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Shape
 
 /**
- * Class representing the style of an AEPButton Composable.
+ * Class representing the style for a Card Composable.
  *
- * @param modifier The modifier to be applied to the button.
- * @param enabled The enabled state of the button.
+ * @param modifier The modifier to be applied to the card.
+ * @param shape The shape of the card.
+ * @param colors The colors that will be used to resolve the colors for this card in different states
  * @param elevation The elevation of the button.
- * @param shape The shape of the button.
  * @param border The border to draw around the container of this button.
- * @param colors The colors that will be used to resolve the colors for this button in different states
- * @param contentPadding the spacing values to apply internally between the container and the text
  */
-class AepButtonStyle(
+class AepCardStyle(
     var modifier: Modifier? = null,
-    var enabled: Boolean? = null,
-    var elevation: ButtonElevation? = null,
     var shape: Shape? = null,
+    var colors: CardColors? = null,
+    var elevation: CardElevation? = null,
     var border: BorderStroke? = null,
-    var colors: ButtonColors? = null,
-    var contentPadding: PaddingValues? = null,
 ) {
-
     companion object {
 
         /**
-         * Returns a new [AepButtonStyle] that is a combination of default style and overridden style.
+         * Returns a new [AepCardStyle] that is a combination of default style and overridden style.
          * If the same property is present in all the styles, the property from the overridden style is used.
          * If a property is not present in the overridden style, the property from the default style is used.
          *
-         * @param defaultStyle The default [AepButtonStyle] to be applied to the button element.
-         * @param overridingStyle The [AepButtonStyle] provided by the app that overrides the default button style.
+         * @param defaultStyle The default [AepCardStyle] to be applied to the text element.
+         * @param overridingStyle The [AepCardStyle] provided by the app that overrides the default text style.
          *
-         * @return The merged [AepButtonStyle]
+         * @return The merged [AepCardStyle]
+         *
          */
         internal fun merge(
-            defaultStyle: AepButtonStyle? = null,
-            overridingStyle: AepButtonStyle? = null
-        ): AepButtonStyle {
-            return AepButtonStyle(
+            defaultStyle: AepCardStyle? = null,
+            overridingStyle: AepCardStyle? = null
+        ): AepCardStyle {
+            return AepCardStyle(
                 modifier = (defaultStyle?.modifier ?: Modifier).then(
                     overridingStyle?.modifier ?: Modifier
                 ),
-                enabled = overridingStyle?.enabled ?: defaultStyle?.enabled,
-                elevation = overridingStyle?.elevation ?: defaultStyle?.elevation,
                 shape = overridingStyle?.shape ?: defaultStyle?.shape,
-                border = overridingStyle?.border ?: defaultStyle?.border,
                 colors = overridingStyle?.colors ?: defaultStyle?.colors,
-                contentPadding = overridingStyle?.contentPadding ?: defaultStyle?.contentPadding
+                elevation = overridingStyle?.elevation ?: defaultStyle?.elevation,
+                border = overridingStyle?.border ?: defaultStyle?.border
             )
         }
     }

--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/aepcomposeui/style/AepColumnStyle.kt
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/aepcomposeui/style/AepColumnStyle.kt
@@ -38,7 +38,7 @@ class AepColumnStyle(
          *
          * @return The merged [AepColumnStyle]
          */
-        fun merge(
+        internal fun merge(
             defaultStyle: AepColumnStyle = AepColumnStyle(),
             overridingStyle: AepColumnStyle? = null
         ): AepColumnStyle {

--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/aepcomposeui/style/AepColumnStyle.kt
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/aepcomposeui/style/AepColumnStyle.kt
@@ -1,0 +1,54 @@
+/*
+  Copyright 2024 Adobe. All rights reserved.
+  This file is licensed to you under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License. You may obtain a copy
+  of the License at http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software distributed under
+  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+  OF ANY KIND, either express or implied. See the License for the specific language
+  governing permissions and limitations under the License.
+*/
+
+package com.adobe.marketing.mobile.aepcomposeui.style
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+
+/**
+ * Class representing the style for a column AEP UI.
+ *
+ * @param modifier The modifier for the column.
+ * @param verticalArrangement The vertical arrangement for the column.
+ * @param horizontalAlignment The horizontal alignment for the column.
+ */
+class AepColumnStyle(
+    var modifier: Modifier? = null,
+    var verticalArrangement: Arrangement.Vertical? = null,
+    var horizontalAlignment: Alignment.Horizontal? = null
+) {
+    companion object {
+        /**
+         * Returns a new [AepColumnStyle] that is a combination of default style and overridden style.
+         * If the same property is present in all the styles, the property from the overridden style is used.
+         * If a property is not present in the overridden style, the property from the default style is used.
+         *
+         * @param defaultStyle The default [AepColumnStyle] to be applied to the text element.
+         * @param overridingStyle The [AepColumnStyle] provided by the app that overrides the default text style.
+         *
+         * @return The merged [AepColumnStyle]
+         */
+        fun merge(
+            defaultStyle: AepColumnStyle? = null,
+            overridingStyle: AepColumnStyle? = null
+        ): AepColumnStyle {
+            return AepColumnStyle(
+                modifier = (defaultStyle?.modifier ?: Modifier).then(
+                    overridingStyle?.modifier ?: Modifier
+                ),
+                verticalArrangement = overridingStyle?.verticalArrangement ?: defaultStyle?.verticalArrangement,
+                horizontalAlignment = overridingStyle?.horizontalAlignment ?: defaultStyle?.horizontalAlignment
+            )
+        }
+    }
+}

--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/aepcomposeui/style/AepColumnStyle.kt
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/aepcomposeui/style/AepColumnStyle.kt
@@ -39,15 +39,18 @@ class AepColumnStyle(
          * @return The merged [AepColumnStyle]
          */
         fun merge(
-            defaultStyle: AepColumnStyle? = null,
+            defaultStyle: AepColumnStyle = AepColumnStyle(),
             overridingStyle: AepColumnStyle? = null
         ): AepColumnStyle {
+            if (overridingStyle == null) {
+                return defaultStyle
+            }
             return AepColumnStyle(
-                modifier = (defaultStyle?.modifier ?: Modifier).then(
-                    overridingStyle?.modifier ?: Modifier
+                modifier = (defaultStyle.modifier ?: Modifier).then(
+                    overridingStyle.modifier ?: Modifier
                 ),
-                verticalArrangement = overridingStyle?.verticalArrangement ?: defaultStyle?.verticalArrangement,
-                horizontalAlignment = overridingStyle?.horizontalAlignment ?: defaultStyle?.horizontalAlignment
+                verticalArrangement = overridingStyle.verticalArrangement ?: defaultStyle.verticalArrangement,
+                horizontalAlignment = overridingStyle.horizontalAlignment ?: defaultStyle.horizontalAlignment
             )
         }
     }

--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/aepcomposeui/style/AepRowStyle.kt
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/aepcomposeui/style/AepRowStyle.kt
@@ -1,0 +1,54 @@
+/*
+  Copyright 2024 Adobe. All rights reserved.
+  This file is licensed to you under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License. You may obtain a copy
+  of the License at http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software distributed under
+  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+  OF ANY KIND, either express or implied. See the License for the specific language
+  governing permissions and limitations under the License.
+*/
+
+package com.adobe.marketing.mobile.aepcomposeui.style
+
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+
+/**
+ * Class representing the style for a row AEP UI.
+ *
+ * @param modifier The modifier for the row.
+ * @param horizontalArrangement The horizontal arrangement for the row.
+ * @param verticalAlignment The vertical alignment for the row.
+ */
+class AepRowStyle(
+    var modifier: Modifier? = null,
+    var horizontalArrangement: Arrangement.Horizontal? = null,
+    var verticalAlignment: Alignment.Vertical? = null,
+) {
+    companion object {
+        /**
+         * Returns a new [AepRowStyle] that is a combination of default style and overridden style.
+         * If the same property is present in all the styles, the property from the overridden style is used.
+         * If a property is not present in the overridden style, the property from the default style is used.
+         *
+         * @param defaultStyle The default [AepRowStyle] to be applied to the text element.
+         * @param overridingStyle The [AepRowStyle] provided by the app that overrides the default text style.
+         *
+         * @return The merged [AepRowStyle]
+         */
+        fun merge(
+            defaultStyle: AepRowStyle? = null,
+            overridingStyle: AepRowStyle? = null
+        ): AepRowStyle {
+            return AepRowStyle(
+                modifier = (defaultStyle?.modifier ?: Modifier).then(
+                    overridingStyle?.modifier ?: Modifier
+                ),
+                horizontalArrangement = overridingStyle?.horizontalArrangement ?: defaultStyle?.horizontalArrangement,
+                verticalAlignment = overridingStyle?.verticalAlignment ?: defaultStyle?.verticalAlignment
+            )
+        }
+    }
+}

--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/aepcomposeui/style/AepRowStyle.kt
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/aepcomposeui/style/AepRowStyle.kt
@@ -39,15 +39,19 @@ class AepRowStyle(
          * @return The merged [AepRowStyle]
          */
         fun merge(
-            defaultStyle: AepRowStyle? = null,
+            defaultStyle: AepRowStyle = AepRowStyle(),
             overridingStyle: AepRowStyle? = null
         ): AepRowStyle {
+            if (overridingStyle == null) {
+                return defaultStyle
+            }
+
             return AepRowStyle(
-                modifier = (defaultStyle?.modifier ?: Modifier).then(
-                    overridingStyle?.modifier ?: Modifier
+                modifier = (defaultStyle.modifier ?: Modifier).then(
+                    overridingStyle.modifier ?: Modifier
                 ),
-                horizontalArrangement = overridingStyle?.horizontalArrangement ?: defaultStyle?.horizontalArrangement,
-                verticalAlignment = overridingStyle?.verticalAlignment ?: defaultStyle?.verticalAlignment
+                horizontalArrangement = overridingStyle.horizontalArrangement ?: defaultStyle.horizontalArrangement,
+                verticalAlignment = overridingStyle.verticalAlignment ?: defaultStyle.verticalAlignment
             )
         }
     }

--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/aepcomposeui/style/AepRowStyle.kt
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/aepcomposeui/style/AepRowStyle.kt
@@ -38,7 +38,7 @@ class AepRowStyle(
          *
          * @return The merged [AepRowStyle]
          */
-        fun merge(
+        internal fun merge(
             defaultStyle: AepRowStyle = AepRowStyle(),
             overridingStyle: AepRowStyle? = null
         ): AepRowStyle {

--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/aepcomposeui/style/AepTextStyle.kt
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/aepcomposeui/style/AepTextStyle.kt
@@ -42,6 +42,8 @@ class AepTextStyle(
          *
          * @param defaultStyle The default [AepTextStyle] to be applied to the text element.
          * @param overridingStyle The [AepTextStyle] provided by the app that overrides the default text style.
+         *
+         * @return The merged [AepTextStyle].
          */
         internal fun merge(
             defaultStyle: AepTextStyle? = null,

--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/aepcomposeui/style/AepTextStyle.kt
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/aepcomposeui/style/AepTextStyle.kt
@@ -46,21 +46,24 @@ class AepTextStyle(
          * @return The merged [AepTextStyle].
          */
         internal fun merge(
-            defaultStyle: AepTextStyle? = null,
+            defaultStyle: AepTextStyle = AepTextStyle(),
             overridingStyle: AepTextStyle? = null
         ): AepTextStyle {
-            val mergedTextStyle = (defaultStyle?.textStyle ?: TextStyle())
-                .merge(overridingStyle?.textStyle)
+            if (overridingStyle == null) {
+                return defaultStyle
+            }
+            val mergedTextStyle = (defaultStyle.textStyle ?: TextStyle())
+                .merge(overridingStyle.textStyle)
 
             return AepTextStyle(
-                modifier = (defaultStyle?.modifier ?: Modifier).then(
-                    overridingStyle?.modifier ?: Modifier
+                modifier = (defaultStyle.modifier ?: Modifier).then(
+                    overridingStyle.modifier ?: Modifier
                 ),
                 textStyle = mergedTextStyle,
-                overflow = overridingStyle?.overflow ?: defaultStyle?.overflow,
-                softWrap = overridingStyle?.softWrap ?: defaultStyle?.softWrap,
-                maxLines = overridingStyle?.maxLines ?: defaultStyle?.maxLines,
-                minLines = overridingStyle?.minLines ?: defaultStyle?.minLines
+                overflow = overridingStyle.overflow ?: defaultStyle.overflow,
+                softWrap = overridingStyle.softWrap ?: defaultStyle.softWrap,
+                maxLines = overridingStyle.maxLines ?: defaultStyle.maxLines,
+                minLines = overridingStyle.minLines ?: defaultStyle.minLines
             )
         }
     }

--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/aepcomposeui/style/AepUIStyle.kt
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/aepcomposeui/style/AepUIStyle.kt
@@ -19,5 +19,5 @@ package com.adobe.marketing.mobile.aepcomposeui.style
  * @property smallImageUiStyle The style configuration for small image AEP UIs.
  */
 class AepUIStyle(
-    val smallImageUiStyle: SmallImageUIStyle = SmallImageUIStyle()
+    val smallImageUiStyle: SmallImageUIStyle = SmallImageUIStyle.Builder().build(),
 )

--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/aepcomposeui/style/SmallImageUIStyle.kt
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/aepcomposeui/style/SmallImageUIStyle.kt
@@ -26,57 +26,79 @@ import com.adobe.marketing.mobile.aepcomposeui.AepUIConstants
  * @property bodyAepTextStyle The custom text style for the body.
  * @property buttonStyle The custom style for the buttons.
  */
-
-class SmallImageUIStyle(
-    var smallImageCardStyle: AepCardStyle? = null,
-    var rootRowStyle: AepRowStyle? = null,
-    var textColumnStyle: AepColumnStyle? = null,
-    var titleAepTextStyle: AepTextStyle? = null,
-    var bodyAepTextStyle: AepTextStyle? = null,
-    var buttonRowStyle: AepRowStyle? = null,
-    var buttonStyle: Array<Pair<AepButtonStyle?, AepTextStyle?>?> = arrayOfNulls(3),
+class SmallImageUIStyle private constructor(
+    val smallImageCardStyle: AepCardStyle,
+    val rootRowStyle: AepRowStyle,
+    val textColumnStyle: AepColumnStyle,
+    val titleAepTextStyle: AepTextStyle,
+    val bodyAepTextStyle: AepTextStyle,
+    val buttonRowStyle: AepRowStyle,
+    val buttonStyle: Array<Pair<AepButtonStyle, AepTextStyle>>
 ) {
-    val defaultCardStyle: AepCardStyle
-        get() = AepCardStyle(
+    companion object {
+        private val defaultSmallImageCardStyle = AepCardStyle(
             modifier = Modifier.padding(AepUIConstants.SmallImageCard.DefaultStyle.SPACING.dp)
         )
-
-    val defaultRootRowStyle: AepRowStyle
-        get() = AepRowStyle(
+        private val defaultRootRowStyle = AepRowStyle(
             modifier = Modifier.padding(AepUIConstants.SmallImageCard.DefaultStyle.SPACING.dp)
         )
-
-    val defaultTextColumnStyle: AepColumnStyle
-        get() = AepColumnStyle(
+        private val defaultTextColumnStyle = AepColumnStyle(
             verticalArrangement = Arrangement.spacedBy(AepUIConstants.SmallImageCard.DefaultStyle.SPACING.dp)
         )
-
-    val defaultButtonRowStyle: AepRowStyle
-        get() = AepRowStyle(
-            horizontalArrangement = Arrangement.spacedBy(AepUIConstants.SmallImageCard.DefaultStyle.SPACING.dp)
-        )
-
-    val defaultTitleTextStyle: AepTextStyle
-        get() = AepTextStyle(
+        private val defaultTitleAepTextStyle = AepTextStyle(
             textStyle = TextStyle(
                 fontSize = AepUIConstants.SmallImageCard.DefaultStyle.TITLE_TEXT_SIZE.sp,
                 fontWeight = AepUIConstants.SmallImageCard.DefaultStyle.TITLE_FONT_WEIGHT
             )
         )
-
-    val defaultBodyTextStyle: AepTextStyle
-        get() = AepTextStyle(
+        private val defaultBodyAepTextStyle = AepTextStyle(
             textStyle = TextStyle(
                 fontSize = AepUIConstants.SmallImageCard.DefaultStyle.BODY_TEXT_SIZE.sp,
                 fontWeight = AepUIConstants.SmallImageCard.DefaultStyle.BODY_FONT_WEIGHT,
             )
         )
-
-    val defaultButtonTextStyle: AepTextStyle
-        get() = AepTextStyle(
+        private val defaultButtonRowStyle = AepRowStyle(
+            horizontalArrangement = Arrangement.spacedBy(AepUIConstants.SmallImageCard.DefaultStyle.SPACING.dp)
+        )
+        private val defaultButtonTextStyle = AepTextStyle(
             textStyle = TextStyle(
                 fontSize = AepUIConstants.SmallImageCard.DefaultStyle.BUTTON_TEXT_SIZE.sp,
                 fontWeight = AepUIConstants.SmallImageCard.DefaultStyle.BUTTON_FONT_WEIGHT,
             )
         )
+        private val defaultButtonStyle = AepButtonStyle()
+    }
+
+    class Builder {
+        private var smallImageCardStyle: AepCardStyle? = null
+        private var rootRowStyle: AepRowStyle? = null
+        private var textColumnStyle: AepColumnStyle? = null
+        private var titleAepTextStyle: AepTextStyle? = null
+        private var bodyAepTextStyle: AepTextStyle? = null
+        private var buttonRowStyle: AepRowStyle? = null
+        private var buttonStyle: Array<Pair<AepButtonStyle?, AepTextStyle?>?>? = arrayOfNulls(3)
+
+        fun smallImageCardStyle(style: AepCardStyle) = apply { this.smallImageCardStyle = style }
+        fun rootRowStyle(style: AepRowStyle) = apply { this.rootRowStyle = style }
+        fun textColumnStyle(style: AepColumnStyle) = apply { this.textColumnStyle = style }
+        fun titleAepTextStyle(style: AepTextStyle) = apply { this.titleAepTextStyle = style }
+        fun bodyAepTextStyle(style: AepTextStyle) = apply { this.bodyAepTextStyle = style }
+        fun buttonRowStyle(style: AepRowStyle) = apply { this.buttonRowStyle = style }
+        fun buttonStyle(style: Array<Pair<AepButtonStyle?, AepTextStyle?>?>) = apply { this.buttonStyle = style }
+
+        fun build() = SmallImageUIStyle(
+            smallImageCardStyle = AepCardStyle.merge(defaultSmallImageCardStyle, smallImageCardStyle),
+            rootRowStyle = AepRowStyle.merge(defaultRootRowStyle, rootRowStyle),
+            textColumnStyle = AepColumnStyle.merge(defaultTextColumnStyle, textColumnStyle),
+            titleAepTextStyle = AepTextStyle.merge(defaultTitleAepTextStyle, titleAepTextStyle),
+            bodyAepTextStyle = AepTextStyle.merge(defaultBodyAepTextStyle, bodyAepTextStyle),
+            buttonRowStyle = AepRowStyle.merge(defaultButtonRowStyle, buttonRowStyle),
+            buttonStyle = (buttonStyle ?: arrayOfNulls(3)).map { pair ->
+                Pair(
+                    AepButtonStyle.merge(defaultButtonStyle, pair?.first),
+                    AepTextStyle.merge(defaultButtonTextStyle, pair?.second)
+                )
+            }.toTypedArray()
+        )
+    }
 }

--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/aepcomposeui/style/SmallImageUIStyle.kt
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/aepcomposeui/style/SmallImageUIStyle.kt
@@ -22,12 +22,16 @@ import com.adobe.marketing.mobile.aepcomposeui.AepUIConstants
 /**
  * Class representing the style for a small image AEP UI.
  *
- * @property titleAepTextStyle The custom text style for the title.
- * @property bodyAepTextStyle The custom text style for the body.
- * @property buttonStyle The custom style for the buttons.
+ * @param cardStyle The style for the card.
+ * @param rootRowStyle The style for the root row.
+ * @param textColumnStyle The style for the column containing the title, body and buttons.
+ * @property titleAepTextStyle The text style for the title.
+ * @property bodyAepTextStyle The text style for the body.
+ * @property buttonRowStyle The style for the row containing the buttons.
+ * @property buttonStyle The style for the buttons.
  */
 class SmallImageUIStyle private constructor(
-    val smallImageCardStyle: AepCardStyle,
+    val cardStyle: AepCardStyle,
     val rootRowStyle: AepRowStyle,
     val textColumnStyle: AepColumnStyle,
     val titleAepTextStyle: AepTextStyle,
@@ -87,7 +91,7 @@ class SmallImageUIStyle private constructor(
         fun buttonStyle(style: Array<Pair<AepButtonStyle?, AepTextStyle?>?>) = apply { this.buttonStyle = style }
 
         fun build() = SmallImageUIStyle(
-            smallImageCardStyle = AepCardStyle.merge(defaultSmallImageCardStyle, smallImageCardStyle),
+            cardStyle = AepCardStyle.merge(defaultSmallImageCardStyle, smallImageCardStyle),
             rootRowStyle = AepRowStyle.merge(defaultRootRowStyle, rootRowStyle),
             textColumnStyle = AepColumnStyle.merge(defaultTextColumnStyle, textColumnStyle),
             titleAepTextStyle = AepTextStyle.merge(defaultTitleAepTextStyle, titleAepTextStyle),

--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/aepcomposeui/style/SmallImageUIStyle.kt
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/aepcomposeui/style/SmallImageUIStyle.kt
@@ -11,7 +11,11 @@
 
 package com.adobe.marketing.mobile.aepcomposeui.style
 
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.padding
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import com.adobe.marketing.mobile.aepcomposeui.AepUIConstants
 
@@ -24,10 +28,34 @@ import com.adobe.marketing.mobile.aepcomposeui.AepUIConstants
  */
 
 class SmallImageUIStyle(
+    var smallImageCardStyle: AepCardStyle? = null,
+    var rootRowStyle: AepRowStyle? = null,
+    var textColumnStyle: AepColumnStyle? = null,
     var titleAepTextStyle: AepTextStyle? = null,
     var bodyAepTextStyle: AepTextStyle? = null,
+    var buttonRowStyle: AepRowStyle? = null,
     var buttonStyle: Array<Pair<AepButtonStyle?, AepTextStyle?>?> = arrayOfNulls(3),
 ) {
+    val defaultCardStyle: AepCardStyle
+        get() = AepCardStyle(
+            modifier = Modifier.padding(AepUIConstants.SmallImageCard.DefaultStyle.SPACING.dp)
+        )
+
+    val defaultRootRowStyle: AepRowStyle
+        get() = AepRowStyle(
+            modifier = Modifier.padding(AepUIConstants.SmallImageCard.DefaultStyle.SPACING.dp)
+        )
+
+    val defaultTextColumnStyle: AepColumnStyle
+        get() = AepColumnStyle(
+            verticalArrangement = Arrangement.spacedBy(AepUIConstants.SmallImageCard.DefaultStyle.SPACING.dp)
+        )
+
+    val defaultButtonRowStyle: AepRowStyle
+        get() = AepRowStyle(
+            horizontalArrangement = Arrangement.spacedBy(AepUIConstants.SmallImageCard.DefaultStyle.SPACING.dp)
+        )
+
     val defaultTitleTextStyle: AepTextStyle
         get() = AepTextStyle(
             textStyle = TextStyle(

--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/aepcomposeui/uimodels/AepDismissButton.kt
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/aepcomposeui/uimodels/AepDismissButton.kt
@@ -19,4 +19,4 @@ package com.adobe.marketing.mobile.aepcomposeui.uimodels
  * - `simple`: A simple dismiss icon.
  * - `circle`: A circular dismiss icon.
  */
-data class AepDismissButton(val style: String? = null)
+data class AepDismissButton(val style: String)

--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/aepcomposeui/uimodels/AepDismissButton.kt
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/aepcomposeui/uimodels/AepDismissButton.kt
@@ -19,4 +19,4 @@ package com.adobe.marketing.mobile.aepcomposeui.uimodels
  * - `simple`: A simple dismiss icon.
  * - `circle`: A circular dismiss icon.
  */
-data class AepDismissButton(val style: String)
+data class AepDismissButton(val style: String? = null)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

- Added `AepCardStyle`, `AepRowStyle` and `AepColumn`Style that defines client side style for card, row and column composables.
- Added card style, row style and column style for various elements in SmallImageCard to SmallImageUIStyle.
- Added AepCardComposable, AepRowComposable and AepColumnComposables accept and use AepCardStyle, AepRowStyle and AepColumnStyle respectively.
- Changed SmallImageCard to use AepCardComposable, AepRowComposable and AepColumnComposables.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
