### PR TITLE
Handle reset identities event by clearing the push token from messaging shared state and persistence

### DIFF
--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/InternalMessagingUtils.java
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/InternalMessagingUtils.java
@@ -186,22 +186,6 @@ class InternalMessagingUtils {
     }
 
     /**
-     * Determines if the passed in {@code Event} is an edge identity reset complete event.
-     *
-     * @param event An Edge Identity Reset Complete {@link Event}.
-     * @return {@code boolean} indicating if the passed in event is an edge identity reset complete
-     *     event.
-     */
-    static boolean isEdgeIdentityResetComplete(final Event event) {
-        if (event == null) {
-            return false;
-        }
-
-        return EventType.EDGE_IDENTITY.equalsIgnoreCase(event.getType())
-                && EventSource.RESET_COMPLETE.equalsIgnoreCase(event.getSource());
-    }
-
-    /**
      * Determines if the passed in {@code Event} is a messaging request content event.
      *
      * @param event A Messaging Request Content {@link Event}.

--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/InternalMessagingUtils.java
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/InternalMessagingUtils.java
@@ -668,6 +668,11 @@ class InternalMessagingUtils {
      */
     static void persistPushToken(final String pushToken) {
         final NamedCollection messagingNamedCollection = getNamedCollection();
+        if (pushToken == null) {
+            messagingNamedCollection.remove(
+                    MessagingConstants.NamedCollectionKeys.Messaging.PUSH_IDENTIFIER);
+            return;
+        }
         messagingNamedCollection.setString(
                 MessagingConstants.NamedCollectionKeys.Messaging.PUSH_IDENTIFIER, pushToken);
     }

