### PR TITLE
Added support for maxWidth in in-app message settings

### DIFF
--- a/code/messaging/build.gradle.kts
+++ b/code/messaging/build.gradle.kts
@@ -61,7 +61,8 @@ aepLibrary {
 }
 
 dependencies {
-    implementation("com.adobe.marketing.mobile:core:$mavenCoreVersion")
+    // TODO: change this back when Core 3.4.0 is released
+    implementation("com.github.adobe.aepsdk-core-android:core:31d3e1a48d")
     // dependencies provided by aep-library:
     // COMPOSE_RUNTIME, COMPOSE_MATERIAL, ANDROIDX_ACTIVITY_COMPOSE, COMPOSE_UI_TOOLING
     implementation("androidx.compose.ui:ui-tooling-preview:${BuildConstants.Versions.COMPOSE}")

--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/MessagingConstants.java
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/MessagingConstants.java
@@ -300,6 +300,7 @@ public final class MessagingConstants {
 
         final class MobileParametersKeys {
             static final String WIDTH = "width";
+            static final String MAX_WIDTH = "maxWidth";
             static final String HEIGHT = "height";
             static final String VERTICAL_ALIGN = "verticalAlign";
             static final String VERTICAL_INSET = "verticalInset";

--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/PresentableMessageMapper.java
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/PresentableMessageMapper.java
@@ -375,6 +375,11 @@ class PresentableMessageMapper {
                             rawSettings,
                             MessagingConstants.EventDataKeys.MobileParametersKeys.WIDTH,
                             FILL_SCREEN);
+            final int maxWidth =
+                    DataReader.optInt(
+                            rawSettings,
+                            MessagingConstants.EventDataKeys.MobileParametersKeys.MAX_WIDTH,
+                            Integer.MAX_VALUE);
             final int height =
                     DataReader.optInt(
                             rawSettings,
@@ -455,6 +460,7 @@ class PresentableMessageMapper {
                     .content(content)
                     .width(width)
                     .height(height)
+                    .maxWidth(maxWidth)
                     .verticalInset(verticalInset)
                     .horizontalInset(horizontalInset)
                     .verticalAlignment(verticalAlign)

--- a/code/messaging/src/test/java/com/adobe/marketing/mobile/messaging/PresentableMessageMapperTests.java
+++ b/code/messaging/src/test/java/com/adobe/marketing/mobile/messaging/PresentableMessageMapperTests.java
@@ -382,6 +382,66 @@ public class PresentableMessageMapperTests {
     }
 
     @Test
+    public void test_createMessage_WithoutMessageSettings() {
+        // setup
+        runUsingMockedServiceProvider(
+                () -> {
+                    // test
+                    try {
+                        Map<String, Object> data = new HashMap<>();
+                        data.put(MessagingTestConstants.ConsequenceDetailDataKeys.CONTENT, html);
+                        data.put(
+                                MessagingTestConstants.ConsequenceDetailDataKeys.CONTENT_TYPE,
+                                ContentType.TEXT_HTML.toString());
+                        PropositionItem propositionItem =
+                                new PropositionItem("123456789", SchemaType.INAPP, data);
+                        internalMessage =
+                                (PresentableMessageMapper.InternalMessage)
+                                        PresentableMessageMapper.getInstance()
+                                                .createMessage(
+                                                        mockMessagingExtension,
+                                                        propositionItem,
+                                                        new HashMap<>(),
+                                                        null);
+                    } catch (Exception exception) {
+                        fail(exception.getMessage());
+                    }
+
+                    // verify
+                    ArgumentCaptor<InAppMessage> inAppMessageCaptor =
+                            ArgumentCaptor.forClass(InAppMessage.class);
+                    verify(mockUIService, times(1))
+                            .create(
+                                    inAppMessageCaptor.capture(),
+                                    any(DefaultPresentationUtilityProvider.class));
+                    InAppMessageSettings settings = inAppMessageCaptor.getValue().getSettings();
+                    assertEquals(html, settings.getContent());
+                    assertEquals(100, settings.getWidth());
+                    assertEquals(Integer.MAX_VALUE, settings.getMaxWidth());
+                    assertEquals(100, settings.getHeight());
+                    assertEquals("#FFFFFF", settings.getBackdropColor());
+                    assertEquals(0.0f, settings.getBackdropOpacity(), 0.0);
+                    assertEquals(0.0f, settings.getCornerRadius(), 0.0);
+                    assertEquals(
+                            InAppMessageSettings.MessageAnimation.NONE,
+                            settings.getDismissAnimation());
+                    assertEquals(
+                            InAppMessageSettings.MessageAnimation.NONE,
+                            settings.getDisplayAnimation());
+                    assertTrue(settings.getGestureMap().isEmpty());
+                    assertEquals(
+                            InAppMessageSettings.MessageAlignment.CENTER,
+                            settings.getHorizontalAlignment());
+                    assertEquals(0, settings.getHorizontalInset());
+                    assertEquals(
+                            InAppMessageSettings.MessageAlignment.CENTER,
+                            settings.getVerticalAlignment());
+                    assertEquals(0, settings.getVerticalInset());
+                    assertTrue(settings.getShouldTakeOverUi());
+                });
+    }
+
+    @Test
     public void test_createMessage_WithMessageSettings() {
         // setup
         runUsingMockedServiceProvider(
@@ -395,8 +455,9 @@ public class PresentableMessageMapperTests {
                         gestureMap.put("swipeRight", "adbinapp://dismiss?interaction=positive");
                         gestureMap.put("swipeUp", "adbinapp://dismiss");
                         gestureMap.put("swipeDown", "adbinapp://dismiss");
-                        rawMessageSettings.put("width", 100);
-                        rawMessageSettings.put("height", 100);
+                        rawMessageSettings.put("width", 90);
+                        rawMessageSettings.put("maxWidth", 200);
+                        rawMessageSettings.put("height", 80);
                         rawMessageSettings.put("backdropColor", "808080");
                         rawMessageSettings.put("backdropOpacity", 0.5f);
                         rawMessageSettings.put("cornerRadius", 70.0f);
@@ -407,7 +468,7 @@ public class PresentableMessageMapperTests {
                         rawMessageSettings.put("horizontalInset", 5);
                         rawMessageSettings.put("verticalAlign", "top");
                         rawMessageSettings.put("verticalInset", 10);
-                        rawMessageSettings.put("uiTakeover", true);
+                        rawMessageSettings.put("uiTakeover", false);
                         Map<String, Object> data = new HashMap<>();
                         data.put(MessagingTestConstants.ConsequenceDetailDataKeys.CONTENT, html);
                         data.put(
@@ -439,8 +500,9 @@ public class PresentableMessageMapperTests {
                                     any(DefaultPresentationUtilityProvider.class));
                     InAppMessageSettings settings = inAppMessageCaptor.getValue().getSettings();
                     assertEquals(html, settings.getContent());
-                    assertEquals(100, settings.getWidth());
-                    assertEquals(100, settings.getHeight());
+                    assertEquals(90, settings.getWidth());
+                    assertEquals(200, settings.getMaxWidth());
+                    assertEquals(80, settings.getHeight());
                     assertEquals("808080", settings.getBackdropColor());
                     assertEquals(0.5f, settings.getBackdropOpacity(), 0.0);
                     assertEquals(70.0f, settings.getCornerRadius(), 0.0);
@@ -478,7 +540,7 @@ public class PresentableMessageMapperTests {
                             InAppMessageSettings.MessageAlignment.TOP,
                             settings.getVerticalAlignment());
                     assertEquals(10, settings.getVerticalInset());
-                    assertTrue(settings.getShouldTakeOverUi());
+                    assertFalse(settings.getShouldTakeOverUi());
                 });
     }
 

--- a/code/messagingtestutils/build.gradle.kts
+++ b/code/messagingtestutils/build.gradle.kts
@@ -43,7 +43,8 @@ android {
 
 dependencies {
     implementation(project(":messaging"))
-    implementation("com.adobe.marketing.mobile:core:$mavenCoreVersion")
+    // TODO: change this back when Core 3.4.0 is released
+    implementation("com.github.adobe.aepsdk-core-android:core:31d3e1a48d")
 
     implementation("com.fasterxml.jackson.core:jackson-databind:2.12.7")
     implementation("androidx.test.ext:junit:1.1.5")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Reading the value of the key `maxWidth` currently sent in `mobileParameters` object the in-app proposition payload. Setting its value in `InAppMessageSettings` provided by Core SDK

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
https://github.com/adobe/aepsdk-core-android/pull/753

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
