### PR TITLE
Expose a IAM object's key value pairs

### DIFF
--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/Message.java
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/Message.java
@@ -51,13 +51,13 @@ public interface Message {
     }
 
     /**
-     * Gets the {@link Message}'s custom data which is the metadata present in the {@code
+     * Gets the {@link Message}'s custom metadata which is the metadata present in the {@code
      * InAppSchemaData} created from the {@code Message} payload.
      *
-     * @return @code Map<String, Object>} containing the custom data present in the {@code Message}
-     *     payload.
+     * @return @code Map<String, Object>} containing the custom metadata present in the {@code
+     *     Message} payload.
      */
-    default Map<String, Object> getCustomData() {
+    default Map<String, Object> getMetadata() {
         return Collections.emptyMap();
     }
 }

--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/Message.java
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/Message.java
@@ -11,6 +11,9 @@
 
 package com.adobe.marketing.mobile;
 
+import java.util.Collections;
+import java.util.Map;
+
 public interface Message {
     /**
      * Dispatch tracking information via a Messaging request content event.
@@ -45,5 +48,16 @@ public interface Message {
      */
     default boolean getAutoTrack() {
         return true;
+    }
+
+    /**
+     * Gets the {@link Message}'s custom data which is the metadata present in the {@code
+     * InAppSchemaData} created from the {@code Message} payload.
+     *
+     * @return @code Map<String, Object>} containing the custom data present in the {@code Message}
+     *     payload.
+     */
+    default Map<String, Object> getCustomData() {
+        return Collections.emptyMap();
     }
 }

--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/PresentableMessageMapper.java
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/PresentableMessageMapper.java
@@ -24,6 +24,7 @@ import com.adobe.marketing.mobile.services.ui.UIService;
 import com.adobe.marketing.mobile.services.ui.message.InAppMessageSettings;
 import com.adobe.marketing.mobile.util.DataReader;
 import com.adobe.marketing.mobile.util.DefaultPresentationUtilityProvider;
+import com.adobe.marketing.mobile.util.MapUtils;
 import com.adobe.marketing.mobile.util.StringUtils;
 import java.util.HashMap;
 import java.util.Map;
@@ -215,6 +216,12 @@ class PresentableMessageMapper {
             }
 
             customData = inAppSchemaData.getMeta();
