### PR TITLE
Fix click behavior for button and image in SmallImageCard

### DIFF
--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/aepcomposeui/components/AepButtonComposable.kt
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/aepcomposeui/components/AepButtonComposable.kt
@@ -11,9 +11,11 @@
 
 package com.adobe.marketing.mobile.aepcomposeui.components
 
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import com.adobe.marketing.mobile.aepcomposeui.style.AepButtonStyle
@@ -44,6 +46,7 @@ internal fun AepButtonComposable(
         elevation = buttonStyle.elevation ?: ButtonDefaults.buttonElevation(),
         border = buttonStyle.border,
         contentPadding = buttonStyle.contentPadding ?: ButtonDefaults.ContentPadding,
+        interactionSource = buttonStyle.interactionSource ?: remember { MutableInteractionSource() }
     ) {
         AepTextComposable(
             model.text,

--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/aepcomposeui/components/AepIconComposable.kt
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/aepcomposeui/components/AepIconComposable.kt
@@ -11,7 +11,6 @@
 
 package com.adobe.marketing.mobile.aepcomposeui.components
 
-import androidx.compose.foundation.clickable
 import androidx.compose.material3.Icon
 import androidx.compose.material3.LocalContentColor
 import androidx.compose.runtime.Composable
@@ -24,18 +23,16 @@ import com.adobe.marketing.mobile.aepcomposeui.style.AepIconStyle
  *
  * @param drawableId The drawable resource ID to be displayed.
  * @param iconStyle The [AepIconStyle] to be applied to the icon element.
- * @param onClick Method that is called when this icon is clicked
  */
 @Composable
 internal fun AepIconComposable(
     drawableId: Int,
-    iconStyle: AepIconStyle = AepIconStyle(),
-    onClick: () -> Unit = {}
+    iconStyle: AepIconStyle = AepIconStyle()
 ) {
     Icon(
         painter = painterResource(id = drawableId),
         contentDescription = iconStyle.contentDescription,
-        modifier = (iconStyle.modifier ?: Modifier).clickable { onClick() },
+        modifier = iconStyle.modifier ?: Modifier,
         tint = iconStyle.tint ?: LocalContentColor.current
     )
 }

--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/aepcomposeui/components/AepImageComposable.kt
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/aepcomposeui/components/AepImageComposable.kt
@@ -12,7 +12,6 @@
 package com.adobe.marketing.mobile.aepcomposeui.components
 
 import androidx.compose.foundation.Image
-import androidx.compose.foundation.clickable
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -26,18 +25,16 @@ import com.adobe.marketing.mobile.aepcomposeui.style.AepImageStyle
  *
  * @param content [Painter] representing image to be displayed.
  * @param imageStyle The [AepImageStyle] to be applied to the image element.
- * @param onClick Method that is called when this image is clicked
  */
 @Composable
 internal fun AepImageComposable(
     content: Painter,
-    imageStyle: AepImageStyle = AepImageStyle(),
-    onClick: () -> Unit = {}
+    imageStyle: AepImageStyle = AepImageStyle()
 ) {
     Image(
         painter = content,
         contentDescription = imageStyle.contentDescription ?: "",
-        modifier = (imageStyle.modifier ?: Modifier).clickable { onClick() },
+        modifier = imageStyle.modifier ?: Modifier,
         alignment = imageStyle.alignment ?: Alignment.Center,
         contentScale = imageStyle.contentScale ?: ContentScale.Fit,
         alpha = imageStyle.alpha ?: DefaultAlpha,

--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/aepcomposeui/components/SmallImageCard.kt
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/aepcomposeui/components/SmallImageCard.kt
@@ -12,6 +12,7 @@
 package com.adobe.marketing.mobile.aepcomposeui.components
 
 import android.graphics.Bitmap
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.size
@@ -84,10 +85,11 @@ fun SmallImageCard(
                     drawableId = it.drawableId,
                     // todo check if we can remember this calculation so that it is not repeated for recompositions
                     iconStyle = style.dismissButtonStyle.apply {
-                        modifier = (modifier ?: Modifier).align(style.dismissButtonAlignment)
-                    },
-                    onClick = {
-                        observer?.onEvent(UIEvent.Dismiss(ui))
+                        modifier = (modifier ?: Modifier)
+                            .align(style.dismissButtonAlignment)
+                            .clickable {
+                                observer?.onEvent(UIEvent.Dismiss(ui))
+                            }
                     }
                 )
             }

--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/aepcomposeui/style/AepButtonStyle.kt
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/aepcomposeui/style/AepButtonStyle.kt
@@ -12,6 +12,7 @@
 package com.adobe.marketing.mobile.aepcomposeui.style
 
 import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.material3.ButtonColors
 import androidx.compose.material3.ButtonElevation
@@ -38,6 +39,7 @@ class AepButtonStyle(
     var border: BorderStroke? = null,
     var colors: ButtonColors? = null,
     var contentPadding: PaddingValues? = null,
+    var interactionSource: MutableInteractionSource? = null,
     var textStyle: AepTextStyle? = null
 ) {
 
@@ -68,6 +70,7 @@ class AepButtonStyle(
                 border = overridingStyle.border ?: defaultStyle.border,
                 colors = overridingStyle.colors ?: defaultStyle.colors,
                 contentPadding = overridingStyle.contentPadding ?: defaultStyle.contentPadding,
+                interactionSource = overridingStyle.interactionSource ?: defaultStyle.interactionSource,
                 textStyle = AepTextStyle.merge(defaultStyle.textStyle ?: AepTextStyle(), overridingStyle.textStyle)
             )
         }

--- a/code/messaging/src/test/java/com/adobe/marketing/mobile/aepcomposeui/components/AepButtonComposableTests.kt
+++ b/code/messaging/src/test/java/com/adobe/marketing/mobile/aepcomposeui/components/AepButtonComposableTests.kt
@@ -14,6 +14,8 @@ package com.adobe.marketing.mobile.aepcomposeui.components
 import android.os.Build
 import androidx.activity.ComponentActivity
 import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.interaction.Interaction
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.width
@@ -33,6 +35,8 @@ import com.adobe.marketing.mobile.aepcomposeui.uimodels.AepButton
 import com.adobe.marketing.mobile.aepcomposeui.uimodels.AepText
 import com.example.compose.TestTheme
 import com.github.takahirom.roborazzi.captureRoboImage
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.emptyFlow
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -222,7 +226,19 @@ class AepButtonComposableTests(
                 disabledContainerColor = Color(0xFF33032f),
                 disabledContentColor = Color.Gray,
             ),
-            contentPadding = PaddingValues(10.dp)
+            contentPadding = PaddingValues(10.dp),
+            interactionSource = NoEffectInteractionSource(),
         )
+    }
+
+    class NoEffectInteractionSource : MutableInteractionSource {
+        override val interactions: Flow<Interaction> = emptyFlow() // No interactions emitted
+        override suspend fun emit(interaction: Interaction) {
+            // Do nothing
+        }
+
+        override fun tryEmit(interaction: Interaction): Boolean {
+            return false
+        }
     }
 }

