### PR TITLE
Refactor gif download and caching to resolve race condition seen with large gif media

### DIFF
--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/MessagingPushBuilder.java
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/MessagingPushBuilder.java
@@ -32,7 +32,6 @@ import com.adobe.marketing.mobile.MobileCore;
 import com.adobe.marketing.mobile.services.Log;
 import com.adobe.marketing.mobile.services.caching.CacheResult;
 import com.adobe.marketing.mobile.util.StringUtils;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
 import java.util.concurrent.CompletableFuture;
@@ -267,19 +266,10 @@ class MessagingPushBuilder {
         CompletableFuture<NotificationCompat.Builder> builderFuture =
                 CompletableFuture.supplyAsync(
                         () -> {
-                            final MessageAssetDownloader assetDownloader =
-                                    new MessageAssetDownloader(
-                                            new ArrayList<String>() {
-                                                {
-                                                    add(payload.getImageUrl());
-                                                }
-                                            });
-                            assetDownloader.downloadAssetCollection();
-
                             final ExecutorService singleThreadScheduledExecutor =
                                     Executors.newSingleThreadScheduledExecutor();
                             final CacheResult cacheResult =
-                                    MessagingPushUtils.getCachedAsset(
+                                    MessagingPushUtils.downloadAndCacheAsset(
                                                     singleThreadScheduledExecutor,
                                                     payload.getImageUrl(),
                                                     MessagingConstants.DOWNLOAD_ASSET_TIMEOUT)

--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/MessagingPushUtils.java
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/MessagingPushUtils.java
@@ -197,13 +197,14 @@ class MessagingPushUtils {
     }
 
     /**
-     * Downloads the asset from the given URL and caches it using the {@link CacheService}.
-     * The downloaded asset is then retrieved from the cache and returned in a
-     * {@code CompletableFuture} supplying a {@code CacheResult}.
+     * Downloads the asset from the given URL and caches it using the {@link CacheService}. The
+     * downloaded asset is then retrieved from the cache and returned in a {@code CompletableFuture}
+     * supplying a {@code CacheResult}.
      *
      * @param singleThreadScheduledExecutor the {@link Executor} to run the download and cache task
      * @param url a {@code String} containing the URL of the asset to download
-     * @param timeoutInMillis an (code int} timeout in milliseconds for the download and cache operation
+     * @param timeoutInMillis an (code int} timeout in milliseconds for the download and cache
+     *     operation
      * @return a {@link CompletableFuture} that will complete with the {@link CacheResult} of the
      *     cached asset
      */

--- a/code/messaging/src/test/java/com/adobe/marketing/mobile/messaging/MessageAssetDownloaderTests.java
+++ b/code/messaging/src/test/java/com/adobe/marketing/mobile/messaging/MessageAssetDownloaderTests.java
@@ -11,7 +11,9 @@
 
 package com.adobe.marketing.mobile.messaging;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -390,6 +392,164 @@ public class MessageAssetDownloaderTests {
                     // verify asset cached
                     verify(mockCacheService, times(0))
                             .set(eq(expectedCacheLocation), eq(assetUrl), any(CacheEntry.class));
+                });
+    }
+
+    // ====================================================================================================
+    // void downloadAsset()
+    // ====================================================================================================
+
+    @Test
+    public void testDownloadAsset_whenAssetIsDownloaded_thenAssetIsCached() {
+        // setup
+        setupServiceProviderMockAndRunTest(
+                () -> {
+                    messageAssetsDownloader = new MessageAssetDownloader();
+                    when(mockHttpConnection.getResponseCode())
+                            .thenReturn(HttpURLConnection.HTTP_OK);
+                    when(mockHttpConnection.getInputStream())
+                            .thenReturn(
+                                    new ByteArrayInputStream(
+                                            "assetData".getBytes(StandardCharsets.UTF_8)));
+                    doAnswer(
+                                    (Answer<Void>)
+                                            invocation -> {
+                                                NetworkCallback callback =
+                                                        invocation.getArgument(1);
+                                                callback.call(mockHttpConnection);
+                                                return null;
+                                            })
+                            .when(mockNetworkService)
+                            .connectAsync(any(NetworkRequest.class), any(NetworkCallback.class));
+
+                    // test
+                    messageAssetsDownloader.downloadAsset(
+                            assetUrl,
+                            cacheResult -> {
+                                // verify
+                                verify(mockCacheService, times(1))
+                                        .set(anyString(), anyString(), any(CacheEntry.class));
+                                assertEquals(mockCacheResult, cacheResult);
+                            });
+                });
+    }
+
+    @Test
+    public void testDownloadAsset_whenNullNetworkConnection_thenAssetIsNotCached() {
+        // setup
+        setupServiceProviderMockAndRunTest(
+                () -> {
+                    messageAssetsDownloader = new MessageAssetDownloader();
+
+                    doAnswer(
+                                    (Answer<Void>)
+                                            invocation -> {
+                                                NetworkCallback callback =
+                                                        invocation.getArgument(1);
+                                                callback.call(null);
+                                                return null;
+                                            })
+                            .when(mockNetworkService)
+                            .connectAsync(any(NetworkRequest.class), any(NetworkCallback.class));
+
+                    // test
+                    messageAssetsDownloader.downloadAsset(
+                            assetUrl,
+                            cacheResult -> {
+                                // verify
+                                verify(mockCacheService, times(0))
+                                        .set(anyString(), anyString(), any(CacheEntry.class));
+                                assertNull(cacheResult);
+                            });
+                });
+    }
+
+    @Test
+    public void testDownloadAsset_whenNullAssetUrl_thenAssetIsNotCached() {
+        // setup
+        setupServiceProviderMockAndRunTest(
+                () -> {
+                    messageAssetsDownloader = new MessageAssetDownloader();
+
+                    // test
+                    messageAssetsDownloader.downloadAsset(
+                            null,
+                            cacheResult -> {
+                                // verify
+                                verify(mockCacheService, times(0))
+                                        .set(anyString(), anyString(), any(CacheEntry.class));
+                                assertNull(cacheResult);
+                            });
+                });
+    }
+
+    @Test
+    public void testDownloadAsset_whenAssetIsNotModified_thenAssetIsNotCached() {
+        // setup
+        setupServiceProviderMockAndRunTest(
+                () -> {
+                    messageAssetsDownloader = new MessageAssetDownloader();
+                    when(mockHttpConnection.getResponseCode())
+                            .thenReturn(HttpURLConnection.HTTP_NOT_MODIFIED);
+                    when(mockHttpConnection.getInputStream())
+                            .thenReturn(
+                                    new ByteArrayInputStream(
+                                            "assetData".getBytes(StandardCharsets.UTF_8)));
+                    doAnswer(
+                                    (Answer<Void>)
+                                            invocation -> {
+                                                NetworkCallback callback =
+                                                        invocation.getArgument(1);
+                                                callback.call(mockHttpConnection);
+                                                return null;
+                                            })
+                            .when(mockNetworkService)
+                            .connectAsync(any(NetworkRequest.class), any(NetworkCallback.class));
+
+                    // test
+                    messageAssetsDownloader.downloadAsset(
+                            assetUrl,
+                            cacheResult -> {
+                                // verify
+                                verify(mockCacheService, times(0))
+                                        .set(anyString(), anyString(), any(CacheEntry.class));
+                                assertEquals(mockCacheResult, cacheResult);
+                            });
+                });
+    }
+
+    @Test
+    public void testDownloadAsset_whenAssetIsNotFound_thenAssetIsNotCached() {
+        // setup
+        setupServiceProviderMockAndRunTest(
+                () -> {
+                    messageAssetsDownloader = new MessageAssetDownloader();
+                    when(mockHttpConnection.getResponseCode())
+                            .thenReturn(HttpURLConnection.HTTP_NOT_FOUND);
+                    when(mockHttpConnection.getInputStream())
+                            .thenReturn(
+                                    new ByteArrayInputStream(
+                                            "assetData".getBytes(StandardCharsets.UTF_8)));
+                    doAnswer(
+                                    (Answer<Void>)
+                                            invocation -> {
+                                                NetworkCallback callback =
+                                                        invocation.getArgument(1);
+                                                callback.call(mockHttpConnection);
+                                                return null;
+                                            })
+                            .when(mockNetworkService)
+                            .connectAsync(any(NetworkRequest.class), any(NetworkCallback.class));
+
+                    // test
+                    messageAssetsDownloader.downloadAsset(
+                            assetUrl,
+                            cacheResult -> {
+                                // verify
+                                verify(mockCacheService, times(0))
+                                        .set(anyString(), anyString(), any(CacheEntry.class));
+                                assertNull(cacheResult);
+                            });
                 });
     }
 }

--- a/code/messaging/src/test/java/com/adobe/marketing/mobile/messaging/MessagingPushUtilsTests.java
+++ b/code/messaging/src/test/java/com/adobe/marketing/mobile/messaging/MessagingPushUtilsTests.java
@@ -345,7 +345,7 @@ public class MessagingPushUtilsTests {
     }
 
     @Test
-    public void getCachedAssetReturnsCacheResultWhenCachedFileExists() {
+    public void downloadAndCacheAssetReturnsCacheResultWhenCachedFileExists() {
         // setup
         mockCacheService = mock(CacheService.class);
         CacheResult mockCacheResult = mock(CacheResult.class);
@@ -376,7 +376,7 @@ public class MessagingPushUtilsTests {
 
             // test
             CacheResult cachedAsset =
-                    MessagingPushUtils.getCachedAsset(mockExecutor, fileName, 2000).join();
+                    MessagingPushUtils.downloadAndCacheAsset(mockExecutor, fileName, 2000).join();
 
             // verify
             assertEquals(mockCacheResult, cachedAsset);
@@ -384,7 +384,7 @@ public class MessagingPushUtilsTests {
     }
 
     @Test
-    public void getCachedAssetReturnsNullWhenCacheResultDoesNotExist() {
+    public void downloadAndCacheAssetReturnsNullWhenCacheResultDoesNotExist() {
         // setup
         mockCacheService = mock(CacheService.class);
         CacheResult mockCacheResult = mock(CacheResult.class);
@@ -415,72 +415,10 @@ public class MessagingPushUtilsTests {
 
             // test
             CacheResult cachedAsset =
-                    MessagingPushUtils.getCachedAsset(mockExecutor, fileName, 2000).join();
+                    MessagingPushUtils.downloadAndCacheAsset(mockExecutor, fileName, 2000).join();
 
             // verify
             assertNull(cachedAsset);
-        }
-    }
-
-    @Test
-    public void tryGetCachedAssetReturnsCacheResultWhenAssetIsCached() {
-        // setup
-        String key = "test_key";
-        int elapsedTime = 0;
-        mockCacheService = mock(CacheService.class);
-        CacheResult mockCacheResult = mock(CacheResult.class);
-        mockServiceProvider = mock(ServiceProvider.class);
-
-        try (MockedStatic<ServiceProvider> serviceProviderMockedStatic =
-                        Mockito.mockStatic(ServiceProvider.class);
-                MockedStatic<InternalMessagingUtils> internalMessagingUtilsMockedStatic =
-                        Mockito.mockStatic(InternalMessagingUtils.class)) {
-            when(mockCacheService.get(anyString(), anyString())).thenReturn(mockCacheResult);
-            when(mockServiceProvider.getCacheService()).thenReturn(mockCacheService);
-
-            serviceProviderMockedStatic
-                    .when(ServiceProvider::getInstance)
-                    .thenReturn(mockServiceProvider);
-
-            internalMessagingUtilsMockedStatic
-                    .when(InternalMessagingUtils::getAssetCacheLocation)
-                    .thenReturn("assetCacheLocation");
-
-            // test
-            CacheResult result = MessagingPushUtils.tryGetCachedAsset(key, 2000);
-
-            // verify
-            assertEquals(mockCacheResult, result);
-        }
-    }
-
-    @Test
-    public void tryGetCachedAssetReturnsNullWhenAssetIsNotCachedWithinTimeout() {
-        // setup
-        String key = "test_key";
-        mockCacheService = mock(CacheService.class);
-        mockServiceProvider = mock(ServiceProvider.class);
-
-        try (MockedStatic<ServiceProvider> serviceProviderMockedStatic =
-                        Mockito.mockStatic(ServiceProvider.class);
-                MockedStatic<InternalMessagingUtils> internalMessagingUtilsMockedStatic =
-                        Mockito.mockStatic(InternalMessagingUtils.class)) {
-            when(mockCacheService.get(anyString(), anyString())).thenReturn(null);
-            when(mockServiceProvider.getCacheService()).thenReturn(mockCacheService);
-
-            serviceProviderMockedStatic
-                    .when(ServiceProvider::getInstance)
-                    .thenReturn(mockServiceProvider);
-
-            internalMessagingUtilsMockedStatic
-                    .when(InternalMessagingUtils::getAssetCacheLocation)
-                    .thenReturn("assetCacheLocation");
-
-            // test
-            CacheResult result = MessagingPushUtils.tryGetCachedAsset(key, 2000);
-
-            // verify
-            assertNull(result);
         }
     }
 }

--- a/code/messaging/src/test/java/com/adobe/marketing/mobile/messaging/MessagingRichPushBuilderTests.kt
+++ b/code/messaging/src/test/java/com/adobe/marketing/mobile/messaging/MessagingRichPushBuilderTests.kt
@@ -94,13 +94,10 @@ class MessagingRichPushBuilderTests {
         every { payload.imageUrl } returns gifUrl
 
         // Setup a cached asset to be returned via a completable future
-        every { MessagingPushUtils.getCachedAsset(any(), any(), any()) } returns CompletableFuture.supplyAsync({ mockk<CacheResult>() })
+        every { MessagingPushUtils.downloadAndCacheAsset(any(), any(), any()) } returns CompletableFuture.supplyAsync({ mockk<CacheResult>() })
 
         // Execute
         val notification = MessagingPushBuilder.build(payload, context)
-
-        // Verify MessageAssetDownloader was used
-        verify(exactly = 1) { anyConstructed<MessageAssetDownloader>().downloadAssetCollection() }
 
         // Verify notification was created
         assertNotNull(notification)
@@ -116,13 +113,10 @@ class MessagingRichPushBuilderTests {
         every { payload.imageUrl } returns gifUrl
 
         // Setup a null cached asset to be returned via a completable future
-        every { MessagingPushUtils.getCachedAsset(any(), any(), any()) } returns CompletableFuture.supplyAsync({ null })
+        every { MessagingPushUtils.downloadAndCacheAsset(any(), any(), any()) } returns CompletableFuture.supplyAsync({ null })
 
         // Execute
         val notification = MessagingPushBuilder.build(payload, context)
-
-        // Verify MessageAssetDownloader was used
-        verify(exactly = 1) { anyConstructed<MessageAssetDownloader>().downloadAssetCollection() }
 
         // Verify notification was created
         assertNotNull(notification)
@@ -137,13 +131,10 @@ class MessagingRichPushBuilderTests {
         every { payload.imageUrl } returns null
 
         // Setup a cached asset to be returned via a completable future
-        every { MessagingPushUtils.getCachedAsset(any(), any(), any()) } returns CompletableFuture.supplyAsync({ mockk<CacheResult>() })
+        every { MessagingPushUtils.downloadAndCacheAsset(any(), any(), any()) } returns CompletableFuture.supplyAsync({ mockk<CacheResult>() })
 
         // Execute
         val notification = MessagingPushBuilder.build(payload, context)
-
-        // Verify MessageAssetDownloader was not used
-        verify(exactly = 0) { anyConstructed<MessageAssetDownloader>().downloadAssetCollection() }
 
         // Verify notification was created
         assertNotNull(notification)
@@ -160,13 +151,10 @@ class MessagingRichPushBuilderTests {
         every { MessagingPushUtils.getCachedRichMediaFileUri(any()) } returns null
 
         // Setup a cached asset to be returned via a completable future
-        every { MessagingPushUtils.getCachedAsset(any(), any(), any()) } returns CompletableFuture.supplyAsync({ mockk<CacheResult>() })
+        every { MessagingPushUtils.downloadAndCacheAsset(any(), any(), any()) } returns CompletableFuture.supplyAsync({ mockk<CacheResult>() })
 
         // Execute
         val notification = MessagingPushBuilder.build(payload, context)
-
-        // Verify MessageAssetDownloader was used
-        verify(exactly = 1) { anyConstructed<MessageAssetDownloader>().downloadAssetCollection() }
 
         // Verify notification was created
         assertNotNull(notification)


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
Refactor the gif download and caching code to wait for the download to complete before retrieving it from the cache. There was a race condition occurring if the asset was attempted to be retrieved before it was downloaded. This was caused by missing asset metadata mistakenly causing large gif media to appear to be corrupted cached assets.

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