+            Log.debug(
+                    MessagingConstants.LOG_TAG,
+                    SELF_TAG,
+                    MapUtils.isNullOrEmpty(customData)
+                            ? "No in-app message custom data found in the proposition payload."
+                            : "Found in-app message custom data in the proposition payload.");
 
             try {
                 final String html = (String) inAppSchemaData.getContent();

--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/PresentableMessageMapper.java
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/PresentableMessageMapper.java
@@ -26,6 +26,7 @@ import com.adobe.marketing.mobile.util.DataReader;
 import com.adobe.marketing.mobile.util.DefaultPresentationUtilityProvider;
 import com.adobe.marketing.mobile.util.MapUtils;
 import com.adobe.marketing.mobile.util.StringUtils;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -129,7 +130,7 @@ class PresentableMessageMapper {
         private final String id;
         private final MessagingExtension messagingExtension;
         private final Presentable<InAppMessage> aepMessage;
-        private final Map<String, Object> customData;
+        private final Map<String, Object> metadata;
 
         private boolean autoTrack = true;
         // package private
@@ -215,13 +216,13 @@ class PresentableMessageMapper {
                                 + " empty.");
             }
 
-            customData = inAppSchemaData.getMeta();
+            metadata = inAppSchemaData.getMeta();
             Log.debug(
                     MessagingConstants.LOG_TAG,
                     SELF_TAG,
-                    MapUtils.isNullOrEmpty(customData)
-                            ? "No in-app message custom data found in the proposition payload."
-                            : "Found in-app message custom data in the proposition payload.");
+                    MapUtils.isNullOrEmpty(metadata)
+                            ? "No in-app message custom metadata found in the proposition payload."
+                            : "Found in-app message custom metadata in the proposition payload.");
 
             try {
                 final String html = (String) inAppSchemaData.getContent();
@@ -254,8 +255,8 @@ class PresentableMessageMapper {
         }
 
         @Override
-        public Map<String, Object> getCustomData() {
-            return customData;
+        public Map<String, Object> getMetadata() {
+            return metadata != null ? metadata : Collections.emptyMap();
         }
 
         /**

--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/PresentableMessageMapper.java
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/PresentableMessageMapper.java
@@ -128,6 +128,7 @@ class PresentableMessageMapper {
         private final String id;
         private final MessagingExtension messagingExtension;
         private final Presentable<InAppMessage> aepMessage;
+        private final Map<String, Object> customData;
 
         private boolean autoTrack = true;
         // package private
@@ -213,6 +214,8 @@ class PresentableMessageMapper {
                                 + " empty.");
             }
 
+            customData = inAppSchemaData.getMeta();
+
             try {
                 final String html = (String) inAppSchemaData.getContent();
                 if (StringUtils.isNullOrEmpty(html)) {
@@ -241,6 +244,11 @@ class PresentableMessageMapper {
                 throw new MessageRequiredFieldMissingException(
                         "Required field: in-app message content is not of type String.");
             }
+        }
+
+        @Override
+        public Map<String, Object> getCustomData() {
+            return customData;
         }
 
         /**

--- a/code/messaging/src/test/java/com/adobe/marketing/mobile/messaging/PresentableMessageMapperTests.java
+++ b/code/messaging/src/test/java/com/adobe/marketing/mobile/messaging/PresentableMessageMapperTests.java
@@ -116,7 +116,6 @@ public class PresentableMessageMapperTests {
     }
 
     PropositionItem createPropositionItem() throws MessageRequiredFieldMissingException {
-        // Create complex metadata with different data types
         Map<String, Object> meta = new HashMap<>();
         meta.put("key", "value");
         Map<String, Object> data = new HashMap<>();
@@ -977,10 +976,10 @@ public class PresentableMessageMapperTests {
     }
 
     // ========================================================================================
-    // Message getCustomData tests
+    // Message getMetadata tests
     // ========================================================================================
     @Test
-    public void test_messageGetCustomData_WithMetaData() {
+    public void test_messageGetMetadata_withMeta() {
         // setup
         runUsingMockedServiceProvider(
                 () -> {
@@ -998,16 +997,16 @@ public class PresentableMessageMapperTests {
                     }
 
                     // test
-                    Map<String, Object> customData = internalMessage.getCustomData();
+                    Map<String, Object> metadata = internalMessage.getMetadata();
 
                     // verify
-                    assertNotNull(customData);
-                    assertEquals("value", customData.get("key"));
+                    assertNotNull(metadata);
+                    assertEquals("value", metadata.get("key"));
                 });
     }
 
     @Test
-    public void test_messageGetCustomData_WithEmptyMetaData() {
+    public void test_messageGetMetadata_withEmptyMeta() {
         // setup
         runUsingMockedServiceProvider(
                 () -> {
@@ -1027,16 +1026,16 @@ public class PresentableMessageMapperTests {
                     }
 
                     // test
-                    Map<String, Object> customData = internalMessage.getCustomData();
+                    Map<String, Object> metadata = internalMessage.getMetadata();
 
                     // verify
-                    assertNotNull(customData);
-                    assertTrue(customData.isEmpty());
+                    assertNotNull(metadata);
+                    assertTrue(metadata.isEmpty());
                 });
     }
 
     @Test
-    public void test_messageGetCustomData_WithNullMetaData() {
+    public void test_messageGetMetadata_withNullMeta() {
         // setup
         runUsingMockedServiceProvider(
                 () -> {
@@ -1056,15 +1055,16 @@ public class PresentableMessageMapperTests {
                     }
 
                     // test
-                    Map<String, Object> customData = internalMessage.getCustomData();
+                    Map<String, Object> metadata = internalMessage.getMetadata();
 
-                    // verify
-                    assertNull(customData);
+                    // verify, metadata is always non-null
+                    assertNotNull(metadata);
+                    assertTrue(metadata.isEmpty());
                 });
     }
 
     @Test
-    public void test_messageGetCustomData_WithComplexMetaData() {
+    public void test_messageGetMetadata_withComplexMeta() {
         // setup
         runUsingMockedServiceProvider(
                 () -> {
@@ -1084,24 +1084,24 @@ public class PresentableMessageMapperTests {
                     }
 
                     // test
-                    Map<String, Object> customData = internalMessage.getCustomData();
+                    Map<String, Object> metadata = internalMessage.getMetadata();
 
                     // verify
-                    assertNotNull(customData);
-                    assertEquals("stringValue", customData.get("stringKey"));
-                    assertEquals(42, customData.get("intKey"));
-                    assertEquals(true, customData.get("boolKey"));
+                    assertNotNull(metadata);
+                    assertEquals("stringValue", metadata.get("stringKey"));
+                    assertEquals(42, metadata.get("intKey"));
+                    assertEquals(true, metadata.get("boolKey"));
 
                     // Verify nested object
                     @SuppressWarnings("unchecked")
                     Map<String, Object> nestedObject =
-                            (Map<String, Object>) customData.get("objectKey");
+                            (Map<String, Object>) metadata.get("objectKey");
                     assertNotNull(nestedObject);
                     assertEquals("nestedValue", nestedObject.get("nestedKey"));
 
                     // Verify array
                     @SuppressWarnings("unchecked")
-                    List<Object> arrayValue = (List<Object>) customData.get("arrayKey");
+                    List<Object> arrayValue = (List<Object>) metadata.get("arrayKey");
                     assertNotNull(arrayValue);
                     assertEquals(3, arrayValue.size());
                     assertEquals("item1", arrayValue.get(0));
@@ -1111,7 +1111,7 @@ public class PresentableMessageMapperTests {
     }
 
     @Test
-    public void test_messageGetCustomData_DefaultInterfaceImplementation() {
+    public void test_messageGetMetadata_DefaultInterfaceImplementation() {
         // test
         Message message =
                 new Message() {
@@ -1134,11 +1134,11 @@ public class PresentableMessageMapperTests {
                 };
 
         // test
-        Map<String, Object> customData = message.getCustomData();
+        Map<String, Object> metadata = message.getMetadata();
 
         // verify
-        assertNotNull(customData);
-        assertTrue(customData.isEmpty());
+        assertNotNull(metadata);
+        assertTrue(metadata.isEmpty());
     }
 
     // ========================================================================================

--- a/code/messaging/src/test/java/com/adobe/marketing/mobile/messaging/PresentableMessageMapperTests.java
+++ b/code/messaging/src/test/java/com/adobe/marketing/mobile/messaging/PresentableMessageMapperTests.java
@@ -13,6 +13,7 @@ package com.adobe.marketing.mobile.messaging;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -35,7 +36,9 @@ import com.adobe.marketing.mobile.services.ui.message.InAppMessageEventHandler;
 import com.adobe.marketing.mobile.services.ui.message.InAppMessageSettings;
 import com.adobe.marketing.mobile.services.uri.UriOpening;
 import com.adobe.marketing.mobile.util.DefaultPresentationUtilityProvider;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -113,11 +116,67 @@ public class PresentableMessageMapperTests {
     }
 
     PropositionItem createPropositionItem() throws MessageRequiredFieldMissingException {
+        // Create complex metadata with different data types
+        Map<String, Object> meta = new HashMap<>();
+        meta.put("key", "value");
         Map<String, Object> data = new HashMap<>();
         data.put(MessagingTestConstants.ConsequenceDetailDataKeys.CONTENT, html);
         data.put(
                 MessagingTestConstants.ConsequenceDetailDataKeys.CONTENT_TYPE,
                 ContentType.TEXT_HTML.toString());
+        data.put(MessagingTestConstants.ConsequenceDetailDataKeys.METADATA, meta);
+        return new PropositionItem("123456789", SchemaType.INAPP, data);
+    }
+
+    PropositionItem createPropositionItemWithEmptyMeta()
+            throws MessageRequiredFieldMissingException {
+        Map<String, Object> data = new HashMap<>();
+        data.put(MessagingTestConstants.ConsequenceDetailDataKeys.CONTENT, html);
+        data.put(
+                MessagingTestConstants.ConsequenceDetailDataKeys.CONTENT_TYPE,
+                ContentType.TEXT_HTML.toString());
+        data.put(MessagingTestConstants.ConsequenceDetailDataKeys.METADATA, new HashMap<>());
+        return new PropositionItem("123456789", SchemaType.INAPP, data);
+    }
+
+    PropositionItem createPropositionItemWithNullMeta()
+            throws MessageRequiredFieldMissingException {
+        Map<String, Object> data = new HashMap<>();
+        data.put(MessagingTestConstants.ConsequenceDetailDataKeys.CONTENT, html);
+        data.put(
+                MessagingTestConstants.ConsequenceDetailDataKeys.CONTENT_TYPE,
+                ContentType.TEXT_HTML.toString());
+        data.put(MessagingTestConstants.ConsequenceDetailDataKeys.METADATA, null);
+        return new PropositionItem("123456789", SchemaType.INAPP, data);
+    }
+
+    PropositionItem createPropositionItemWithComplexMeta()
+            throws MessageRequiredFieldMissingException {
+        Map<String, Object> data = new HashMap<>();
+        data.put(MessagingTestConstants.ConsequenceDetailDataKeys.CONTENT, html);
+        data.put(
+                MessagingTestConstants.ConsequenceDetailDataKeys.CONTENT_TYPE,
+                ContentType.TEXT_HTML.toString());
+
+        // Create complex metadata with different data types
+        Map<String, Object> meta = new HashMap<>();
+        meta.put("stringKey", "stringValue");
+        meta.put("intKey", 42);
+        meta.put("boolKey", true);
+
+        // Nested object
+        Map<String, Object> nestedObject = new HashMap<>();
+        nestedObject.put("nestedKey", "nestedValue");
+        meta.put("objectKey", nestedObject);
+
+        // Array
+        List<String> arrayValue = new ArrayList<>();
+        arrayValue.add("item1");
+        arrayValue.add("item2");
+        arrayValue.add("item3");
+        meta.put("arrayKey", arrayValue);
+
+        data.put(MessagingTestConstants.ConsequenceDetailDataKeys.METADATA, meta);
         return new PropositionItem("123456789", SchemaType.INAPP, data);
     }
 
@@ -915,6 +974,171 @@ public class PresentableMessageMapperTests {
                     // verify no tracking event
                     verify(mockMessagingExtension, times(0)).sendPropositionInteraction(any());
                 });
+    }
+
+    // ========================================================================================
+    // Message getCustomData tests
+    // ========================================================================================
+    @Test
+    public void test_messageGetCustomData_WithMetaData() {
+        // setup
+        runUsingMockedServiceProvider(
+                () -> {
+                    try {
+                        internalMessage =
+                                (PresentableMessageMapper.InternalMessage)
+                                        PresentableMessageMapper.getInstance()
+                                                .createMessage(
+                                                        mockMessagingExtension,
+                                                        createPropositionItem(),
+                                                        new HashMap<>(),
+                                                        null);
+                    } catch (Exception exception) {
+                        fail(exception.getMessage());
+                    }
+
+                    // test
+                    Map<String, Object> customData = internalMessage.getCustomData();
+
+                    // verify
+                    assertNotNull(customData);
+                    assertEquals("value", customData.get("key"));
+                });
+    }
+
+    @Test
+    public void test_messageGetCustomData_WithEmptyMetaData() {
+        // setup
+        runUsingMockedServiceProvider(
+                () -> {
+                    try {
+                        // Create a proposition item with empty metadata
+                        PropositionItem propositionItem = createPropositionItemWithEmptyMeta();
+                        internalMessage =
+                                (PresentableMessageMapper.InternalMessage)
+                                        PresentableMessageMapper.getInstance()
+                                                .createMessage(
+                                                        mockMessagingExtension,
+                                                        propositionItem,
+                                                        new HashMap<>(),
+                                                        null);
+                    } catch (Exception exception) {
+                        fail(exception.getMessage());
+                    }
+
+                    // test
+                    Map<String, Object> customData = internalMessage.getCustomData();
+
+                    // verify
+                    assertNotNull(customData);
+                    assertTrue(customData.isEmpty());
+                });
+    }
+
+    @Test
+    public void test_messageGetCustomData_WithNullMetaData() {
+        // setup
+        runUsingMockedServiceProvider(
+                () -> {
+                    try {
+                        // Create a proposition item with null metadata
+                        PropositionItem propositionItem = createPropositionItemWithNullMeta();
+                        internalMessage =
+                                (PresentableMessageMapper.InternalMessage)
+                                        PresentableMessageMapper.getInstance()
+                                                .createMessage(
+                                                        mockMessagingExtension,
+                                                        propositionItem,
+                                                        new HashMap<>(),
+                                                        null);
+                    } catch (Exception exception) {
+                        fail(exception.getMessage());
+                    }
+
+                    // test
+                    Map<String, Object> customData = internalMessage.getCustomData();
+
+                    // verify
+                    assertNull(customData);
+                });
+    }
+
+    @Test
+    public void test_messageGetCustomData_WithComplexMetaData() {
+        // setup
+        runUsingMockedServiceProvider(
+                () -> {
+                    try {
+                        // Create a proposition item with complex metadata
+                        PropositionItem propositionItem = createPropositionItemWithComplexMeta();
+                        internalMessage =
+                                (PresentableMessageMapper.InternalMessage)
+                                        PresentableMessageMapper.getInstance()
+                                                .createMessage(
+                                                        mockMessagingExtension,
+                                                        propositionItem,
+                                                        new HashMap<>(),
+                                                        null);
+                    } catch (Exception exception) {
+                        fail(exception.getMessage());
+                    }
+
+                    // test
+                    Map<String, Object> customData = internalMessage.getCustomData();
+
+                    // verify
+                    assertNotNull(customData);
+                    assertEquals("stringValue", customData.get("stringKey"));
+                    assertEquals(42, customData.get("intKey"));
+                    assertEquals(true, customData.get("boolKey"));
+
+                    // Verify nested object
+                    @SuppressWarnings("unchecked")
+                    Map<String, Object> nestedObject =
+                            (Map<String, Object>) customData.get("objectKey");
+                    assertNotNull(nestedObject);
+                    assertEquals("nestedValue", nestedObject.get("nestedKey"));
+
+                    // Verify array
+                    @SuppressWarnings("unchecked")
+                    List<Object> arrayValue = (List<Object>) customData.get("arrayKey");
+                    assertNotNull(arrayValue);
+                    assertEquals(3, arrayValue.size());
+                    assertEquals("item1", arrayValue.get(0));
+                    assertEquals("item2", arrayValue.get(1));
+                    assertEquals("item3", arrayValue.get(2));
+                });
+    }
+
+    @Test
+    public void test_messageGetCustomData_DefaultInterfaceImplementation() {
+        // test
+        Message message =
+                new Message() {
+                    @Override
+                    public void track(String interaction, MessagingEdgeEventType eventType) {}
+
+                    @Override
+                    public void show() {}
+
+                    @Override
+                    public void dismiss() {}
+
+                    @Override
+                    public String getId() {
+                        return "testId";
+                    }
+
+                    @Override
+                    public void setAutoTrack(boolean enabled) {}
+                };
+
+        // test
+        Map<String, Object> customData = message.getCustomData();
+
+        // verify
+        assertNotNull(customData);
+        assertTrue(customData.isEmpty());
     }
 
     // ========================================================================================


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Add Message.getMetadata() which exposes the "meta" property of the IAM proposition. The "meta" property contains the custom key/value pairs set in the IAM editor UI.


Jira: MOB-23681

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
