### PR TITLE
Button right alignment not working fix

### DIFF
--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/aepcomposeui/components/SmallImageCard.kt
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/aepcomposeui/components/SmallImageCard.kt
@@ -137,7 +137,7 @@ fun SmallImageCard(
                                     observer?.onEvent(UIEvent.Interact(ui, UIAction.Click(button.id, button.actionUrl)))
                                 },
                                 buttonStyle = style.buttonStyle[index].apply {
-                                    modifier = (modifier ?: Modifier).then(Modifier.weight(1f))
+                                    modifier = (modifier ?: Modifier).then(Modifier.weight(1f, fill = false))
                                 }
                             )
                         }

--- a/code/testapp/src/main/java/com/adobe/marketing/mobile/messagingsample/ScrollingFeedActivity.kt
+++ b/code/testapp/src/main/java/com/adobe/marketing/mobile/messagingsample/ScrollingFeedActivity.kt
@@ -17,6 +17,7 @@ import android.widget.ImageButton
 import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
@@ -153,10 +154,10 @@ class ScrollingFeedActivity : AppCompatActivity() {
         // Displaying content cards in a Row
         // create a custom style for the small image card in row
         val smallImageCardStyleRow = SmallImageUIStyle.Builder()
-            .cardStyle(AepCardStyle(modifier = Modifier.width(400.dp).height(200.dp)))
+            .cardStyle(AepCardStyle(modifier = Modifier.width(400.dp).height(200.dp).padding(8.dp)))
             .rootRowStyle(
                 AepRowStyle(
-                    modifier = Modifier.fillMaxSize()
+                    modifier = Modifier.fillMaxSize().padding(8.dp)
                 )
             )
             .titleAepTextStyle(AepTextStyle(textStyle = TextStyle(Color.Green)))


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Fixing [issue](https://jira.corp.adobe.com/browse/MOB-22541) reported by Acrobat where content card button was taking up entire width of the row because of which it could not be aligned to the end of the row

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
