### PR TITLE
Rename composable classes to remove suffix

### DIFF
--- a/Documentation/sources/content-card-ui/public-classes/Styles/imageonlyuistyle.md
+++ b/Documentation/sources/content-card-ui/public-classes/Styles/imageonlyuistyle.md
@@ -2,6 +2,8 @@
 
 Class representing the style for an image-only AEP UI.
 
+![Image Only Card Composeable Layout](../../../../assets/image-only-card-layout.png)
+
 ## Public Properties
 
 | Property               | Type                                                         | Description                                                  |

--- a/Documentation/sources/content-card-ui/public-classes/Styles/largeimageuistyle.md
+++ b/Documentation/sources/content-card-ui/public-classes/Styles/largeimageuistyle.md
@@ -2,6 +2,8 @@
 
 Class representing the style for a large image AEP UI.
 
+![Large Image Card Composeable Layout](../../../../assets/large-image-card-layout.png)
+
 ## Public Properties
 
 | Property               | Type                                                         | Description                                                  |

--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/aepcomposeui/components/AepAsyncImage.kt
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/aepcomposeui/components/AepAsyncImage.kt
@@ -43,7 +43,7 @@ import com.adobe.marketing.mobile.messaging.ContentCardImageManager
  * @param onError Callback invoked when there is an error loading the image.
  */
 @Composable
