### PR TITLE
Changing UI state on SmallImageCard events + Test app updates

### DIFF
--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/aepcomposeui/components/AepTextComposable.kt
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/aepcomposeui/components/AepTextComposable.kt
@@ -37,6 +37,9 @@ internal fun AepTextComposable(
     model: AepText,
     textStyle: AepTextStyle = AepTextStyle()
 ) {
+    if (model.content.isBlank()) {
+        return
+    }
     Text(
         text = model.content,
         style = textStyle.textStyle ?: TextStyle(),

--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/aepcomposeui/components/SmallImageCard.kt
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/aepcomposeui/components/SmallImageCard.kt
@@ -132,7 +132,9 @@ fun SmallImageCard(
                                 onClick = {
                                     observer?.onEvent(UIEvent.Interact(ui, UIAction.Click(button.id, button.actionUrl)))
                                 },
-                                buttonStyle = style.buttonStyle[index].first,
+                                buttonStyle = style.buttonStyle[index].first.apply {
+                                    modifier = (modifier ?: Modifier).then(Modifier.weight(1f))
+                                },
                                 buttonTextStyle = style.buttonStyle[index].second
                             )
                         }

--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/aepcomposeui/components/SmallImageCard.kt
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/aepcomposeui/components/SmallImageCard.kt
@@ -58,8 +58,16 @@ fun SmallImageCard(
         if (imageUrl.isNullOrBlank()) {
             isLoading = false
         } else {
-            imageBitmap = UIUtils.downloadImage(imageUrl)
-            isLoading = false
+            UIUtils.downloadImage(imageUrl) {
+                it.onSuccess { bitmap ->
+                    imageBitmap = bitmap
+                    isLoading = false
+                }
+                it.onFailure {
+                    // TODO once we have a default image, we can use that here
+                    isLoading = false
+                }
+            }
         }
     }
 

--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/aepcomposeui/components/SmallImageCard.kt
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/aepcomposeui/components/SmallImageCard.kt
@@ -50,16 +50,20 @@ fun SmallImageCard(
     style: SmallImageUIStyle,
     observer: AepUIEventObserver?,
 ) {
+    var isLoading by remember { mutableStateOf(true) }
     var imageBitmap by remember { mutableStateOf<Bitmap?>(null) }
     val imageUrl = if (isSystemInDarkTheme() && ui.getTemplate().image?.darkUrl != null)
         ui.getTemplate().image?.darkUrl else ui.getTemplate().image?.url
 
     LaunchedEffect(ui.getTemplate().id) {
         observer?.onEvent(UIEvent.Display(ui))
-        if (imageUrl != null) {
+        if (imageUrl.isNullOrBlank()) {
+            isLoading = false
+        } else {
             imageBitmap = withContext(Dispatchers.IO) {
                 UIUtils.downloadImage(imageUrl)
             }
+            isLoading = false
         }
     }
 
@@ -91,7 +95,8 @@ fun SmallImageCard(
                         content = BitmapPainter(it.asImageBitmap()),
                         style = style.imageStyle
                     )
-                } ?: run {
+                }
+                if (isLoading) {
                     Box(
                         modifier = Modifier
                             .size(AepUIConstants.SmallImageCard.DefaultStyle.IMAGE_WIDTH.dp),

--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/aepcomposeui/components/SmallImageCard.kt
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/aepcomposeui/components/SmallImageCard.kt
@@ -34,8 +34,6 @@ import com.adobe.marketing.mobile.aepcomposeui.UIEvent
 import com.adobe.marketing.mobile.aepcomposeui.observers.AepUIEventObserver
 import com.adobe.marketing.mobile.aepcomposeui.style.SmallImageUIStyle
 import com.adobe.marketing.mobile.aepcomposeui.utils.UIUtils
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
 
 /**
  * Composable function that renders a small image card UI.
@@ -60,9 +58,7 @@ fun SmallImageCard(
         if (imageUrl.isNullOrBlank()) {
             isLoading = false
         } else {
-            imageBitmap = withContext(Dispatchers.IO) {
-                UIUtils.downloadImage(imageUrl)
-            }
+            imageBitmap = UIUtils.downloadImage(imageUrl)
             isLoading = false
         }
     }

--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/MessagingEventHandler.kt
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/MessagingEventHandler.kt
@@ -34,6 +34,12 @@ internal open class MessagingEventHandler(private val callback: ContentCardCallb
     internal open fun onEvent(event: UIEvent<*, *>, propositionId: String) {
         if (event is UIEvent.Display) {
             Log.trace(MessagingConstants.LOG_TAG, SELF_TAG, "${event.aepUi.getTemplate().getType()} Displayed")
+            // onEvent can be called multiple times on configuration changes
+            // We only need to send tracking events for initial composition
+            if (event.aepUi.getState().displayed) {
+                Log.debug(MessagingConstants.LOG_TAG, SELF_TAG, "UI already displayed, skipping display event")
+                return
+            }
             callback?.onDisplay(event.aepUi)
             track(propositionId, null, MessagingEdgeEventType.DISPLAY)
         } else if (event is UIEvent.Dismiss) {

--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/MessagingEventHandler.kt
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/MessagingEventHandler.kt
@@ -26,8 +26,21 @@ internal abstract class MessagingEventHandler(private val callback: ContentCardC
         private const val SELF_TAG = "MessagingEventHandler"
     }
 
+    /**
+     * Method to be implemented by the subclass to perform the template specific logic on events.
+     *
+     * @param event the event to handle
+     * @param propositionId the id of the proposition
+     */
     abstract fun handleEvent(event: UIEvent<*, *>, propositionId: String)
 
+    /**
+     * Performs the logic common for all templates for display and dismiss events.
+     * Delegates the template specific logic and interact event handling to the subclass by calling [handleEvent].
+     *
+     * @param event the event to handle
+     * @param propositionId the id of the proposition
+     */
     internal fun onEvent(event: UIEvent<*, *>, propositionId: String) {
 
         when (event) {
@@ -38,7 +51,7 @@ internal abstract class MessagingEventHandler(private val callback: ContentCardC
                     "${event.aepUi.getTemplate().getType()} with id $propositionId is displayed"
                 )
 
-                // onEvent can be called multiple times on configuration changes
+                // UIEvent.Display can be called multiple times on configuration changes
                 // We only need to send tracking events for initial composition
                 if (event.aepUi.getState().displayed) {
                     Log.debug(
@@ -66,8 +79,8 @@ internal abstract class MessagingEventHandler(private val callback: ContentCardC
                     "${event.aepUi.getTemplate().getType()} with id $propositionId is dismissed"
                 )
 
-                // onEvent can be called multiple times on configuration changes
-                // We only need to send tracking events for initial composition
+                // UIEvent.Dismiss can be called multiple times on multiple dismiss actions
+                // We only need to send tracking events for initial dismissal
                 if (event.aepUi.getState().dismissed) {
                     Log.debug(
                         MessagingConstants.LOG_TAG,

--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/MessagingEventHandler.kt
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/MessagingEventHandler.kt
@@ -62,14 +62,15 @@ internal abstract class MessagingEventHandler(private val callback: ContentCardC
                     return
                 }
 
-                Log.debug(
+                Log.trace(
                     MessagingConstants.LOG_TAG,
                     SELF_TAG,
                     "UI displayed for the first time, sending display tracking event"
                 )
 
-                track(propositionId, null, MessagingEdgeEventType.DISPLAY)
                 handleEvent(event, propositionId)
+
+                track(propositionId, null, MessagingEdgeEventType.DISPLAY)
                 callback?.onDisplay(event.aepUi)
             }
             is UIEvent.Dismiss -> {
@@ -89,14 +90,15 @@ internal abstract class MessagingEventHandler(private val callback: ContentCardC
                     )
                     return
                 }
-                Log.debug(
+                Log.trace(
                     MessagingConstants.LOG_TAG,
                     SELF_TAG,
                     "UI dismissed for the first time, sending dismiss tracking event"
                 )
 
-                track(propositionId, null, MessagingEdgeEventType.DISMISS)
                 handleEvent(event, propositionId)
+
+                track(propositionId, null, MessagingEdgeEventType.DISMISS)
                 callback?.onDismiss(event.aepUi)
             }
 

--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/SmallImageTemplateEventHandler.kt
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/SmallImageTemplateEventHandler.kt
@@ -30,28 +30,24 @@ internal class SmallImageTemplateEventHandler(private val callback: ContentCardC
         private const val SELF_TAG = "SmallImageTemplateEventHandler"
     }
 
-    override fun onEvent(event: UIEvent<*, *>, propositionId: String) {
-        if (event is UIEvent.Interact) {
-            onInteractEvent(event, propositionId)
-        } else {
-            if (event.aepUi is SmallImageUI) {
-                val smallImageUI = event.aepUi as SmallImageUI
-                val currentUiState = event.aepUi.getState() as SmallImageCardUIState
+    override fun handleEvent(event: UIEvent<*, *>, propositionId: String) {
+        val smallImageUI = event.aepUi as SmallImageUI
+        val currentUiState = event.aepUi.getState() as SmallImageCardUIState
+        when (event) {
+            // For dismiss event, change the dismissed state of the UI to true
+            // so that the UI can be removed from the screen
+            is UIEvent.Dismiss -> {
+                smallImageUI.updateState(currentUiState.copy(dismissed = true))
+            }
 
-                // For dismiss event, change the dismissed state of the UI to true
-                // so that the UI can be removed from the screen
-                if (event is UIEvent.Dismiss) {
-                    smallImageUI.updateState(currentUiState.copy(dismissed = true))
-                }
+            // For display event, change the displayed state of the UI to true
+            // after the tracking event is sent for the initial composition
+            is UIEvent.Display -> {
+                smallImageUI.updateState(currentUiState.copy(displayed = true))
+            }
 
-                // Call the super class to call the callback and send tracking event if needed
-                super.onEvent(event, propositionId)
-
-                // For display event, change the displayed state of the UI to true
-                // after the tracking event is sent for the initial composition
-                if (event is UIEvent.Display) {
-                    smallImageUI.updateState(currentUiState.copy(displayed = true))
-                }
+            is UIEvent.Interact -> {
+                onInteractEvent(event, propositionId)
             }
         }
     }

--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/SmallImageTemplateEventHandler.kt
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/SmallImageTemplateEventHandler.kt
@@ -38,15 +38,17 @@ internal class SmallImageTemplateEventHandler(private val callback: ContentCardC
                 val smallImageUI = event.aepUi as SmallImageUI
                 val currentUiState = event.aepUi.getState() as SmallImageCardUIState
 
-                // For dismiss event, change the state of the UI to dismissed
+                // For dismiss event, change the dismissed state of the UI to true
+                // so that the UI can be removed from the screen
                 if (event is UIEvent.Dismiss) {
                     smallImageUI.updateState(currentUiState.copy(dismissed = true))
                 }
 
-                // Call the super class to call the callback and track the event
+                // Call the super class to call the callback and send tracking event if needed
                 super.onEvent(event, propositionId)
 
-                // For display event, change the state of the UI to displayed
+                // For display event, change the displayed state of the UI to true
+                // after the tracking event is sent for the initial composition
                 if (event is UIEvent.Display) {
                     smallImageUI.updateState(currentUiState.copy(displayed = true))
                 }

--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/SmallImageTemplateEventHandler.kt
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/SmallImageTemplateEventHandler.kt
@@ -12,8 +12,10 @@
 package com.adobe.marketing.mobile.messaging
 
 import com.adobe.marketing.mobile.MessagingEdgeEventType
+import com.adobe.marketing.mobile.aepcomposeui.SmallImageUI
 import com.adobe.marketing.mobile.aepcomposeui.UIAction
 import com.adobe.marketing.mobile.aepcomposeui.UIEvent
+import com.adobe.marketing.mobile.aepcomposeui.state.SmallImageCardUIState
 import com.adobe.marketing.mobile.services.Log
 import com.adobe.marketing.mobile.services.ServiceProvider
 
@@ -32,7 +34,23 @@ internal class SmallImageTemplateEventHandler(private val callback: ContentCardC
         if (event is UIEvent.Interact) {
             onInteractEvent(event, propositionId)
         } else {
-            super.onEvent(event, propositionId)
+            if (event.aepUi is SmallImageUI) {
+                val smallImageUI = event.aepUi as SmallImageUI
+                val currentUiState = event.aepUi.getState() as SmallImageCardUIState
+
+                // For dismiss event, change the state of the UI to dismissed
+                if (event is UIEvent.Dismiss) {
+                    smallImageUI.updateState(currentUiState.copy(dismissed = true))
+                }
+
+                // Call the super class to call the callback and track the event
+                super.onEvent(event, propositionId)
+
+                // For display event, change the state of the UI to displayed
+                if (event is UIEvent.Display) {
+                    smallImageUI.updateState(currentUiState.copy(displayed = true))
+                }
+            }
         }
     }
 

--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/SmallImageTemplateEventHandler.kt
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/SmallImageTemplateEventHandler.kt
@@ -41,7 +41,7 @@ internal class SmallImageTemplateEventHandler(private val callback: ContentCardC
             }
 
             // For display event, change the displayed state of the UI to true
-            // after the tracking event is sent for the initial composition
+            // after the initial composition
             is UIEvent.Display -> {
                 smallImageUI.updateState(currentUiState.copy(displayed = true))
             }

--- a/code/testapp/build.gradle.kts
+++ b/code/testapp/build.gradle.kts
@@ -49,6 +49,10 @@ android {
     }
     buildFeatures {
         viewBinding = true
+        compose=true
+    }
+    composeOptions {
+        kotlinCompilerExtensionVersion="1.4.6"
     }
 }
 
@@ -64,4 +68,12 @@ dependencies {
     implementation("androidx.appcompat:appcompat:1.6.1")
     implementation("androidx.constraintlayout:constraintlayout:2.1.4")
     implementation("com.google.android.material:material:1.11.0")
+
+    implementation(platform("androidx.compose:compose-bom:2024.10.00"))
+    implementation("androidx.compose.runtime:runtime")
+    implementation("androidx.compose.ui:ui")
+    implementation("androidx.compose.ui:ui-tooling")
+    implementation("androidx.compose.material3:material3")
+    implementation("androidx.lifecycle:lifecycle-viewmodel-compose:2.8.6")
+    implementation("androidx.lifecycle:lifecycle-runtime-compose:2.8.6")
 }

--- a/code/testapp/src/main/java/com/adobe/marketing/mobile/messagingsample/MessagingApplication.kt
+++ b/code/testapp/src/main/java/com/adobe/marketing/mobile/messagingsample/MessagingApplication.kt
@@ -23,9 +23,9 @@ import com.google.firebase.messaging.FirebaseMessaging
 
 class MessagingApplication : Application() {
     private val ENVIRONMENT_FILE_ID = "3149c49c3910/4f6b2fbf2986/launch-7d78a5fd1de3-development"
-    private val ASSURANCE_SESSION_ID = "demoapp://?adb_validation_sessionid=c6357de3-aded-47ec-82a0-24faf7ec083c&env=qa"
+    private val ASSURANCE_SESSION_ID = ""
     private val STAGING_APP_ID = "staging/1b50a869c4a2/bcd1a623883f/launch-e44d085fc760-development"
-    private val STAGING = true
+    private val STAGING = false
 
     override fun onCreate() {
         super.onCreate()
@@ -44,7 +44,7 @@ class MessagingApplication : Application() {
             }
             MobileCore.lifecycleStart(null)
         }
-        Assurance.startSession(ASSURANCE_SESSION_ID)
+        // Assurance.startSession(ASSURANCE_SESSION_ID)
 
         FirebaseMessaging.getInstance().token.addOnCompleteListener { task ->
             // Log and toast

--- a/code/testapp/src/main/java/com/adobe/marketing/mobile/messagingsample/MessagingApplication.kt
+++ b/code/testapp/src/main/java/com/adobe/marketing/mobile/messagingsample/MessagingApplication.kt
@@ -22,7 +22,7 @@ import com.adobe.marketing.mobile.edge.identity.Identity
 import com.google.firebase.messaging.FirebaseMessaging
 
 class MessagingApplication : Application() {
-    private val ENVIRONMENT_FILE_ID = "3149c49c3910/473386a6e5b0/launch-6099493a8c97-development"
+    private val ENVIRONMENT_FILE_ID = "3149c49c3910/4f6b2fbf2986/launch-7d78a5fd1de3-development"
     private val ASSURANCE_SESSION_ID = "demoapp://?adb_validation_sessionid=c6357de3-aded-47ec-82a0-24faf7ec083c&env=qa"
     private val STAGING_APP_ID = "staging/1b50a869c4a2/bcd1a623883f/launch-e44d085fc760-development"
     private val STAGING = true

--- a/code/testapp/src/main/java/com/adobe/marketing/mobile/messagingsample/MessagingApplication.kt
+++ b/code/testapp/src/main/java/com/adobe/marketing/mobile/messagingsample/MessagingApplication.kt
@@ -22,10 +22,10 @@ import com.adobe.marketing.mobile.edge.identity.Identity
 import com.google.firebase.messaging.FirebaseMessaging
 
 class MessagingApplication : Application() {
-    private val ENVIRONMENT_FILE_ID = "3149c49c3910/4f6b2fbf2986/launch-7d78a5fd1de3-development"
-    private val ASSURANCE_SESSION_ID = ""
+    private val ENVIRONMENT_FILE_ID = "3149c49c3910/473386a6e5b0/launch-6099493a8c97-development"
+    private val ASSURANCE_SESSION_ID = "demoapp://?adb_validation_sessionid=c6357de3-aded-47ec-82a0-24faf7ec083c&env=qa"
     private val STAGING_APP_ID = "staging/1b50a869c4a2/bcd1a623883f/launch-e44d085fc760-development"
-    private val STAGING = false
+    private val STAGING = true
 
     override fun onCreate() {
         super.onCreate()
@@ -44,7 +44,7 @@ class MessagingApplication : Application() {
             }
             MobileCore.lifecycleStart(null)
         }
-        // Assurance.startSession(ASSURANCE_SESSION_ID)
+        Assurance.startSession(ASSURANCE_SESSION_ID)
 
         FirebaseMessaging.getInstance().token.addOnCompleteListener { task ->
             // Log and toast

--- a/code/testapp/src/main/java/com/adobe/marketing/mobile/messagingsample/ScrollingFeedActivity.kt
+++ b/code/testapp/src/main/java/com/adobe/marketing/mobile/messagingsample/ScrollingFeedActivity.kt
@@ -12,17 +12,54 @@
 package com.adobe.marketing.mobile.messagingsample
 
 import android.os.Bundle
+import android.util.Log
+import android.widget.ImageButton
 import androidx.appcompat.app.AppCompatActivity
-import androidx.recyclerview.widget.LinearLayoutManager
-import androidx.recyclerview.widget.RecyclerView
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.fillMaxHeight
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.platform.ViewCompositionStrategy
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.viewModelScope
 import com.adobe.marketing.mobile.Messaging
-import com.adobe.marketing.mobile.messaging.Proposition
-import com.adobe.marketing.mobile.messaging.SchemaType
+import com.adobe.marketing.mobile.aepcomposeui.AepUI
+import com.adobe.marketing.mobile.aepcomposeui.SmallImageUI
+import com.adobe.marketing.mobile.aepcomposeui.components.SmallImageCard
+import com.adobe.marketing.mobile.aepcomposeui.style.AepCardStyle
+import com.adobe.marketing.mobile.aepcomposeui.style.AepRowStyle
+import com.adobe.marketing.mobile.aepcomposeui.style.AepTextStyle
+import com.adobe.marketing.mobile.aepcomposeui.style.SmallImageUIStyle
+import com.adobe.marketing.mobile.messaging.ContentCardCallback
+import com.adobe.marketing.mobile.messaging.ContentCardEventObserver
+import com.adobe.marketing.mobile.messaging.ContentCardMapper
+import com.adobe.marketing.mobile.messaging.ContentCardUIProvider
 import com.adobe.marketing.mobile.messaging.Surface
 import com.adobe.marketing.mobile.messagingsample.databinding.ActivityScrollingBinding
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
 
 class ScrollingFeedActivity : AppCompatActivity() {
     private lateinit var binding: ActivityScrollingBinding
+    private lateinit var contentCardUIProvider: ContentCardUIProvider
+    private lateinit var contentCardViewModel: AepContentCardViewModel
+    private lateinit var contentCardCallback: ContentCardCallback
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -30,40 +67,182 @@ class ScrollingFeedActivity : AppCompatActivity() {
         binding = ActivityScrollingBinding.inflate(layoutInflater)
         setContentView(binding.root)
 
-        // retrieve any cached feed propositions
-        var propositions = mutableListOf<Proposition>()
-        val surfaces = mutableListOf<Surface>()
-
         // staging environment - CJM Stage, AJO Web (VA7)
         // surface for content card -
         // mobileapp://com.adobe.marketing.mobile.messagingsample/card/ms
+        val surfaces = mutableListOf<Surface>()
         val surface = Surface("card/ms")
-
-//        val surface = Surface("feeds/apifeed")
         surfaces.add(surface)
-        Messaging.updatePropositionsForSurfaces(surfaces)
-        Messaging.getPropositionsForSurfaces(surfaces) {
-            println("getPropositionsForSurfaces callback contained ${it.entries.size} entry/entries for surface ${surface.uri}")
-            for (entry in it.entries) {
-                for (proposition in entry.value) {
-                    if (isContentCard(proposition)) {
-                        propositions.add(proposition)
-                    }
-                }
-            }
 
-            // show feed items
-            val feedInboxRecyclerView = findViewById<RecyclerView>(R.id.feedInboxView)
-            val linearLayoutManager = LinearLayoutManager(this, LinearLayoutManager.VERTICAL, false)
-            val feedCardAdapter = FeedCardAdapter(propositions)
-            runOnUiThread {
-                feedInboxRecyclerView.layoutManager = linearLayoutManager
-                feedInboxRecyclerView.adapter = feedCardAdapter
+        // Initialize the ContentCardUIProvider
+        contentCardUIProvider = ContentCardUIProvider(surface)
+
+        // Initialize the ViewModel
+        contentCardViewModel =
+            ViewModelProvider(this, AepContentCardViewModelFactory(contentCardUIProvider)).get(
+                AepContentCardViewModel::class.java
+            )
+
+        contentCardCallback = ContentCardCallback()
+
+        // Set a click listener for refresh button which calls the API for fetch content cards from Edge
+        val refreshButton: ImageButton = findViewById(R.id.refreshButton)
+        refreshButton.setOnClickListener {
+            Messaging.updatePropositionsForSurfaces(surfaces)
+            contentCardViewModel.refreshContent()
+        }
+
+        binding.composeView.apply {
+            setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
+            setContent {
+                AppTheme {
+                    AepContentCardList(contentCardViewModel)
+                }
             }
         }
     }
 
-    private fun isContentCard(proposition: Proposition): Boolean {
-        return proposition.items[0].schema == SchemaType.CONTENT_CARD
+
+    @Composable
+    private fun AepContentCardList(viewModel: AepContentCardViewModel) {
+        // Collect the state from ViewModel
+        val aepUiList by viewModel.aepUIList.collectAsStateWithLifecycle()
+
+        // Get the ContentCardSchemaData for the AepUI list if needed
+        val contentCardSchemaDataList = aepUiList.map {
+            when (it) {
+                is SmallImageUI ->
+                    ContentCardMapper.Companion.instance.getContentCardSchemaData(it.getTemplate().id)
+
+                else -> null
+            }
+        }
+
+        // Reorder the AepUI list based on the ContentCardSchemaData fields if needed
+        val reorderedAepUIList = aepUiList.sortedWith(compareByDescending {
+            val rank =
+                contentCardSchemaDataList[aepUiList.indexOf(it)]?.meta?.get("priority") as String?
+                    ?: "0"
+            rank.toInt()
+        })
+
+/*        // Displaying content cards in a Column
+        // create a custom style for the small image card in column
+        val smallImageCardStyleColumn = SmallImageUIStyle.Builder()
+            .rootRowStyle(
+                AepRowStyle(
+                    modifier = Modifier.fillMaxWidth()
+                )
+            )
+            .titleAepTextStyle(AepTextStyle(textStyle = TextStyle(Color.Green)))
+            .build()
+
+        // Create column with composables from AepUI instances
+        LazyColumn {
+            items(reorderedAepUIList) { aepUI ->
+                when (aepUI) {
+                    is SmallImageUI -> {
+                        val state = aepUI.getState()
+                        if (!state.dismissed) {
+                            SmallImageCard(
+                                ui = aepUI,
+                                style = smallImageCardStyleColumn,
+                                observer = ContentCardEventObserver(null)
+                            )
+                        }
+                    }
+                }
+            }
+        }*/
+
+        // Displaying content cards in a Row
+        // create a custom style for the small image card in row
+        val smallImageCardStyleRow = SmallImageUIStyle.Builder()
+            .cardStyle(AepCardStyle(modifier = Modifier.width(400.dp).height(200.dp)))
+            .rootRowStyle(
+                AepRowStyle(
+                    modifier = Modifier.fillMaxSize()
+                )
+            )
+            .titleAepTextStyle(AepTextStyle(textStyle = TextStyle(Color.Green)))
+            .build()
+
+        // Create row with composables from AepUI instances
+        LazyRow {
+            items(reorderedAepUIList) { aepUI ->
+                when (aepUI) {
+                    is SmallImageUI -> {
+                        val state = aepUI.getState()
+                        if (!state.dismissed) {
+                            SmallImageCard(
+                                ui = aepUI,
+                                style = smallImageCardStyleRow,
+                                observer = ContentCardEventObserver(contentCardCallback)
+                            )
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+class ContentCardCallback: ContentCardCallback {
+    override fun onDisplay(aepUI: AepUI<*, *>) {
+        Log.d("ContentCardCallback", "onDisplay")
+    }
+
+    override fun onDismiss(aepUI: AepUI<*, *>) {
+        Log.d("ContentCardCallback", "onDismiss")
+    }
+
+    override fun onInteract(
+        aepUI: AepUI<*, *>,
+        interactionId: String?,
+        actionUrl: String?
+    ): Boolean {
+        Log.d("ContentCardCallback", "onInteract $interactionId $actionUrl")
+        // If the url is handled here, return true
+        return false
+    }
+}
+
+// create new view model or reuse existing one to hold the aepUIList
+class AepContentCardViewModel(private val contentCardUIProvider: ContentCardUIProvider) : ViewModel() {
+    // State to hold AepUI list
+    private val _aepUIList = MutableStateFlow<List<AepUI<*, *>>>(emptyList())
+    val aepUIList: StateFlow<List<AepUI<*, *>>> = _aepUIList.asStateFlow()
+
+    init {
+        // Launch a coroutine to fetch the aepUIList from the ContentCardUIProvider
+        // when the ViewModel is created
+        viewModelScope.launch {
+            contentCardUIProvider.getAepUi().collect { aepUi ->
+                _aepUIList.value = aepUi
+            }
+        }
+    }
+
+    // Function to refresh the aepUIList from the ContentCardUIProvider
+    fun refreshContent() {
+        viewModelScope.launch {
+            contentCardUIProvider.refreshContent()
+        }
+    }
+}
+
+class AepContentCardViewModelFactory(
+    private val contentCardUIProvider: ContentCardUIProvider
+) : ViewModelProvider.Factory {
+
+    @Suppress("UNCHECKED_CAST")
+    override fun <T : ViewModel> create(modelClass: Class<T>): T {
+        return when {
+            modelClass.isAssignableFrom(AepContentCardViewModel::class.java) -> {
+                AepContentCardViewModel(contentCardUIProvider) as T
+            }
+
+            else -> throw IllegalArgumentException("Unknown ViewModel class")
+        }
     }
 }

--- a/code/testapp/src/main/java/com/adobe/marketing/mobile/messagingsample/Theme.kt
+++ b/code/testapp/src/main/java/com/adobe/marketing/mobile/messagingsample/Theme.kt
@@ -1,0 +1,46 @@
+/*
+  Copyright 2024 Adobe. All rights reserved.
+  This file is licensed to you under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License. You may obtain a copy
+  of the License at http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software distributed under
+  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+  OF ANY KIND, either express or implied. See the License for the specific language
+  governing permissions and limitations under the License.
+*/
+
+package com.adobe.marketing.mobile.messagingsample
+
+import android.os.Build
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.darkColorScheme
+import androidx.compose.material3.dynamicDarkColorScheme
+import androidx.compose.material3.dynamicLightColorScheme
+import androidx.compose.material3.lightColorScheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.platform.LocalContext
+
+@Composable
+fun AppTheme(
+    useDarkTheme: Boolean = isSystemInDarkTheme(),
+    useDynamicColors: Boolean = true,
+    content: @Composable () -> Unit
+) {
+
+    val colorScheme = when {
+        useDynamicColors && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S -> {
+            if (useDarkTheme) dynamicDarkColorScheme(context = LocalContext.current)
+            else dynamicLightColorScheme(context = LocalContext.current)
+        }
+
+        useDarkTheme -> darkColorScheme()
+        else -> lightColorScheme()
+    }
+
+    MaterialTheme(
+        colorScheme = colorScheme,
+        content = content
+    )
+}
+

--- a/code/testapp/src/main/res/drawable/refresh.xml
+++ b/code/testapp/src/main/res/drawable/refresh.xml
@@ -1,0 +1,5 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android" android:height="24dp" android:tint="#000000" android:viewportHeight="24" android:viewportWidth="24" android:width="24dp">
+      
+    <path android:fillColor="@android:color/white" android:pathData="M17.65,6.35C16.2,4.9 14.21,4 12,4c-4.42,0 -7.99,3.58 -7.99,8s3.57,8 7.99,8c3.73,0 6.84,-2.55 7.73,-6h-2.08c-0.82,2.33 -3.04,4 -5.65,4 -3.31,0 -6,-2.69 -6,-6s2.69,-6 6,-6c1.66,0 3.14,0.69 4.22,1.78L13,11h7V4l-2.35,2.35z"/>
+    
+</vector>

--- a/code/testapp/src/main/res/layout/activity_scrolling.xml
+++ b/code/testapp/src/main/res/layout/activity_scrolling.xml
@@ -12,27 +12,44 @@
     governing permissions and limitations under the License.
 
 -->
-<androidx.coordinatorlayout.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
+    android:orientation="vertical"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:fitsSystemWindows="true"
     tools:context=".ScrollingFeedActivity">
 
-    <TextView
-        android:id="@+id/feedTitleTextView"
-        android:layout_width="wrap_content"
+    <LinearLayout
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_gravity="center_horizontal"
-        android:text="Feed Messages"
-        android:textAppearance="@style/TextAppearance.AppCompat.Large" />
+        android:gravity="center">
+        <TextView
+            android:id="@+id/feedTitleTextView"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="center_horizontal"
+            android:text="Feed Messages"
+            android:textAppearance="@style/TextAppearance.AppCompat.Large" />
+        <ImageButton
+            android:id="@+id/refreshButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:src="@drawable/refresh"
+            android:contentDescription="Refresh"/>
+    </LinearLayout>
 
-    <include
+    <androidx.compose.ui.platform.ComposeView
+        android:id="@+id/compose_view"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" />
+<!--    <include
         android:id="@+id/scrollingFeedView"
         layout="@layout/feed_content_scrolling"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginTop="@dimen/app_bar_height"
-        />
+        />-->
 
-</androidx.coordinatorlayout.widget.CoordinatorLayout>
+</LinearLayout>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

1. Added an `isLoading` flag to be used when image is being downloaded from the url
2. AepUiState `dismissed` is set to `true` when `UIEvent.Dismiss` is received.
3. SmallImageCard composable is recomposed on configuration changes like theme or orientation change leading to multiple `UIEvent.Display` events for a single "view". To ensure `decisioning.propositionDisplay` events are sent only on the initial composition, `displayed` is set to `true` in AepUiState after the first display. `ContentCardSchemaData.track(MessagingEdgeEventType.DISPLAY)` is only called if `displayed` is `false`
4. Updated messaging test app to use content card UI library

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