--- a/code/messaging/src/test/java/com/adobe/marketing/mobile/aepcomposeui/style/AepButtonStyleTests.kt
+++ b/code/messaging/src/test/java/com/adobe/marketing/mobile/aepcomposeui/style/AepButtonStyleTests.kt
@@ -13,6 +13,7 @@ package com.adobe.marketing.mobile.aepcomposeui.style
 
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.border
+import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.ButtonColors
@@ -37,6 +38,7 @@ class AepButtonStyleTests {
             border = mock(BorderStroke::class.java),
             colors = mock(ButtonColors::class.java),
             contentPadding = mock(PaddingValues::class.java),
+            interactionSource = mock(MutableInteractionSource::class.java),
             textStyle = mock(AepTextStyle::class.java)
         )
         val overridingStyle = AepButtonStyle(
@@ -47,6 +49,7 @@ class AepButtonStyleTests {
             border = mock(BorderStroke::class.java),
             colors = mock(ButtonColors::class.java),
             contentPadding = mock(PaddingValues::class.java),
+            interactionSource = mock(MutableInteractionSource::class.java),
             textStyle = mock(AepTextStyle::class.java)
         )
 
@@ -70,12 +73,7 @@ class AepButtonStyleTests {
         val overridingStyle = AepButtonStyle(
             modifier = Modifier.padding(16.dp).border(BorderStroke(2.dp, Color.Red)),
             enabled = true,
-            elevation = null,
-            shape = null,
-            border = BorderStroke(3.dp, Color.Green),
-            colors = null,
-            contentPadding = null,
-            textStyle = null
+            border = BorderStroke(3.dp, Color.Green)
         )
 
         val result = AepButtonStyle.merge(defaultStyle, overridingStyle)
@@ -134,6 +132,7 @@ class AepButtonStyleTests {
             border = null,
             colors = null,
             contentPadding = null,
+            interactionSource = null,
             textStyle = null
         )
 

--- a/code/messaging/src/test/java/com/adobe/marketing/mobile/aepcomposeui/style/AepStyleValidator.kt
+++ b/code/messaging/src/test/java/com/adobe/marketing/mobile/aepcomposeui/style/AepStyleValidator.kt
@@ -71,6 +71,7 @@ internal class AepStyleValidator {
             assertEquals(expectedStyle?.border, style?.border)
             assertEquals(expectedStyle?.colors, style?.colors)
             assertEquals(expectedStyle?.contentPadding, style?.contentPadding)
+            assertEquals(expectedStyle?.interactionSource, style?.interactionSource)
             validateTextStyle(expectedStyle?.textStyle, style?.textStyle)
         }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

1. Added a new field `interactionSource` to `AepButtonStyle` to allow customizing the appearance / behavior of the button in different states.
2. Removed explicit `onClick` fields in `AepImageComposable` and `AepIconComposable`. It can be added/overridden using Modifier. This ensures that image in the SmallImageCard inherits the parent card click behavior by default.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

 [MOB-22770](https://jira.corp.adobe.com/browse/MOB-22770)
 [MOB-22771](https://jira.corp.adobe.com/browse/MOB-22771)

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