-internal fun AepAsyncImageComposable(
+internal fun AepAsyncImage(
     image: AepImage?,
     imageStyle: AepImageStyle = AepImageStyle(),
     onSuccess: (Bitmap) -> Unit = {},
@@ -86,7 +86,7 @@ internal fun AepAsyncImageComposable(
         }
     } else {
         imageBitmap?.let {
-            AepImageComposable(
+            AepImage(
                 content = BitmapPainter(it.asImageBitmap()),
                 imageStyle = imageStyle
             )

--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/aepcomposeui/components/AepButton.kt
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/aepcomposeui/components/AepButton.kt
@@ -31,7 +31,7 @@ import com.adobe.marketing.mobile.aepcomposeui.uimodels.AepText
  * @param buttonStyle The [AepButtonStyle] to be applied to the button element.
  */
 @Composable
-internal fun AepButtonComposable(
+internal fun AepButton(
     model: AepButton,
     onClick: () -> Unit,
     buttonStyle: AepButtonStyle = AepButtonStyle(),
@@ -47,7 +47,7 @@ internal fun AepButtonComposable(
         contentPadding = buttonStyle.contentPadding ?: ButtonDefaults.ContentPadding,
         interactionSource = buttonStyle.interactionSource ?: remember { MutableInteractionSource() }
     ) {
-        AepTextComposable(
+        AepText(
             model.text,
             buttonStyle.textStyle ?: AepTextStyle(),
         )
@@ -55,7 +55,7 @@ internal fun AepButtonComposable(
 }
 
 /**
- * Preview for [AepTextComposable].
+ * Preview for [AepText].
  * This function creates a sample button using predefined schema data for demonstration
  * purposes. It showcases how the button will appear with various styling options.
  */
@@ -63,7 +63,7 @@ internal fun AepButtonComposable(
 @Composable
 internal fun AepButtonComposablePreview() {
     // Render the AepButtonComposable with the properties from AepButton
-    AepButtonComposable(
+    AepButton(
         AepButton(
             id = "button1",
             text = AepText(

--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/aepcomposeui/components/AepButtonRow.kt
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/aepcomposeui/components/AepButtonRow.kt
@@ -26,18 +26,18 @@ import com.adobe.marketing.mobile.aepcomposeui.uimodels.AepButton
  * @param onClick Callback function to be invoked when a button is clicked.
  */
 @Composable
-internal fun AepButtonRowComposable(
+internal fun AepButtonRow(
     buttons: List<AepButton>?,
     buttonsStyle: Array<AepButtonStyle>,
     rowStyle: AepRowStyle = AepRowStyle(),
     onClick: (AepButton) -> Unit = {}
 ) {
     buttons?.let { buttonList ->
-        AepRowComposable(
+        AepRow(
             rowStyle = rowStyle
         ) {
             buttonList.forEachIndexed { index, button ->
-                AepButtonComposable(
+                AepButton(
                     model = button,
                     onClick = { onClick(button) },
                     buttonStyle = buttonsStyle[index].apply {

--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/aepcomposeui/components/AepCard.kt
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/aepcomposeui/components/AepCard.kt
@@ -26,7 +26,7 @@ import com.adobe.marketing.mobile.aepcomposeui.style.AepCardStyle
  * @param content The content of the card.
  */
 @Composable
-internal fun AepCardComposable(
+internal fun AepCard(
     cardStyle: AepCardStyle = AepCardStyle(),
     onClick: () -> Unit = {},
     content: @Composable ColumnScope.() -> Unit

--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/aepcomposeui/components/AepColumn.kt
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/aepcomposeui/components/AepColumn.kt
@@ -26,7 +26,7 @@ import com.adobe.marketing.mobile.aepcomposeui.style.AepColumnStyle
  * @param content The content of the column.
  */
 @Composable
-internal fun AepColumnComposable(
+internal fun AepColumn(
     columnStyle: AepColumnStyle = AepColumnStyle(),
     content: @Composable (ColumnScope.() -> Unit)
 ) {

--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/aepcomposeui/components/AepDismissButton.kt
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/aepcomposeui/components/AepDismissButton.kt
@@ -26,14 +26,14 @@ import com.adobe.marketing.mobile.aepcomposeui.uimodels.AepIcon
  * @param onClick Callback function to be invoked when the button is clicked.
  */
 @Composable
-internal fun AepDismissButtonComposable(
+internal fun AepDismissButton(
     modifier: Modifier,
     dismissIcon: AepIcon?,
     style: AepIconStyle = AepIconStyle(),
     onClick: () -> Unit = {},
 ) {
     dismissIcon?.let {
-        AepIconComposable(
+        AepIcon(
             model = dismissIcon,
             iconStyle = style.apply {
                 this.modifier = (this.modifier ?: Modifier).then(modifier)

--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/aepcomposeui/components/AepIcon.kt
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/aepcomposeui/components/AepIcon.kt
@@ -26,7 +26,7 @@ import com.adobe.marketing.mobile.aepcomposeui.uimodels.AepIcon
  * @param iconStyle The [AepIconStyle] to be applied to the icon element.
  */
 @Composable
-internal fun AepIconComposable(
+internal fun AepIcon(
     model: AepIcon,
     iconStyle: AepIconStyle = AepIconStyle()
 ) {

--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/aepcomposeui/components/AepImage.kt
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/aepcomposeui/components/AepImage.kt
@@ -27,7 +27,7 @@ import com.adobe.marketing.mobile.aepcomposeui.style.AepImageStyle
  * @param imageStyle The [AepImageStyle] to be applied to the image element.
  */
 @Composable
-internal fun AepImageComposable(
+internal fun AepImage(
     content: Painter,
     imageStyle: AepImageStyle = AepImageStyle()
 ) {

--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/aepcomposeui/components/AepRow.kt
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/aepcomposeui/components/AepRow.kt
@@ -26,7 +26,7 @@ import com.adobe.marketing.mobile.aepcomposeui.style.AepRowStyle
  * @param content The content of the row.
  */
 @Composable
-internal fun AepRowComposable(
+internal fun AepRow(
     rowStyle: AepRowStyle = AepRowStyle(),
     content: @Composable RowScope.() -> Unit
 ) {

--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/aepcomposeui/components/AepText.kt
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/aepcomposeui/components/AepText.kt
@@ -32,7 +32,7 @@ import com.adobe.marketing.mobile.aepcomposeui.uimodels.AepText
  * @param textStyle The [AepTextStyle] to be applied to the text element.
  */
 @Composable
-internal fun AepTextComposable(
+internal fun AepText(
     model: AepText,
     textStyle: AepTextStyle = AepTextStyle()
 ) {
@@ -51,7 +51,7 @@ internal fun AepTextComposable(
 }
 
 /**
- * Preview for testing the [AepTextComposable] with various inputs.
+ * Preview for testing the [AepText] with various inputs.
  * This function showcases different variations of text properties, including colors,
  * alignments, fonts, and edge cases.
  */
@@ -68,47 +68,47 @@ internal fun AepTextComposablePreview() {
             .padding(16.dp)
     ) {
         // Basic usage
-        AepTextComposable(AepText(content = "Basic Text"))
+        AepText(AepText(content = "Basic Text"))
 
         // Color variations
-        AepTextComposable(AepText(content = "Red Text"))
-        AepTextComposable(AepText(content = "Green Text"))
-        AepTextComposable(AepText(content = "Blue Text"))
-        AepTextComposable(AepText(content = "Invalid Color")) // Test invalid color
+        AepText(AepText(content = "Red Text"))
+        AepText(AepText(content = "Green Text"))
+        AepText(AepText(content = "Blue Text"))
+        AepText(AepText(content = "Invalid Color")) // Test invalid color
 
         // Alignment variations
-        AepTextComposable(AepText(content = "Left Aligned"))
-        AepTextComposable(AepText(content = "Center Aligned"))
-        AepTextComposable(AepText(content = "Right Aligned"))
-        AepTextComposable(AepText(content = "Invalid Alignment")) // Test invalid alignment
+        AepText(AepText(content = "Left Aligned"))
+        AepText(AepText(content = "Center Aligned"))
+        AepText(AepText(content = "Right Aligned"))
+        AepText(AepText(content = "Invalid Alignment")) // Test invalid alignment
 
         // Font variations
-        AepTextComposable(AepText(content = "Large Text"))
-        AepTextComposable(AepText(content = "Small Text"))
-        AepTextComposable(AepText(content = "Bold Text"))
-        AepTextComposable(AepText(content = "Italic Text"))
-        AepTextComposable(AepText(content = "Bold Italic Text"))
+        AepText(AepText(content = "Large Text"))
+        AepText(AepText(content = "Small Text"))
+        AepText(AepText(content = "Bold Text"))
+        AepText(AepText(content = "Italic Text"))
+        AepText(AepText(content = "Bold Italic Text"))
 
         // Combination of properties
-        AepTextComposable(
+        AepText(
             AepText(
                 content = "Complex Styling",
             )
         )
 
         // Edge cases
-        AepTextComposable(AepText(content = "Empty String")) // Providing valid content instead of empty
-        AepTextComposable(AepText(content = "Very Long Text ".repeat(20))) // Very long text
-        AepTextComposable(AepText(content = "Special Characters: !@#$%^&*()_+{}[]|\\:;\"'<>,.?/"))
-        AepTextComposable(AepText(content = "Multi\nLine\nText")) // Multi-line text
+        AepText(AepText(content = "Empty String")) // Providing valid content instead of empty
+        AepText(AepText(content = "Very Long Text ".repeat(20))) // Very long text
+        AepText(AepText(content = "Special Characters: !@#$%^&*()_+{}[]|\\:;\"'<>,.?/"))
+        AepText(AepText(content = "Multi\nLine\nText")) // Multi-line text
 
         // Null values for optional parameters
-        AepTextComposable(AepText(content = "Null Color"))
-        AepTextComposable(AepText(content = "Null Alignment"))
-        AepTextComposable(AepText(content = "Null Font"))
+        AepText(AepText(content = "Null Color"))
+        AepText(AepText(content = "Null Alignment"))
+        AepText(AepText(content = "Null Font"))
 
         // Extreme font sizes
-        AepTextComposable(AepText(content = "Tiny Text"))
-        AepTextComposable(AepText(content = "Huge Text"))
+        AepText(AepText(content = "Tiny Text"))
+        AepText(AepText(content = "Huge Text"))
     }
 }

--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/aepcomposeui/components/ImageOnlyCard.kt
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/aepcomposeui/components/ImageOnlyCard.kt
@@ -47,7 +47,7 @@ fun ImageOnlyCard(
 
     // Only render the card if the image download is pending or successful.
     if (isImageDownloadPendingOrSuccess) {
-        AepCardComposable(
+        AepCard(
             cardStyle = style.cardStyle,
             onClick = {
                 observer?.onEvent(
@@ -62,14 +62,14 @@ fun ImageOnlyCard(
             }
         ) {
             Box {
-                AepAsyncImageComposable(
+                AepAsyncImage(
                     image = ui.getTemplate().image,
                     imageStyle = style.imageStyle,
                     onError = {
                         isImageDownloadPendingOrSuccess = false
                     }
                 )
-                AepDismissButtonComposable(
+                AepDismissButton(
                     modifier = Modifier.align(style.dismissButtonAlignment),
                     dismissIcon = ui.getTemplate().dismissBtn,
                     style = style.dismissButtonStyle,

--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/aepcomposeui/components/LargeImageCard.kt
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/aepcomposeui/components/LargeImageCard.kt
@@ -39,7 +39,7 @@ fun LargeImageCard(
         observer?.onEvent(UIEvent.Display(ui))
     }
 
-    AepCardComposable(
+    AepCard(
         cardStyle = style.cardStyle,
         onClick = {
             observer?.onEvent(
@@ -54,29 +54,29 @@ fun LargeImageCard(
         }
     ) {
         Box {
-            AepColumnComposable(
+            AepColumn(
                 columnStyle = style.rootColumnStyle
             ) {
-                AepAsyncImageComposable(
+                AepAsyncImage(
                     image = ui.getTemplate().image,
                     imageStyle = style.imageStyle
                 )
-                AepColumnComposable(
+                AepColumn(
                     columnStyle = style.textColumnStyle
                 ) {
                     ui.getTemplate().title.let {
-                        AepTextComposable(
+                        AepText(
                             model = it,
                             textStyle = style.titleTextStyle
                         )
                     }
                     ui.getTemplate().body?.let {
-                        AepTextComposable(
+                        AepText(
                             model = it,
                             textStyle = style.bodyTextStyle
                         )
                     }
-                    AepButtonRowComposable(
+                    AepButtonRow(
                         buttons = ui.getTemplate().buttons,
                         buttonsStyle = style.buttonStyle,
                         rowStyle = style.buttonRowStyle,
@@ -91,7 +91,7 @@ fun LargeImageCard(
                     )
                 }
             }
-            AepDismissButtonComposable(
+            AepDismissButton(
                 modifier = Modifier.align(style.dismissButtonAlignment),
                 dismissIcon = ui.getTemplate().dismissBtn,
                 style = style.dismissButtonStyle,

--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/aepcomposeui/components/SmallImageCard.kt
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/aepcomposeui/components/SmallImageCard.kt
@@ -39,7 +39,7 @@ fun SmallImageCard(
         observer?.onEvent(UIEvent.Display(ui))
     }
 
-    AepCardComposable(
+    AepCard(
         cardStyle = style.cardStyle,
         onClick = {
             observer?.onEvent(
@@ -54,30 +54,30 @@ fun SmallImageCard(
         }
     ) {
         Box {
-            AepRowComposable(
+            AepRow(
                 rowStyle = style.rootRowStyle
             ) {
-                AepAsyncImageComposable(
+                AepAsyncImage(
                     image = ui.getTemplate().image,
                     imageStyle = style.imageStyle
                 )
 
-                AepColumnComposable(
+                AepColumn(
                     columnStyle = style.textColumnStyle
                 ) {
                     ui.getTemplate().title.let {
-                        AepTextComposable(
+                        AepText(
                             model = it,
                             textStyle = style.titleTextStyle
                         )
                     }
                     ui.getTemplate().body?.let {
-                        AepTextComposable(
+                        AepText(
                             model = it,
                             textStyle = style.bodyTextStyle
                         )
                     }
-                    AepButtonRowComposable(
+                    AepButtonRow(
                         buttons = ui.getTemplate().buttons,
                         buttonsStyle = style.buttonStyle,
                         rowStyle = style.buttonRowStyle,
@@ -92,7 +92,7 @@ fun SmallImageCard(
                     )
                 }
             }
-            AepDismissButtonComposable(
+            AepDismissButton(
                 modifier = Modifier.align(style.dismissButtonAlignment),
                 dismissIcon = ui.getTemplate().dismissBtn,
                 style = style.dismissButtonStyle,

--- a/code/messaging/src/test/java/com/adobe/marketing/mobile/aepcomposeui/components/AepAsyncImageTests.kt
+++ b/code/messaging/src/test/java/com/adobe/marketing/mobile/aepcomposeui/components/AepAsyncImageTests.kt
@@ -17,8 +17,6 @@ import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import android.os.Build
 import androidx.activity.ComponentActivity
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.testTag
 import androidx.compose.ui.test.assertCountEquals
@@ -53,7 +51,7 @@ import org.robolectric.annotation.GraphicsMode
 @RunWith(ParameterizedRobolectricTestRunner::class)
 @GraphicsMode(GraphicsMode.Mode.NATIVE)
 @Config(sdk = [33])
-class AepAsyncImageComposableTests(
+class AepAsyncImageTests(
     private val qualifier: String
 ) {
     @get: Rule
@@ -93,7 +91,7 @@ class AepAsyncImageComposableTests(
     }
 
     @Test
-    fun `Test AepAsyncImageComposable shows progress indicator while loading`() {
+    fun `Test AepAsyncImage shows progress indicator while loading`() {
         // setup
         mockkObject(ContentCardImageManager)
         every {
@@ -102,16 +100,16 @@ class AepAsyncImageComposableTests(
 
         // test
         composeTestRule.setContent {
-            AepAsyncImageComposable(image = mockAepImage)
+            AepAsyncImage(image = mockAepImage)
         }
 
         // verify and capture screenshot
         composeTestRule.onRoot()
-            .captureRoboImage("build/outputs/roborazzi/AepAsyncImageComposable_Loading_${Build.VERSION.SDK_INT}_$qualifier.png")
+            .captureRoboImage("build/outputs/roborazzi/AepAsyncImage_Loading_${Build.VERSION.SDK_INT}_$qualifier.png")
     }
 
     @Test
-    fun `Test AepAsyncImageComposable shows image on success`() {
+    fun `Test AepAsyncImage shows image on success`() {
         // setup
         mockkObject(ContentCardImageManager)
         every {
@@ -123,7 +121,7 @@ class AepAsyncImageComposableTests(
 
         // test
         composeTestRule.setContent {
-            AepAsyncImageComposable(
+            AepAsyncImage(
                 image = mockAepImage,
                 onSuccess = { downloadedBitmap = it }
             )
@@ -133,11 +131,11 @@ class AepAsyncImageComposableTests(
         assertNotNull(downloadedBitmap)
         assertEquals(mockLightBitmap, downloadedBitmap)
         composeTestRule.onRoot()
-            .captureRoboImage("build/outputs/roborazzi/AepAsyncImageComposable_Success_${Build.VERSION.SDK_INT}_$qualifier.png")
+            .captureRoboImage("build/outputs/roborazzi/AepAsyncImage_Success_${Build.VERSION.SDK_INT}_$qualifier.png")
     }
 
     @Test
-    fun `Test AepAsyncImageComposable shows dark theme image on success`() {
+    fun `Test AepAsyncImage shows dark theme image on success`() {
         // setup
         val ctx = ApplicationProvider.getApplicationContext<Context>()
         val cfg = ctx.resources.configuration
@@ -155,7 +153,7 @@ class AepAsyncImageComposableTests(
         // test
         composeTestRule.setContent {
             TestTheme(useDarkTheme = true) {
-                AepAsyncImageComposable(
+                AepAsyncImage(
                     image = mockAepImage,
                     onSuccess = { downloadedBitmap = it }
                 )
@@ -166,11 +164,11 @@ class AepAsyncImageComposableTests(
         assertNotNull(downloadedBitmap)
         assertEquals(mockDarkBitmap, downloadedBitmap)
         composeTestRule.onRoot()
-            .captureRoboImage("build/outputs/roborazzi/AepAsyncImageComposable_SuccessDark_${Build.VERSION.SDK_INT}_$qualifier.png")
+            .captureRoboImage("build/outputs/roborazzi/AepAsyncImage_SuccessDark_${Build.VERSION.SDK_INT}_$qualifier.png")
     }
 
     @Test
-    fun `Test AepAsyncImageComposable handles image load failure`() {
+    fun `Test AepAsyncImage handles image load failure`() {
         // setup
         mockkObject(ContentCardImageManager)
         val exception = RuntimeException("Image loading failed")
@@ -183,7 +181,7 @@ class AepAsyncImageComposableTests(
 
         // test
         composeTestRule.setContent {
-            AepAsyncImageComposable(
+            AepAsyncImage(
                 image = mockAepImage,
                 imageStyle = AepImageStyle(
                     modifier = Modifier.testTag("AepImageComposable")
@@ -201,7 +199,7 @@ class AepAsyncImageComposableTests(
     }
 
     @Test
-    fun `Test AepAsyncImageComposable handles null image url`() {
+    fun `Test AepAsyncImage handles null image url`() {
         // setup
         mockkObject(ContentCardImageManager)
         every {
@@ -210,7 +208,7 @@ class AepAsyncImageComposableTests(
 
         // test
         composeTestRule.setContent {
-            AepAsyncImageComposable(image = AepImage(null))
+            AepAsyncImage(image = AepImage(null))
         }
 
         // verify
@@ -223,7 +221,7 @@ class AepAsyncImageComposableTests(
     }
 
     @Test
-    fun `Test AepAsyncImageComposable handles null image`() {
+    fun `Test AepAsyncImage handles null image`() {
         // setup
         mockkObject(ContentCardImageManager)
         every {
@@ -232,7 +230,7 @@ class AepAsyncImageComposableTests(
 
         // test
         composeTestRule.setContent {
-            AepAsyncImageComposable(
+            AepAsyncImage(
                 image = null,
                 imageStyle = AepImageStyle(
                     modifier = Modifier.testTag("AepImageComposable")

--- a/code/messaging/src/test/java/com/adobe/marketing/mobile/aepcomposeui/components/AepButtonRowTests.kt
+++ b/code/messaging/src/test/java/com/adobe/marketing/mobile/aepcomposeui/components/AepButtonRowTests.kt
@@ -1,5 +1,5 @@
 /*
-  Copyright 2024 Adobe. All rights reserved.
+  Copyright 2025 Adobe. All rights reserved.
   This file is licensed to you under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License. You may obtain a copy
   of the License at http://www.apache.org/licenses/LICENSE-2.0
@@ -16,14 +16,14 @@ import androidx.activity.ComponentActivity
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.interaction.Interaction
 import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.shape.CutCornerShape
 import androidx.compose.material3.ButtonColors
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.ReadOnlyComposable
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
@@ -31,6 +31,7 @@ import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onRoot
 import androidx.compose.ui.unit.dp
 import com.adobe.marketing.mobile.aepcomposeui.style.AepButtonStyle
+import com.adobe.marketing.mobile.aepcomposeui.style.AepRowStyle
 import com.adobe.marketing.mobile.aepcomposeui.uimodels.AepButton
 import com.adobe.marketing.mobile.aepcomposeui.uimodels.AepText
 import com.example.compose.TestTheme
@@ -48,24 +49,34 @@ import org.robolectric.annotation.GraphicsMode
 @RunWith(ParameterizedRobolectricTestRunner::class)
 @GraphicsMode(GraphicsMode.Mode.NATIVE)
 @Config(sdk = [33])
-class AepButtonComposableTests(
+class AepButtonRowTests(
     private val qualifier: String
 ) {
     @get: Rule
     val composeTestRule = createAndroidComposeRule<ComponentActivity>()
 
-    private val mockAepText
+    private val mockAepButton1
         @Composable
-        @ReadOnlyComposable
-        get() = AepText(stringResource(id = android.R.string.httpErrorBadUrl))
-
-    private val mockAepButton
-        @Composable
-        @ReadOnlyComposable
         get() = AepButton(
-            id = "mockId",
-            actionUrl = "mockActionUrl",
-            text = mockAepText,
+            id = "mockId1",
+            actionUrl = "mockActionUrl1",
+            text = AepText(stringResource(id = android.R.string.ok)),
+        )
+
+    private val mockAepButton2
+        @Composable
+        get() = AepButton(
+            id = "mockId2",
+            actionUrl = "mockActionUrl2",
+            text = AepText(stringResource(id = android.R.string.cancel)),
+        )
+
+    private val mockAepButton3
+        @Composable
+        get() = AepButton(
+            id = "mockId3",
+            actionUrl = "mockActionUrl3",
+            text = AepText(stringResource(id = android.R.string.unknownName)),
         )
 
     companion object {
@@ -77,37 +88,41 @@ class AepButtonComposableTests(
     }
 
     @Test
-    fun `Test AepButtonComposable with default style`() {
+    fun `Test AepButtonRow with three buttons and default style`() {
         // setup
         RuntimeEnvironment.setQualifiers(qualifier)
 
         // test
         setComposeContent(
-            composeTestRule, qualifier
+            composeTestRule,
+            qualifier
         ) {
-            AepButtonComposable(
-                model = mockAepButton,
+            AepButtonRow(
+                buttons = listOf(mockAepButton1, mockAepButton2, mockAepButton3),
+                buttonsStyle = arrayOf(AepButtonStyle(), AepButtonStyle(), AepButtonStyle()),
                 onClick = { }
             )
         }
 
         // Capture screenshot
         composeTestRule.onRoot()
-            .captureRoboImage(filePath = "build/outputs/roborazzi/AepButtonComposableTests_${Build.VERSION.SDK_INT}_$qualifier.png")
+            .captureRoboImage(filePath = "build/outputs/roborazzi/AepButtonRowTestsDefault_${Build.VERSION.SDK_INT}_$qualifier.png")
     }
 
     @Test
-    fun `Test AepButtonComposable with default style in dark theme`() {
+    fun `Test AepButtonRow with three buttons and default style in dark theme`() {
         // setup
         RuntimeEnvironment.setQualifiers(qualifier)
 
         // test
         setComposeContent(
-            composeTestRule, qualifier
+            composeTestRule,
+            qualifier
         ) {
             TestTheme(useDarkTheme = true) {
-                AepButtonComposable(
-                    model = mockAepButton,
+                AepButtonRow(
+                    buttons = listOf(mockAepButton1, mockAepButton2, mockAepButton3),
+                    buttonsStyle = arrayOf(AepButtonStyle(), AepButtonStyle(), AepButtonStyle()),
                     onClick = { }
                 )
             }
@@ -115,102 +130,72 @@ class AepButtonComposableTests(
 
         // Capture screenshot
         composeTestRule.onRoot()
-            .captureRoboImage(filePath = "build/outputs/roborazzi/AepButtonComposableTestsDarkTheme_${Build.VERSION.SDK_INT}_$qualifier.png")
+            .captureRoboImage(filePath = "build/outputs/roborazzi/AepButtonRowTestsDefaultDark_${Build.VERSION.SDK_INT}_$qualifier.png")
     }
 
     @Test
-    fun `Test custom style is applied to enabled AepButtonComposable`() {
+    fun `Test AepButtonRow with three buttons and custom style`() {
         // setup
         RuntimeEnvironment.setQualifiers(qualifier)
 
         // test
         setComposeContent(
-            composeTestRule, qualifier
+            composeTestRule,
+            qualifier
         ) {
-            AepButtonComposable(
-                model = mockAepButton,
-                onClick = {},
-                buttonStyle = mockCustomAepButtonStyle(true)
+            AepButtonRow(
+                buttons = listOf(mockAepButton1, mockAepButton2, mockAepButton3),
+                buttonsStyle = arrayOf(mockCustomAepButtonStyle(), mockCustomAepButtonStyle(), mockCustomAepButtonStyle()),
+                rowStyle = AepRowStyle(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.SpaceEvenly,
+                    verticalAlignment = Alignment.CenterVertically
+                ),
+                onClick = { }
             )
         }
 
         // Capture screenshot
         composeTestRule.onRoot()
-            .captureRoboImage(filePath = "build/outputs/roborazzi/AepButtonComposableTestsCustomStyleEnabled_${Build.VERSION.SDK_INT}_$qualifier.png")
+            .captureRoboImage(filePath = "build/outputs/roborazzi/AepButtonRowTestsCustom_${Build.VERSION.SDK_INT}_$qualifier.png")
     }
 
     @Test
-    fun `Test custom style is applied to disabled AepButtonComposable`() {
+    fun `Test AepButtonRow with three buttons and custom style in dark theme`() {
         // setup
         RuntimeEnvironment.setQualifiers(qualifier)
 
         // test
         setComposeContent(
-            composeTestRule, qualifier
-        ) {
-            AepButtonComposable(
-                model = mockAepButton,
-                onClick = { },
-                buttonStyle = mockCustomAepButtonStyle(false)
-            )
-        }
-
-        // Capture screenshot
-        composeTestRule.onRoot()
-            .captureRoboImage(filePath = "build/outputs/roborazzi/AepButtonComposableTestsCustomStyleDisabled_${Build.VERSION.SDK_INT}_$qualifier.png")
-    }
-
-    @Test
-    fun `Test custom style is applied to enabled AepButtonComposable in dark theme`() {
-        // setup
-        RuntimeEnvironment.setQualifiers(qualifier)
-
-        // test
-        setComposeContent(
-            composeTestRule, qualifier
+            composeTestRule,
+            qualifier
         ) {
             TestTheme(useDarkTheme = true) {
-                AepButtonComposable(
-                    model = mockAepButton,
-                    onClick = { },
-                    buttonStyle = mockCustomAepButtonStyle(true)
+                AepButtonRow(
+                    buttons = listOf(mockAepButton1, mockAepButton2, mockAepButton3),
+                    buttonsStyle = arrayOf(
+                        mockCustomAepButtonStyle(),
+                        mockCustomAepButtonStyle(),
+                        mockCustomAepButtonStyle()
+                    ),
+                    rowStyle = AepRowStyle(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.spacedBy(5.dp),
+                        verticalAlignment = Alignment.CenterVertically
+                    ),
+                    onClick = { }
                 )
             }
         }
 
         // Capture screenshot
         composeTestRule.onRoot()
-            .captureRoboImage(filePath = "build/outputs/roborazzi/AepButtonComposableTestsCustomStyleEnabledDarkTheme_${Build.VERSION.SDK_INT}_$qualifier.png")
-    }
-
-    @Test
-    fun `Test custom style is applied to disabled AepButtonComposable in dark theme`() {
-        // setup
-        RuntimeEnvironment.setQualifiers(qualifier)
-
-        // test
-        setComposeContent(
-            composeTestRule, qualifier
-        ) {
-            TestTheme(useDarkTheme = false) {
-                AepButtonComposable(
-                    model = mockAepButton,
-                    onClick = { },
-                    buttonStyle = mockCustomAepButtonStyle(false)
-                )
-            }
-        }
-
-        // Capture screenshot
-        composeTestRule.onRoot()
-            .captureRoboImage(filePath = "build/outputs/roborazzi/AepButtonComposableTestsCustomStyleDisabledDarkTheme_${Build.VERSION.SDK_INT}_$qualifier.png")
+            .captureRoboImage(filePath = "build/outputs/roborazzi/AepButtonRowTestsCustomDark_${Build.VERSION.SDK_INT}_$qualifier.png")
     }
 
     @Composable
-    private fun mockCustomAepButtonStyle(enabled: Boolean): AepButtonStyle {
+    private fun mockCustomAepButtonStyle(): AepButtonStyle {
         return AepButtonStyle(
-            modifier = Modifier.height(50.dp).width(200.dp),
-            enabled = enabled,
             elevation = ButtonDefaults.buttonElevation(
                 defaultElevation = 10.dp,
                 pressedElevation = 10.dp,
@@ -232,13 +217,8 @@ class AepButtonComposableTests(
     }
 
     class NoEffectInteractionSource : MutableInteractionSource {
-        override val interactions: Flow<Interaction> = emptyFlow() // No interactions emitted
-        override suspend fun emit(interaction: Interaction) {
-            // Do nothing
-        }
-
-        override fun tryEmit(interaction: Interaction): Boolean {
-            return false
-        }
+        override val interactions: Flow<Interaction> = emptyFlow()
+        override suspend fun emit(interaction: Interaction) {}
+        override fun tryEmit(interaction: Interaction): Boolean = false
     }
 }

--- a/code/messaging/src/test/java/com/adobe/marketing/mobile/aepcomposeui/components/AepButtonTests.kt
+++ b/code/messaging/src/test/java/com/adobe/marketing/mobile/aepcomposeui/components/AepButtonTests.kt
@@ -1,5 +1,5 @@
 /*
-  Copyright 2025 Adobe. All rights reserved.
+  Copyright 2024 Adobe. All rights reserved.
   This file is licensed to you under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License. You may obtain a copy
   of the License at http://www.apache.org/licenses/LICENSE-2.0
@@ -16,14 +16,14 @@ import androidx.activity.ComponentActivity
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.interaction.Interaction
 import androidx.compose.foundation.interaction.MutableInteractionSource
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CutCornerShape
 import androidx.compose.material3.ButtonColors
 import androidx.compose.material3.ButtonDefaults
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
+import androidx.compose.runtime.ReadOnlyComposable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.res.stringResource
@@ -31,7 +31,6 @@ import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onRoot
 import androidx.compose.ui.unit.dp
 import com.adobe.marketing.mobile.aepcomposeui.style.AepButtonStyle
-import com.adobe.marketing.mobile.aepcomposeui.style.AepRowStyle
 import com.adobe.marketing.mobile.aepcomposeui.uimodels.AepButton
 import com.adobe.marketing.mobile.aepcomposeui.uimodels.AepText
 import com.example.compose.TestTheme
@@ -49,34 +48,24 @@ import org.robolectric.annotation.GraphicsMode
 @RunWith(ParameterizedRobolectricTestRunner::class)
 @GraphicsMode(GraphicsMode.Mode.NATIVE)
 @Config(sdk = [33])
-class AepButtonRowComposableTests(
+class AepButtonTests(
     private val qualifier: String
 ) {
     @get: Rule
     val composeTestRule = createAndroidComposeRule<ComponentActivity>()
 
-    private val mockAepButton1
+    private val mockAepText
         @Composable
-        get() = AepButton(
-            id = "mockId1",
-            actionUrl = "mockActionUrl1",
-            text = AepText(stringResource(id = android.R.string.ok)),
-        )
+        @ReadOnlyComposable
+        get() = AepText(stringResource(id = android.R.string.httpErrorBadUrl))
 
-    private val mockAepButton2
+    private val mockAepButton
         @Composable
+        @ReadOnlyComposable
         get() = AepButton(
-            id = "mockId2",
-            actionUrl = "mockActionUrl2",
-            text = AepText(stringResource(id = android.R.string.cancel)),
-        )
-
-    private val mockAepButton3
-        @Composable
-        get() = AepButton(
-            id = "mockId3",
-            actionUrl = "mockActionUrl3",
-            text = AepText(stringResource(id = android.R.string.unknownName)),
+            id = "mockId",
+            actionUrl = "mockActionUrl",
+            text = mockAepText,
         )
 
     companion object {
@@ -88,41 +77,37 @@ class AepButtonRowComposableTests(
     }
 
     @Test
-    fun `Test AepButtonRowComposable with three buttons and default style`() {
+    fun `Test AepButton with default style`() {
         // setup
         RuntimeEnvironment.setQualifiers(qualifier)
 
         // test
         setComposeContent(
-            composeTestRule,
-            qualifier
+            composeTestRule, qualifier
         ) {
-            AepButtonRowComposable(
-                buttons = listOf(mockAepButton1, mockAepButton2, mockAepButton3),
-                buttonsStyle = arrayOf(AepButtonStyle(), AepButtonStyle(), AepButtonStyle()),
+            AepButton(
+                model = mockAepButton,
                 onClick = { }
             )
         }
 
         // Capture screenshot
         composeTestRule.onRoot()
-            .captureRoboImage(filePath = "build/outputs/roborazzi/AepButtonRowComposableTestsDefault_${Build.VERSION.SDK_INT}_$qualifier.png")
+            .captureRoboImage(filePath = "build/outputs/roborazzi/AepButtonTests_${Build.VERSION.SDK_INT}_$qualifier.png")
     }
 
     @Test
-    fun `Test AepButtonRowComposable with three buttons and default style in dark theme`() {
+    fun `Test AepButton with default style in dark theme`() {
         // setup
         RuntimeEnvironment.setQualifiers(qualifier)
 
         // test
         setComposeContent(
-            composeTestRule,
-            qualifier
+            composeTestRule, qualifier
         ) {
             TestTheme(useDarkTheme = true) {
-                AepButtonRowComposable(
-                    buttons = listOf(mockAepButton1, mockAepButton2, mockAepButton3),
-                    buttonsStyle = arrayOf(AepButtonStyle(), AepButtonStyle(), AepButtonStyle()),
+                AepButton(
+                    model = mockAepButton,
                     onClick = { }
                 )
             }
@@ -130,72 +115,102 @@ class AepButtonRowComposableTests(
 
         // Capture screenshot
         composeTestRule.onRoot()
-            .captureRoboImage(filePath = "build/outputs/roborazzi/AepButtonRowComposableTestsDefaultDark_${Build.VERSION.SDK_INT}_$qualifier.png")
+            .captureRoboImage(filePath = "build/outputs/roborazzi/AepButtonTestsDarkTheme_${Build.VERSION.SDK_INT}_$qualifier.png")
     }
 
     @Test
-    fun `Test AepButtonRowComposable with three buttons and custom style`() {
+    fun `Test custom style is applied to enabled AepButton`() {
         // setup
         RuntimeEnvironment.setQualifiers(qualifier)
 
         // test
         setComposeContent(
-            composeTestRule,
-            qualifier
+            composeTestRule, qualifier
         ) {
-            AepButtonRowComposable(
-                buttons = listOf(mockAepButton1, mockAepButton2, mockAepButton3),
-                buttonsStyle = arrayOf(mockCustomAepButtonStyle(), mockCustomAepButtonStyle(), mockCustomAepButtonStyle()),
-                rowStyle = AepRowStyle(
-                    modifier = Modifier.fillMaxWidth(),
-                    horizontalArrangement = Arrangement.SpaceEvenly,
-                    verticalAlignment = Alignment.CenterVertically
-                ),
-                onClick = { }
+            AepButton(
+                model = mockAepButton,
+                onClick = {},
+                buttonStyle = mockCustomAepButtonStyle(true)
             )
         }
 
         // Capture screenshot
         composeTestRule.onRoot()
-            .captureRoboImage(filePath = "build/outputs/roborazzi/AepButtonRowComposableTestsCustom_${Build.VERSION.SDK_INT}_$qualifier.png")
+            .captureRoboImage(filePath = "build/outputs/roborazzi/AepButtonTestsCustomStyleEnabled_${Build.VERSION.SDK_INT}_$qualifier.png")
     }
 
     @Test
-    fun `Test AepButtonRowComposable with three buttons and custom style in dark theme`() {
+    fun `Test custom style is applied to disabled AepButton`() {
         // setup
         RuntimeEnvironment.setQualifiers(qualifier)
 
         // test
         setComposeContent(
-            composeTestRule,
-            qualifier
+            composeTestRule, qualifier
+        ) {
+            AepButton(
+                model = mockAepButton,
+                onClick = { },
+                buttonStyle = mockCustomAepButtonStyle(false)
+            )
+        }
+
+        // Capture screenshot
+        composeTestRule.onRoot()
+            .captureRoboImage(filePath = "build/outputs/roborazzi/AepButtonTestsCustomStyleDisabled_${Build.VERSION.SDK_INT}_$qualifier.png")
+    }
+
+    @Test
+    fun `Test custom style is applied to enabled AepButton in dark theme`() {
+        // setup
+        RuntimeEnvironment.setQualifiers(qualifier)
+
+        // test
+        setComposeContent(
+            composeTestRule, qualifier
         ) {
             TestTheme(useDarkTheme = true) {
-                AepButtonRowComposable(
-                    buttons = listOf(mockAepButton1, mockAepButton2, mockAepButton3),
-                    buttonsStyle = arrayOf(
-                        mockCustomAepButtonStyle(),
-                        mockCustomAepButtonStyle(),
-                        mockCustomAepButtonStyle()
-                    ),
-                    rowStyle = AepRowStyle(
-                        modifier = Modifier.fillMaxWidth(),
-                        horizontalArrangement = Arrangement.spacedBy(5.dp),
-                        verticalAlignment = Alignment.CenterVertically
-                    ),
-                    onClick = { }
+                AepButton(
+                    model = mockAepButton,
+                    onClick = { },
+                    buttonStyle = mockCustomAepButtonStyle(true)
                 )
             }
         }
 
         // Capture screenshot
         composeTestRule.onRoot()
-            .captureRoboImage(filePath = "build/outputs/roborazzi/AepButtonRowComposableTestsCustomDark_${Build.VERSION.SDK_INT}_$qualifier.png")
+            .captureRoboImage(filePath = "build/outputs/roborazzi/AepButtonTestsCustomStyleEnabledDarkTheme_${Build.VERSION.SDK_INT}_$qualifier.png")
+    }
+
+    @Test
+    fun `Test custom style is applied to disabled AepButton in dark theme`() {
+        // setup
+        RuntimeEnvironment.setQualifiers(qualifier)
+
+        // test
+        setComposeContent(
+            composeTestRule, qualifier
+        ) {
+            TestTheme(useDarkTheme = false) {
+                AepButton(
+                    model = mockAepButton,
+                    onClick = { },
+                    buttonStyle = mockCustomAepButtonStyle(false)
+                )
+            }
+        }
+
+        // Capture screenshot
+        composeTestRule.onRoot()
+            .captureRoboImage(filePath = "build/outputs/roborazzi/AepButtonTestsCustomStyleDisabledDarkTheme_${Build.VERSION.SDK_INT}_$qualifier.png")
     }
 
     @Composable
-    private fun mockCustomAepButtonStyle(): AepButtonStyle {
+    private fun mockCustomAepButtonStyle(enabled: Boolean): AepButtonStyle {
         return AepButtonStyle(
+            modifier = Modifier.height(50.dp).width(200.dp),
+            enabled = enabled,
             elevation = ButtonDefaults.buttonElevation(
                 defaultElevation = 10.dp,
                 pressedElevation = 10.dp,
@@ -217,8 +232,13 @@ class AepButtonRowComposableTests(
     }
 
     class NoEffectInteractionSource : MutableInteractionSource {
-        override val interactions: Flow<Interaction> = emptyFlow()
-        override suspend fun emit(interaction: Interaction) {}
-        override fun tryEmit(interaction: Interaction): Boolean = false
+        override val interactions: Flow<Interaction> = emptyFlow() // No interactions emitted
+        override suspend fun emit(interaction: Interaction) {
+            // Do nothing
+        }
+
+        override fun tryEmit(interaction: Interaction): Boolean {
+            return false
+        }
     }
 }

--- a/code/messaging/src/test/java/com/adobe/marketing/mobile/aepcomposeui/components/AepCardTests.kt
+++ b/code/messaging/src/test/java/com/adobe/marketing/mobile/aepcomposeui/components/AepCardTests.kt
@@ -42,15 +42,15 @@ import org.robolectric.annotation.GraphicsMode
 @RunWith(ParameterizedRobolectricTestRunner::class)
 @GraphicsMode(GraphicsMode.Mode.NATIVE)
 @Config(sdk = [33])
-class AepCardComposableTests(
+class AepCardTests(
     private val qualifier: String
 ) {
     @get: Rule
     val composeTestRule = createAndroidComposeRule<ComponentActivity>()
 
-    private val MockAepTextComposable
+    private val mockAepText
         @Composable
-        get() = AepTextComposable(AepText(stringResource(id = android.R.string.httpErrorBadUrl)))
+        get() = AepText(AepText(stringResource(id = android.R.string.httpErrorBadUrl)))
 
     companion object {
         @JvmStatic
@@ -61,7 +61,7 @@ class AepCardComposableTests(
     }
 
     @Test
-    fun `Test AepCardComposable with default style`() {
+    fun `Test AepCard with default style`() {
         // setup
         RuntimeEnvironment.setQualifiers(qualifier)
 
@@ -69,18 +69,18 @@ class AepCardComposableTests(
         setComposeContent(
             composeTestRule, qualifier
         ) {
-            AepCardComposable {
-                MockAepTextComposable
+            AepCard {
+                mockAepText
             }
         }
 
         // Capture screenshot
         composeTestRule.onRoot()
-            .captureRoboImage(filePath = "build/outputs/roborazzi/AepCardComposableTests_${Build.VERSION.SDK_INT}_$qualifier.png")
+            .captureRoboImage(filePath = "build/outputs/roborazzi/AepCardTests_${Build.VERSION.SDK_INT}_$qualifier.png")
     }
 
     @Test
-    fun `Test AepCardComposable with default style in dark theme`() {
+    fun `Test AepCard with default style in dark theme`() {
         // setup
         RuntimeEnvironment.setQualifiers(qualifier)
 
@@ -89,19 +89,19 @@ class AepCardComposableTests(
             composeTestRule, qualifier
         ) {
             TestTheme(useDarkTheme = true) {
-                AepCardComposable {
-                    MockAepTextComposable
+                AepCard {
+                    mockAepText
                 }
             }
         }
 
         // Capture screenshot
         composeTestRule.onRoot()
-            .captureRoboImage(filePath = "build/outputs/roborazzi/AepCardComposableTestsDarkTheme_${Build.VERSION.SDK_INT}_$qualifier.png")
+            .captureRoboImage(filePath = "build/outputs/roborazzi/AepCardTestsDarkTheme_${Build.VERSION.SDK_INT}_$qualifier.png")
     }
 
     @Test
-    fun `Test custom style applied to enabled AepCardComposable`() {
+    fun `Test custom style applied to enabled AepCard`() {
         // setup
         RuntimeEnvironment.setQualifiers(qualifier)
 
@@ -109,20 +109,20 @@ class AepCardComposableTests(
         setComposeContent(
             composeTestRule, qualifier
         ) {
-            AepCardComposable(
+            AepCard(
                 cardStyle = mockCustomAepCardStyle(enabled = true)
             ) {
-                MockAepTextComposable
+                mockAepText
             }
         }
 
         // Capture screenshot
         composeTestRule.onRoot()
-            .captureRoboImage(filePath = "build/outputs/roborazzi/AepCardComposableTestsCustomStyleEnabled_${Build.VERSION.SDK_INT}_$qualifier.png")
+            .captureRoboImage(filePath = "build/outputs/roborazzi/AepCardTestsCustomStyleEnabled_${Build.VERSION.SDK_INT}_$qualifier.png")
     }
 
     @Test
-    fun `Test custom style applied to disabled AepCardComposable`() {
+    fun `Test custom style applied to disabled AepCard`() {
         // setup
         RuntimeEnvironment.setQualifiers(qualifier)
 
@@ -130,20 +130,20 @@ class AepCardComposableTests(
         setComposeContent(
             composeTestRule, qualifier
         ) {
-            AepCardComposable(
+            AepCard(
                 cardStyle = mockCustomAepCardStyle(enabled = false)
             ) {
-                MockAepTextComposable
+                mockAepText
             }
         }
 
         // Capture screenshot
         composeTestRule.onRoot()
-            .captureRoboImage(filePath = "build/outputs/roborazzi/AepCardComposableTestsCustomStyleDisabled_${Build.VERSION.SDK_INT}_$qualifier.png")
+            .captureRoboImage(filePath = "build/outputs/roborazzi/AepCardTestsCustomStyleDisabled_${Build.VERSION.SDK_INT}_$qualifier.png")
     }
 
     @Test
-    fun `Test custom style applied to enabled AepCardComposable in dark theme`() {
+    fun `Test custom style applied to enabled AepCard in dark theme`() {
         // setup
         RuntimeEnvironment.setQualifiers(qualifier)
 
@@ -152,21 +152,21 @@ class AepCardComposableTests(
             composeTestRule, qualifier
         ) {
             TestTheme(useDarkTheme = true) {
-                AepCardComposable(
+                AepCard(
                     cardStyle = mockCustomAepCardStyle(enabled = true)
                 ) {
-                    MockAepTextComposable
+                    mockAepText
                 }
             }
         }
 
         // Capture screenshot
         composeTestRule.onRoot()
-            .captureRoboImage(filePath = "build/outputs/roborazzi/AepCardComposableTestsCustomStyleEnabledDarkTheme_${Build.VERSION.SDK_INT}_$qualifier.png")
+            .captureRoboImage(filePath = "build/outputs/roborazzi/AepCardTestsCustomStyleEnabledDarkTheme_${Build.VERSION.SDK_INT}_$qualifier.png")
     }
 
     @Test
-    fun `Test custom style applied to disabled AepCardComposable in dark theme`() {
+    fun `Test custom style applied to disabled AepCard in dark theme`() {
         // setup
         RuntimeEnvironment.setQualifiers(qualifier)
 
@@ -175,17 +175,17 @@ class AepCardComposableTests(
             composeTestRule, qualifier
         ) {
             TestTheme(useDarkTheme = true) {
-                AepCardComposable(
+                AepCard(
                     cardStyle = mockCustomAepCardStyle(enabled = false)
                 ) {
-                    MockAepTextComposable
+                    mockAepText
                 }
             }
         }
 
         // Capture screenshot
         composeTestRule.onRoot()
-            .captureRoboImage(filePath = "build/outputs/roborazzi/AepCardComposableTestsCustomStyleDisabledDarkTheme_${Build.VERSION.SDK_INT}_$qualifier.png")
+            .captureRoboImage(filePath = "build/outputs/roborazzi/AepCardTestsCustomStyleDisabledDarkTheme_${Build.VERSION.SDK_INT}_$qualifier.png")
     }
 
     @Composable

--- a/code/messaging/src/test/java/com/adobe/marketing/mobile/aepcomposeui/components/AepColumnTests.kt
+++ b/code/messaging/src/test/java/com/adobe/marketing/mobile/aepcomposeui/components/AepColumnTests.kt
@@ -15,9 +15,9 @@ import android.os.Build
 import androidx.activity.ComponentActivity
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -26,7 +26,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onRoot
 import androidx.compose.ui.unit.dp
-import com.adobe.marketing.mobile.aepcomposeui.style.AepRowStyle
+import com.adobe.marketing.mobile.aepcomposeui.style.AepColumnStyle
 import com.adobe.marketing.mobile.aepcomposeui.uimodels.AepText
 import com.github.takahirom.roborazzi.captureRoboImage
 import org.junit.Rule
@@ -40,15 +40,15 @@ import org.robolectric.annotation.GraphicsMode
 @RunWith(ParameterizedRobolectricTestRunner::class)
 @GraphicsMode(GraphicsMode.Mode.NATIVE)
 @Config(sdk = [33])
-class AepRowComposableTests(
+class AepColumnTests(
     private val qualifier: String
 ) {
     @get: Rule
     val composeTestRule = createAndroidComposeRule<ComponentActivity>()
 
-    private val MockAepTextComposable
+    private val mockAepText
         @Composable
-        get() = AepTextComposable(AepText(stringResource(id = android.R.string.httpErrorBadUrl)))
+        get() = AepText(AepText(stringResource(id = android.R.string.httpErrorBadUrl)))
 
     companion object {
         @JvmStatic
@@ -59,7 +59,7 @@ class AepRowComposableTests(
     }
 
     @Test
-    fun `Test AepRowComposable with default style`() {
+    fun `Test AepColumn with default style`() {
         // setup
         RuntimeEnvironment.setQualifiers(qualifier)
 
@@ -67,18 +67,18 @@ class AepRowComposableTests(
         setComposeContent(
             composeTestRule, qualifier
         ) {
-            AepRowComposable {
-                MockAepTextComposable
+            AepColumn {
+                mockAepText
             }
         }
 
         // Capture screenshot
         composeTestRule.onRoot()
-            .captureRoboImage(filePath = "build/outputs/roborazzi/AepRowComposableTests_${Build.VERSION.SDK_INT}_$qualifier.png")
+            .captureRoboImage(filePath = "build/outputs/roborazzi/AepColumnTests_${Build.VERSION.SDK_INT}_$qualifier.png")
     }
 
     @Test
-    fun `Test custom style applied to AepRowComposable`() {
+    fun `Test custom style applied to AepColumn`() {
         // setup
         RuntimeEnvironment.setQualifiers(qualifier)
 
@@ -86,23 +86,23 @@ class AepRowComposableTests(
         setComposeContent(
             composeTestRule, qualifier
         ) {
-            AepRowComposable(
-                rowStyle = AepRowStyle(
+            AepColumn(
+                columnStyle = AepColumnStyle(
                     modifier = Modifier
-                        .height(100.dp)
-                        .fillMaxWidth()
+                        .fillMaxHeight()
+                        .width(500.dp)
                         .background(Color(0xFF0065db))
                         .padding(10.dp),
-                    horizontalArrangement = Arrangement.End,
-                    verticalAlignment = Alignment.Bottom
+                    verticalArrangement = Arrangement.Bottom,
+                    horizontalAlignment = Alignment.End
                 )
             ) {
-                MockAepTextComposable
+                mockAepText
             }
         }
 
         // Capture screenshot
         composeTestRule.onRoot()
-            .captureRoboImage(filePath = "build/outputs/roborazzi/AepRowComposableTestsCustomStyle_${Build.VERSION.SDK_INT}_$qualifier.png")
+            .captureRoboImage(filePath = "build/outputs/roborazzi/AepColumnTestsCustomStyle_${Build.VERSION.SDK_INT}_$qualifier.png")
     }
 }

--- a/code/messaging/src/test/java/com/adobe/marketing/mobile/aepcomposeui/components/AepDismissButtonTests.kt
+++ b/code/messaging/src/test/java/com/adobe/marketing/mobile/aepcomposeui/components/AepDismissButtonTests.kt
@@ -40,7 +40,7 @@ import org.robolectric.annotation.GraphicsMode
 @RunWith(ParameterizedRobolectricTestRunner::class)
 @GraphicsMode(GraphicsMode.Mode.NATIVE)
 @Config(sdk = [33])
-class AepDismissButtonComposableTests(
+class AepDismissButtonTests(
     private val qualifier: String
 ) {
     @get: Rule
@@ -59,7 +59,7 @@ class AepDismissButtonComposableTests(
     }
 
     @Test
-    fun `Test AepDismissButtonComposable with default style`() {
+    fun `Test AepDismissButton with default style`() {
         // setup
         RuntimeEnvironment.setQualifiers(qualifier)
 
@@ -68,7 +68,7 @@ class AepDismissButtonComposableTests(
             composeTestRule,
             qualifier
         ) {
-            AepDismissButtonComposable(
+            AepDismissButton(
                 modifier = Modifier,
                 dismissIcon = mockAepIcon,
                 onClick = {}
@@ -77,11 +77,11 @@ class AepDismissButtonComposableTests(
 
         // Capture screenshot
         composeTestRule.onRoot()
-            .captureRoboImage(filePath = "build/outputs/roborazzi/AepDismissButtonComposableTests_Default_${Build.VERSION.SDK_INT}_$qualifier.png")
+            .captureRoboImage(filePath = "build/outputs/roborazzi/AepDismissButtonTests_Default_${Build.VERSION.SDK_INT}_$qualifier.png")
     }
 
     @Test
-    fun `Test AepDismissButtonComposable with default style in dark theme`() {
+    fun `Test AepDismissButton with default style in dark theme`() {
         // setup
         RuntimeEnvironment.setQualifiers(qualifier)
 
@@ -91,7 +91,7 @@ class AepDismissButtonComposableTests(
             qualifier
         ) {
             TestTheme(useDarkTheme = true) {
-                AepDismissButtonComposable(
+                AepDismissButton(
                     modifier = Modifier,
                     dismissIcon = mockAepIcon,
                     onClick = {}
@@ -101,11 +101,11 @@ class AepDismissButtonComposableTests(
 
         // Capture screenshot
         composeTestRule.onRoot()
-            .captureRoboImage(filePath = "build/outputs/roborazzi/AepDismissButtonComposableTests_DefaultDark_${Build.VERSION.SDK_INT}_$qualifier.png")
+            .captureRoboImage(filePath = "build/outputs/roborazzi/AepDismissButtonTests_DefaultDark_${Build.VERSION.SDK_INT}_$qualifier.png")
     }
 
     @Test
-    fun `Test AepDismissButtonComposable with custom style`() {
+    fun `Test AepDismissButton with custom style`() {
         // setup
         RuntimeEnvironment.setQualifiers(qualifier)
         val customStyle = AepIconStyle(
@@ -118,7 +118,7 @@ class AepDismissButtonComposableTests(
             composeTestRule,
             qualifier
         ) {
-            AepDismissButtonComposable(
+            AepDismissButton(
                 modifier = Modifier,
                 dismissIcon = mockAepIcon,
                 style = customStyle,
@@ -128,11 +128,11 @@ class AepDismissButtonComposableTests(
 
         // Capture screenshot
         composeTestRule.onRoot()
-            .captureRoboImage(filePath = "build/outputs/roborazzi/AepDismissButtonComposableTests_Custom_${Build.VERSION.SDK_INT}_$qualifier.png")
+            .captureRoboImage(filePath = "build/outputs/roborazzi/AepDismissButtonTests_Custom_${Build.VERSION.SDK_INT}_$qualifier.png")
     }
 
     @Test
-    fun `Test AepDismissButtonComposable with custom style in dark theme`() {
+    fun `Test AepDismissButton with custom style in dark theme`() {
         // setup
         RuntimeEnvironment.setQualifiers(qualifier)
         val customStyle = AepIconStyle(
@@ -146,7 +146,7 @@ class AepDismissButtonComposableTests(
             qualifier
         ) {
             TestTheme(useDarkTheme = true) {
-                AepDismissButtonComposable(
+                AepDismissButton(
                     modifier = Modifier,
                     dismissIcon = mockAepIcon,
                     style = customStyle,
@@ -157,17 +157,17 @@ class AepDismissButtonComposableTests(
 
         // Capture screenshot
         composeTestRule.onRoot()
-            .captureRoboImage(filePath = "build/outputs/roborazzi/AepDismissButtonComposableTests_CustomDark_${Build.VERSION.SDK_INT}_$qualifier.png")
+            .captureRoboImage(filePath = "build/outputs/roborazzi/AepDismissButtonTests_CustomDark_${Build.VERSION.SDK_INT}_$qualifier.png")
     }
 
     @Test
-    fun `Test AepDismissButtonComposable onClick is called`() {
+    fun `Test AepDismissButton onClick is called`() {
         // setup
         var clicked by mutableStateOf(false)
 
         // test
         composeTestRule.setContent {
-            AepDismissButtonComposable(
+            AepDismissButton(
                 modifier = Modifier.testTag("test"),
                 dismissIcon = mockAepIcon,
                 onClick = { clicked = true }

--- a/code/messaging/src/test/java/com/adobe/marketing/mobile/aepcomposeui/components/AepIconTests.kt
+++ b/code/messaging/src/test/java/com/adobe/marketing/mobile/aepcomposeui/components/AepIconTests.kt
@@ -37,7 +37,7 @@ import org.robolectric.annotation.GraphicsMode
 @RunWith(ParameterizedRobolectricTestRunner::class)
 @GraphicsMode(GraphicsMode.Mode.NATIVE)
 @Config(sdk = [33])
-class AepIconComposableTests(
+class AepIconTests(
     private val qualifier: String
 ) {
     @get: Rule
@@ -59,14 +59,14 @@ class AepIconComposableTests(
     }
 
     @Test
-    fun `Test AepIconComposable with default style`() {
+    fun `Test AepIcon with default style`() {
         // setup
         RuntimeEnvironment.setQualifiers(qualifier)
 
         // test
         composeTestRule.setContent {
             CompositionLocalProvider(LocalContentColor provides Color.LightGray) {
-                AepIconComposable(
+                AepIcon(
                     model = AepIcon(iconContent),
                 )
             }
@@ -74,11 +74,11 @@ class AepIconComposableTests(
 
         // Capture screenshot
         composeTestRule.onRoot()
-            .captureRoboImage(filePath = "build/outputs/roborazzi/AepIconComposableTests_${Build.VERSION.SDK_INT}_$qualifier.png")
+            .captureRoboImage(filePath = "build/outputs/roborazzi/AepIconTests_${Build.VERSION.SDK_INT}_$qualifier.png")
     }
 
     @Test
-    fun `Test AepIconComposable with default style in dark theme`() {
+    fun `Test AepIcon with default style in dark theme`() {
         // setup
         RuntimeEnvironment.setQualifiers(qualifier)
 
@@ -87,7 +87,7 @@ class AepIconComposableTests(
             composeTestRule, qualifier
         ) {
             TestTheme(useDarkTheme = true) {
-                AepIconComposable(
+                AepIcon(
                     model = AepIcon(iconContent),
                 )
             }
@@ -95,11 +95,11 @@ class AepIconComposableTests(
 
         // Capture screenshot
         composeTestRule.onRoot()
-            .captureRoboImage(filePath = "build/outputs/roborazzi/AepIconComposableTestsDarkTheme_${Build.VERSION.SDK_INT}_$qualifier.png")
+            .captureRoboImage(filePath = "build/outputs/roborazzi/AepIconTestsDarkTheme_${Build.VERSION.SDK_INT}_$qualifier.png")
     }
 
     @Test
-    fun `Test custom style is applied to AepIconComposable`() {
+    fun `Test custom style is applied to AepIcon`() {
         // setup
         RuntimeEnvironment.setQualifiers(qualifier)
 
@@ -108,7 +108,7 @@ class AepIconComposableTests(
             composeTestRule, qualifier
         ) {
             TestTheme(useDarkTheme = true) {
-                AepIconComposable(
+                AepIcon(
                     model = AepIcon(iconContent),
                     iconStyle = mockAepIconStyle
                 )
@@ -117,11 +117,11 @@ class AepIconComposableTests(
 
         // Capture screenshot
         composeTestRule.onRoot()
-            .captureRoboImage(filePath = "build/outputs/roborazzi/AepIconComposableTestsCustomStyle_${Build.VERSION.SDK_INT}_$qualifier.png")
+            .captureRoboImage(filePath = "build/outputs/roborazzi/AepIconTestsCustomStyle_${Build.VERSION.SDK_INT}_$qualifier.png")
     }
 
     @Test
-    fun `Test custom style is applied to AepIconComposable in dark mode`() {
+    fun `Test custom style is applied to AepIcon in dark mode`() {
         // setup
         RuntimeEnvironment.setQualifiers(qualifier)
 
@@ -129,7 +129,7 @@ class AepIconComposableTests(
         composeTestRule.setContent {
             CompositionLocalProvider(LocalContentColor provides Color.LightGray) {
                 TestTheme(useDarkTheme = true) {
-                    AepIconComposable(
+                    AepIcon(
                         model = AepIcon(iconContent),
                         iconStyle = mockAepIconStyle
                     )
@@ -139,6 +139,6 @@ class AepIconComposableTests(
 
         // Capture screenshot
         composeTestRule.onRoot()
-            .captureRoboImage(filePath = "build/outputs/roborazzi/AepIconComposableTestsCustomStyleDarkTheme_${Build.VERSION.SDK_INT}_$qualifier.png")
+            .captureRoboImage(filePath = "build/outputs/roborazzi/AepIconTestsCustomStyleDarkTheme_${Build.VERSION.SDK_INT}_$qualifier.png")
     }
 }

--- a/code/messaging/src/test/java/com/adobe/marketing/mobile/aepcomposeui/components/AepImageTests.kt
+++ b/code/messaging/src/test/java/com/adobe/marketing/mobile/aepcomposeui/components/AepImageTests.kt
@@ -13,21 +13,20 @@ package com.adobe.marketing.mobile.aepcomposeui.components
 
 import android.os.Build
 import androidx.activity.ComponentActivity
-import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.fillMaxHeight
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onRoot
 import androidx.compose.ui.unit.dp
-import com.adobe.marketing.mobile.aepcomposeui.style.AepColumnStyle
-import com.adobe.marketing.mobile.aepcomposeui.uimodels.AepText
+import com.adobe.marketing.mobile.aepcomposeui.style.AepImageStyle
 import com.github.takahirom.roborazzi.captureRoboImage
 import org.junit.Rule
 import org.junit.Test
@@ -40,15 +39,14 @@ import org.robolectric.annotation.GraphicsMode
 @RunWith(ParameterizedRobolectricTestRunner::class)
 @GraphicsMode(GraphicsMode.Mode.NATIVE)
 @Config(sdk = [33])
-class AepColumnComposableTests(
+class AepImageTests(
     private val qualifier: String
 ) {
     @get: Rule
     val composeTestRule = createAndroidComposeRule<ComponentActivity>()
-
-    private val MockAepTextComposable
+    private val imageContent: Painter
         @Composable
-        get() = AepTextComposable(AepText(stringResource(id = android.R.string.httpErrorBadUrl)))
+        get() = painterResource(id = android.R.drawable.ic_menu_report_image)
 
     companion object {
         @JvmStatic
@@ -59,7 +57,7 @@ class AepColumnComposableTests(
     }
 
     @Test
-    fun `Test AepColumnComposable with default style`() {
+    fun `Test AepImage with default style`() {
         // setup
         RuntimeEnvironment.setQualifiers(qualifier)
 
@@ -67,18 +65,18 @@ class AepColumnComposableTests(
         setComposeContent(
             composeTestRule, qualifier
         ) {
-            AepColumnComposable {
-                MockAepTextComposable
-            }
+            AepImage(
+                content = imageContent,
+            )
         }
 
         // Capture screenshot
         composeTestRule.onRoot()
-            .captureRoboImage(filePath = "build/outputs/roborazzi/AepColumnComposableTests_${Build.VERSION.SDK_INT}_$qualifier.png")
+            .captureRoboImage(filePath = "build/outputs/roborazzi/AepImageTests_${Build.VERSION.SDK_INT}_$qualifier.png")
     }
 
     @Test
-    fun `Test custom style applied to AepColumnComposable`() {
+    fun `Test AepImage with default style in dark theme`() {
         // setup
         RuntimeEnvironment.setQualifiers(qualifier)
 
@@ -86,23 +84,40 @@ class AepColumnComposableTests(
         setComposeContent(
             composeTestRule, qualifier
         ) {
-            AepColumnComposable(
-                columnStyle = AepColumnStyle(
-                    modifier = Modifier
-                        .fillMaxHeight()
-                        .width(500.dp)
-                        .background(Color(0xFF0065db))
-                        .padding(10.dp),
-                    verticalArrangement = Arrangement.Bottom,
-                    horizontalAlignment = Alignment.End
-                )
-            ) {
-                MockAepTextComposable
-            }
+            AepImage(
+                content = imageContent,
+            )
         }
 
         // Capture screenshot
         composeTestRule.onRoot()
-            .captureRoboImage(filePath = "build/outputs/roborazzi/AepColumnComposableTestsCustomStyle_${Build.VERSION.SDK_INT}_$qualifier.png")
+            .captureRoboImage(filePath = "build/outputs/roborazzi/AepImageTestsDarkTheme_${Build.VERSION.SDK_INT}_$qualifier.png")
+    }
+
+    @Test
+    fun `Test custom style applied to AepImage`() {
+        // setup
+        RuntimeEnvironment.setQualifiers(qualifier)
+
+        // test
+        setComposeContent(
+            composeTestRule, qualifier
+        ) {
+            AepImage(
+                content = imageContent,
+                imageStyle = AepImageStyle(
+                    modifier = Modifier.size(500.dp).aspectRatio(1.5f),
+                    contentDescription = "Test Image",
+                    alignment = Alignment.BottomEnd,
+                    contentScale = ContentScale.Fit,
+                    alpha = 0.85f,
+                    colorFilter = ColorFilter.tint(Color(0xFF0065db))
+                )
+            )
+        }
+
+        // Capture screenshot
+        composeTestRule.onRoot()
+            .captureRoboImage(filePath = "build/outputs/roborazzi/AepImageTestsCustomStyle_${Build.VERSION.SDK_INT}_$qualifier.png")
     }
 }

--- a/code/messaging/src/test/java/com/adobe/marketing/mobile/aepcomposeui/components/AepRowTests.kt
+++ b/code/messaging/src/test/java/com/adobe/marketing/mobile/aepcomposeui/components/AepRowTests.kt
@@ -13,20 +13,21 @@ package com.adobe.marketing.mobile.aepcomposeui.components
 
 import android.os.Build
 import androidx.activity.ComponentActivity
-import androidx.compose.foundation.layout.aspectRatio
-import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.ColorFilter
-import androidx.compose.ui.graphics.painter.Painter
-import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.compose.ui.test.onRoot
 import androidx.compose.ui.unit.dp
-import com.adobe.marketing.mobile.aepcomposeui.style.AepImageStyle
+import com.adobe.marketing.mobile.aepcomposeui.style.AepRowStyle
+import com.adobe.marketing.mobile.aepcomposeui.uimodels.AepText
 import com.github.takahirom.roborazzi.captureRoboImage
 import org.junit.Rule
 import org.junit.Test
@@ -39,14 +40,15 @@ import org.robolectric.annotation.GraphicsMode
 @RunWith(ParameterizedRobolectricTestRunner::class)
 @GraphicsMode(GraphicsMode.Mode.NATIVE)
 @Config(sdk = [33])
-class AepImageComposableTests(
+class AepRowTests(
     private val qualifier: String
 ) {
     @get: Rule
     val composeTestRule = createAndroidComposeRule<ComponentActivity>()
-    private val imageContent: Painter
+
+    private val mockAepText
         @Composable
-        get() = painterResource(id = android.R.drawable.ic_menu_report_image)
+        get() = AepText(AepText(stringResource(id = android.R.string.httpErrorBadUrl)))
 
     companion object {
         @JvmStatic
@@ -57,7 +59,7 @@ class AepImageComposableTests(
     }
 
     @Test
-    fun `Test AepImageComposable with default style`() {
+    fun `Test AepRow with default style`() {
         // setup
         RuntimeEnvironment.setQualifiers(qualifier)
 
@@ -65,18 +67,18 @@ class AepImageComposableTests(
         setComposeContent(
             composeTestRule, qualifier
         ) {
-            AepImageComposable(
-                content = imageContent,
-            )
+            AepRow {
+                mockAepText
+            }
         }
 
         // Capture screenshot
         composeTestRule.onRoot()
-            .captureRoboImage(filePath = "build/outputs/roborazzi/AepImageComposableTests_${Build.VERSION.SDK_INT}_$qualifier.png")
+            .captureRoboImage(filePath = "build/outputs/roborazzi/AepRowTests_${Build.VERSION.SDK_INT}_$qualifier.png")
     }
 
     @Test
-    fun `Test AepImageComposable with default style in dark theme`() {
+    fun `Test custom style applied to AepRow`() {
         // setup
         RuntimeEnvironment.setQualifiers(qualifier)
 
@@ -84,40 +86,23 @@ class AepImageComposableTests(
         setComposeContent(
             composeTestRule, qualifier
         ) {
-            AepImageComposable(
-                content = imageContent,
-            )
-        }
-
-        // Capture screenshot
-        composeTestRule.onRoot()
-            .captureRoboImage(filePath = "build/outputs/roborazzi/AepImageComposableTestsDarkTheme_${Build.VERSION.SDK_INT}_$qualifier.png")
-    }
-
-    @Test
-    fun `Test custom style applied to AepImageComposable`() {
-        // setup
-        RuntimeEnvironment.setQualifiers(qualifier)
-
-        // test
-        setComposeContent(
-            composeTestRule, qualifier
-        ) {
-            AepImageComposable(
-                content = imageContent,
-                imageStyle = AepImageStyle(
-                    modifier = Modifier.size(500.dp).aspectRatio(1.5f),
-                    contentDescription = "Test Image",
-                    alignment = Alignment.BottomEnd,
-                    contentScale = ContentScale.Fit,
-                    alpha = 0.85f,
-                    colorFilter = ColorFilter.tint(Color(0xFF0065db))
+            AepRow(
+                rowStyle = AepRowStyle(
+                    modifier = Modifier
+                        .height(100.dp)
+                        .fillMaxWidth()
+                        .background(Color(0xFF0065db))
+                        .padding(10.dp),
+                    horizontalArrangement = Arrangement.End,
+                    verticalAlignment = Alignment.Bottom
                 )
-            )
+            ) {
+                mockAepText
+            }
         }
 
         // Capture screenshot
         composeTestRule.onRoot()
-            .captureRoboImage(filePath = "build/outputs/roborazzi/AepImageComposableTestsCustomStyle_${Build.VERSION.SDK_INT}_$qualifier.png")
+            .captureRoboImage(filePath = "build/outputs/roborazzi/AepRowTestsCustomStyle_${Build.VERSION.SDK_INT}_$qualifier.png")
     }
 }

--- a/code/messaging/src/test/java/com/adobe/marketing/mobile/aepcomposeui/components/AepTextTests.kt
+++ b/code/messaging/src/test/java/com/adobe/marketing/mobile/aepcomposeui/components/AepTextTests.kt
@@ -50,7 +50,7 @@ import org.robolectric.annotation.GraphicsMode
 @RunWith(ParameterizedRobolectricTestRunner::class)
 @GraphicsMode(GraphicsMode.Mode.NATIVE)
 @Config(sdk = [31])
-class AepTextComposableTests(
+class AepTextTests(
     private val qualifier: String
 ) {
     @get: Rule
@@ -101,7 +101,7 @@ class AepTextComposableTests(
     }
 
     @Test
-    fun `Test AepTextComposable with default style`() {
+    fun `Test AepText with default style`() {
         // setup
         RuntimeEnvironment.setQualifiers(qualifier)
 
@@ -109,18 +109,18 @@ class AepTextComposableTests(
         setComposeContent(
             composeTestRule, qualifier
         ) {
-            AepTextComposable(
+            AepText(
                 model = mockAepText,
             )
         }
 
         // Capture screenshot
         composeTestRule.onRoot()
-            .captureRoboImage(filePath = "build/outputs/roborazzi/AepTextComposableTests_${Build.VERSION.SDK_INT}_$qualifier.png")
+            .captureRoboImage(filePath = "build/outputs/roborazzi/AepTextTests_${Build.VERSION.SDK_INT}_$qualifier.png")
     }
 
     @Test
-    fun `Test AepTextComposable with default style in dark theme`() {
+    fun `Test AepText with default style in dark theme`() {
         // setup
         RuntimeEnvironment.setQualifiers(qualifier)
 
@@ -129,7 +129,7 @@ class AepTextComposableTests(
             composeTestRule, qualifier
         ) {
             TestTheme(useDarkTheme = true) {
-                AepTextComposable(
+                AepText(
                     model = mockAepText,
                 )
             }
@@ -137,11 +137,11 @@ class AepTextComposableTests(
 
         // Capture screenshot
         composeTestRule.onRoot()
-            .captureRoboImage(filePath = "build/outputs/roborazzi/AepTextComposableTestsDarkTheme_${Build.VERSION.SDK_INT}_$qualifier.png")
+            .captureRoboImage(filePath = "build/outputs/roborazzi/AepTextTestsDarkTheme_${Build.VERSION.SDK_INT}_$qualifier.png")
     }
 
     @Test
-    fun `Test custom style is applied to AepTextComposable`() {
+    fun `Test custom style is applied to AepText`() {
         // setup
         RuntimeEnvironment.setQualifiers(qualifier)
 
@@ -149,7 +149,7 @@ class AepTextComposableTests(
         setComposeContent(
             composeTestRule, qualifier
         ) {
-            AepTextComposable(
+            AepText(
                 model = mockAepText,
                 textStyle = mockAepTextStyle
             )
@@ -157,11 +157,11 @@ class AepTextComposableTests(
 
         // Capture screenshot
         composeTestRule.onRoot()
-            .captureRoboImage(filePath = "build/outputs/roborazzi/AepTextComposableTestsCustomStyle_${Build.VERSION.SDK_INT}_$qualifier.png")
+            .captureRoboImage(filePath = "build/outputs/roborazzi/AepTextTestsCustomStyle_${Build.VERSION.SDK_INT}_$qualifier.png")
     }
 
     @Test
-    fun `Test custom style is applied to AepTextComposable in dark theme`() {
+    fun `Test custom style is applied to AepText in dark theme`() {
         // setup
         RuntimeEnvironment.setQualifiers(qualifier)
 
@@ -170,7 +170,7 @@ class AepTextComposableTests(
             composeTestRule, qualifier
         ) {
             TestTheme(useDarkTheme = true) {
-                AepTextComposable(
+                AepText(
                     model = mockAepText,
                     textStyle = mockAepTextStyle
                 )
@@ -179,6 +179,6 @@ class AepTextComposableTests(
 
         // Capture screenshot
         composeTestRule.onRoot()
-            .captureRoboImage(filePath = "build/outputs/roborazzi/AepTextComposableTestsCustomStyleDarkTheme_${Build.VERSION.SDK_INT}_$qualifier.png")
+            .captureRoboImage(filePath = "build/outputs/roborazzi/AepTextTestsCustomStyleDarkTheme_${Build.VERSION.SDK_INT}_$qualifier.png")
     }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
Renamed all internal composable classes to drop the `Composable` prefix

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