--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/InternalMessagingUtils.java
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/InternalMessagingUtils.java
@@ -186,6 +186,22 @@ class InternalMessagingUtils {
     }
 
     /**
+     * Determines if the passed in {@code Event} is an edge identity reset complete event.
+     *
+     * @param event An Edge Identity Reset Complete {@link Event}.
+     * @return {@code boolean} indicating if the passed in event is an edge identity reset complete
+     *     event.
+     */
+    static boolean isEdgeIdentityResetComplete(final Event event) {
+        if (event == null) {
+            return false;
+        }
+
+        return EventType.EDGE_IDENTITY.equalsIgnoreCase(event.getType())
+                && EventSource.RESET_COMPLETE.equalsIgnoreCase(event.getSource());
+    }
+
+    /**
      * Determines if the passed in {@code Event} is a messaging request content event.
      *
      * @param event A Messaging Request Content {@link Event}.

--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/InternalMessagingUtils.java
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/InternalMessagingUtils.java
@@ -170,6 +170,22 @@ class InternalMessagingUtils {
     }
 
     /**
+     * Determines if the passed in {@code Event} is a generic identity request reset event.
+     *
+     * @param event A Generic Identity Request Reset {@link Event}.
+     * @return {@code boolean} indicating if the passed in event is a generic identity request reset
+     *     event.
+     */
+    static boolean isGenericIdentityResetEvent(final Event event) {
+        if (event == null) {
+            return false;
+        }
+
+        return EventType.GENERIC_IDENTITY.equalsIgnoreCase(event.getType())
+                && EventSource.REQUEST_RESET.equalsIgnoreCase(event.getSource());
+    }
+
+    /**
      * Determines if the passed in {@code Event} is a messaging request content event.
      *
      * @param event A Messaging Request Content {@link Event}.
@@ -580,7 +596,7 @@ class InternalMessagingUtils {
     static boolean shouldSyncPushToken(
             @Nullable final Map<String, Object> configSharedState,
             @Nullable final String newPushToken,
-            long eventTimestamp) {
+            final long eventTimestamp) {
         if (StringUtils.isNullOrEmpty(newPushToken)) {
             Log.debug(
                     MessagingConstants.LOG_TAG,
@@ -621,9 +637,7 @@ class InternalMessagingUtils {
         Log.debug(MessagingConstants.LOG_TAG, "shouldSyncPushToken", syncReason);
 
         // persist the push token in the messaging named collection
-        final NamedCollection messagingNamedCollection = getNamedCollection();
-        messagingNamedCollection.setString(
-                MessagingConstants.SharedState.Messaging.PUSH_IDENTIFIER, newPushToken);
+        persistPushToken(newPushToken);
 
         lastPushTokenSyncTimestamp = eventTimestamp;
 
@@ -633,6 +647,16 @@ class InternalMessagingUtils {
     // ========================================================================================
     // Datastore utils
     // ========================================================================================
+    /**
+     * Persists the provided push token in the Messaging extension {@link NamedCollection}.
+     *
+     * @param pushToken A {@code String} containing the push token to be persisted
+     */
+    static void persistPushToken(final String pushToken) {
+        final NamedCollection messagingNamedCollection = getNamedCollection();
+        messagingNamedCollection.setString(
+                MessagingConstants.NamedCollectionKeys.Messaging.PUSH_IDENTIFIER, pushToken);
+    }
     /**
      * Retrieves the Messaging extension {@link NamedCollection} from the {@link DataStoring}
      * service.

--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/MessagingExtension.java
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/MessagingExtension.java
@@ -938,7 +938,10 @@ public final class MessagingExtension extends Extension {
 
     private void createMessagingSharedState(final String pushToken, final Event event) {
         final Map<String, Object> newMessagingState = new HashMap<>();
-        newMessagingState.put(MessagingConstants.SharedState.Messaging.PUSH_IDENTIFIER, pushToken);
+        if (!StringUtils.isNullOrEmpty(pushToken)) {
+            newMessagingState.put(
+                    MessagingConstants.SharedState.Messaging.PUSH_IDENTIFIER, pushToken);
+        }
         getApi().createSharedState(newMessagingState, event);
     }
     // endregion

--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/MessagingExtension.java
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/MessagingExtension.java
@@ -63,6 +63,8 @@ public final class MessagingExtension extends Extension {
      *       {@link EventSource#REQUEST_CONTENT}
      *   <li>Listening to event with eventType {@link EventType#GENERIC_IDENTITY} and EventSource
      *       {@link EventSource#REQUEST_RESET}
+     *   <li>Listening to event with eventType {@link EventType#EDGE_IDENTITY} and EventSource
+     *       {@link EventSource#RESET_COMPLETE}
      *   <li>Listening to event with eventType {@link MessagingConstants.EventType#MESSAGING} and
      *       EventSource {@link EventSource#REQUEST_CONTENT}
      *   <li>Listening to event with eventType {@link MessagingConstants.EventType#EDGE} and
@@ -145,6 +147,8 @@ public final class MessagingExtension extends Extension {
                         this::processEvent);
         getApi().registerEventListener(
                         EventType.GENERIC_IDENTITY, EventSource.REQUEST_RESET, this::processEvent);
+        getApi().registerEventListener(
+                        EventType.EDGE_IDENTITY, EventSource.RESET_COMPLETE, this::processEvent);
         getApi().registerEventListener(
                         MessagingConstants.EventType.MESSAGING,
                         EventSource.REQUEST_CONTENT,
@@ -337,7 +341,7 @@ public final class MessagingExtension extends Extension {
      * @param eventToProcess an {@link Event} from an {@link ExtensionEventListener} to be processed
      */
     void processEvent(final Event eventToProcess) {
-        if (!eventIsValid(eventToProcess) && !isRequestResetEvent(eventToProcess)) {
+        if (!eventIsValid(eventToProcess)) {
             Log.debug(MessagingConstants.LOG_TAG, SELF_TAG, "Invalid event, ignoring.");
             return;
         }
@@ -382,6 +386,9 @@ public final class MessagingExtension extends Extension {
         } else if (InternalMessagingUtils.isGenericIdentityResetEvent(eventToProcess)) {
             // handle the reset identities event
             handleResetIdentitiesEvent(eventToProcess);
+        } else if (InternalMessagingUtils.isEdgeIdentityResetComplete(eventToProcess)) {
+            // handle the reset complete event
+            handleResetCompleteEvent(eventToProcess);
         } else if (InternalMessagingUtils.isMessagingRequestContentEvent(eventToProcess)) {
             // need experience event dataset id for sending the push token
             final Map<String, Object> configSharedState =
@@ -474,6 +481,52 @@ public final class MessagingExtension extends Extension {
             return;
         }
 
+        dispatchPushTokenEdgeEvent(pushToken, event);
+    }
+
+    /**
+     * Handles the reset identities event by setting a null push token in the Messaging shared state
+     * and by removing the persisted push token from the Messaging {@link
+     * com.adobe.marketing.mobile.services.NamedCollection}
+     *
+     * @param resetIdentitiesEvent the reset identities {@link Event}
+     */
+    private void handleResetIdentitiesEvent(final Event resetIdentitiesEvent) {
+        Log.debug(
+                MessagingConstants.LOG_TAG,
+                SELF_TAG,
+                "Clearing the push token from persistence and the Messaging shared state.");
+        // remove the push token from the shared state
+        createMessagingSharedState(null, resetIdentitiesEvent);
+        // remove the push token from the named collection
+        InternalMessagingUtils.persistPushToken(null);
+    }
+
+    /**
+     * Handles the reset complete event by re-syncing the push token using the newly generated ECID.
+     *
+     * @param resetCompleteEvent the reset complete {@link Event}
+     */
+    private void handleResetCompleteEvent(final Event resetCompleteEvent) {
+        final String pushToken = InternalMessagingUtils.getPushTokenFromPersistence();
+        if (StringUtils.isNullOrEmpty(pushToken)) {
+            Log.debug(
+                    MessagingConstants.LOG_TAG,
+                    SELF_TAG,
+                    "Push token is null or empty, skipping the re-sync.");
+            return;
+        }
+
+        Log.debug(
+                MessagingConstants.LOG_TAG,
+                SELF_TAG,
+                "Re-syncing the existing push token %s.",
+                pushToken);
+
+        dispatchPushTokenEdgeEvent(pushToken, resetCompleteEvent);
+    }
+
+    private void dispatchPushTokenEdgeEvent(final String pushToken, final Event event) {
         final Map<String, Object> edgeIdentitySharedState =
                 getXDMSharedState(
                         MessagingConstants.SharedState.EdgeIdentity.EXTENSION_NAME, event);
@@ -502,20 +555,6 @@ public final class MessagingExtension extends Extension {
                 eventData,
                 getApi(),
                 event);
-    }
-
-    /**
-     * Handles the reset identities event by setting a null push token in the Messaging shared state
-     * and by removing the persisted push token from the Messaging {@link
-     * com.adobe.marketing.mobile.services.NamedCollection}
-     *
-     * @param resetIdentitiesEvent the reset identities {@link Event}
-     */
-    private void handleResetIdentitiesEvent(final Event resetIdentitiesEvent) {
-        // remove the push token from the shared state
-        createMessagingSharedState(null, resetIdentitiesEvent);
-        // remove the push token from the named collection
-        InternalMessagingUtils.persistPushToken(null);
     }
 
     /**
@@ -915,11 +954,17 @@ public final class MessagingExtension extends Extension {
     }
 
     private boolean eventIsValid(final Event event) {
-        return event != null && event.getEventData() != null;
+        return (event != null && event.getEventData() != null)
+                || isRequestResetEvent(event)
+                || isResetCompleteEvent(event);
     }
 
     private boolean isRequestResetEvent(final Event event) {
         return event != null && event.getSource().equals(EventSource.REQUEST_RESET);
+    }
+
+    private boolean isResetCompleteEvent(final Event event) {
+        return event != null && event.getSource().equals(EventSource.RESET_COMPLETE);
     }
 
     private void createMessagingSharedState(final String pushToken, final Event event) {

--- a/code/messaging/src/test/java/com/adobe/marketing/mobile/messaging/MessagingExtensionTests.java
+++ b/code/messaging/src/test/java/com/adobe/marketing/mobile/messaging/MessagingExtensionTests.java
@@ -28,7 +28,6 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isNull;
-import static org.mockito.ArgumentMatchers.nullable;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockStatic;
 import static org.mockito.Mockito.never;
@@ -350,7 +349,7 @@ public class MessagingExtensionTests {
                                                     .PUSH_IDENTIFIER),
                                     any());
                     verify(mockExtensionApi, times(1))
-                            .createSharedState(argThat(map -> map.containsValue(null)), isNull());
+                            .createSharedState(argThat(Map::isEmpty), isNull());
                 });
     }
 
@@ -1482,17 +1481,15 @@ public class MessagingExtensionTests {
                         messagingExtension.processEvent(mockEvent);
 
                         // verify
-                        // messaging shared state cleared by adding a null push token
+                        // messaging shared state cleared by adding an empty state
                         verify(mockExtensionApi, times(1))
-                                .createSharedState(
-                                        argThat(map -> map.containsValue(null)), eq(mockEvent));
+                                .createSharedState(argThat(Map::isEmpty), eq(mockEvent));
 
-                        // verify null push token added to named collection
+                        // verify push token removed from named collection
                         verify(mockNamedCollection, times(1))
-                                .setString(
+                                .remove(
                                         MessagingConstants.NamedCollectionKeys.Messaging
-                                                .PUSH_IDENTIFIER,
-                                        eq(nullable(String.class)));
+                                                .PUSH_IDENTIFIER);
                     }
                 });
     }

--- a/code/testapp/src/main/java/com/adobe/marketing/mobile/messagingsample/MainActivity.kt
+++ b/code/testapp/src/main/java/com/adobe/marketing/mobile/messagingsample/MainActivity.kt
@@ -322,6 +322,10 @@ class MainActivity : ComponentActivity() {
                 MobileCore.setPushIdentifier(token)
             }
         }
+
+        binding.btnResetIdentities.setOnClickListener {
+            MobileCore.resetIdentities()
+        }
     }
 
     private suspend fun getRegToken(): String {

--- a/code/testapp/src/main/java/com/adobe/marketing/mobile/messagingsample/MessagingApplication.kt
+++ b/code/testapp/src/main/java/com/adobe/marketing/mobile/messagingsample/MessagingApplication.kt
@@ -19,13 +19,12 @@ import com.adobe.marketing.mobile.MobileCore
 import com.adobe.marketing.mobile.LoggingMode
 import com.adobe.marketing.mobile.Lifecycle
 import com.adobe.marketing.mobile.edge.identity.Identity
-import com.google.firebase.messaging.FirebaseMessaging
 
 class MessagingApplication : Application() {
     private val ENVIRONMENT_FILE_ID = "3149c49c3910/4f6b2fbf2986/launch-7d78a5fd1de3-development"
     private val ASSURANCE_SESSION_ID = ""
     private val STAGING_APP_ID = "staging/1b50a869c4a2/bcd1a623883f/launch-e44d085fc760-development"
-    private val STAGING = true
+    private val STAGING = false
 
     override fun onCreate() {
         super.onCreate()

--- a/code/testapp/src/main/res/layout/activity_main.xml
+++ b/code/testapp/src/main/res/layout/activity_main.xml
@@ -92,6 +92,12 @@
         android:id="@+id/btn_setPushIdentifier"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="set push identifier" />
+        android:text="Set push identifier" />
+
+    <Button
+        android:id="@+id/btn_resetIdentities"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Reset identities" />
 
 </androidx.appcompat.widget.LinearLayoutCompat>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
A new ECID is generated when the resetIdentities API is called. The Messaging extension should clear the existing push token from Messaging shared state and persistence when a resetIdentities event is received. The app developer will then be responsible for syncing the push token with the newly generated ECID.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
