### PR TITLE
Add test for card clicking override, bump version to beta6

### DIFF
--- a/code/gradle.properties
+++ b/code/gradle.properties
@@ -16,7 +16,7 @@ org.gradle.caching=true
 android.useAndroidX=true
 
 moduleName=messaging
-moduleVersion=3.3.0-beta5
+moduleVersion=3.3.0-beta6
 
 #Maven artifact
 mavenRepoName=AdobeMobileMessagingSdk

--- a/code/messaging/src/phone/java/com/adobe/marketing/mobile/Messaging.java
+++ b/code/messaging/src/phone/java/com/adobe/marketing/mobile/Messaging.java
@@ -31,7 +31,7 @@ import java.util.List;
 import java.util.Map;
 
 public final class Messaging {
-    private static final String EXTENSION_VERSION = "3.3.0-beta5";
+    private static final String EXTENSION_VERSION = "3.3.0-beta6";
     private static final String LOG_TAG = "Messaging";
     private static final String CLASS_NAME = "Messaging";
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

1. Added a test to ensure adding `clickable` to dismissButtonStyle modifier does not override the default click handling.
2. Bumped version to beta6 for snapshot release

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
