### PR TITLE
[PLATIR-60272] Added public API to Message.java that records a display event in the device's event history

### DIFF
--- a/Documentation/sources/enum-public-classes/class-message.md
+++ b/Documentation/sources/enum-public-classes/class-message.md
@@ -65,6 +65,28 @@ Returns the message's id.
 String getId()
 ```
 
+### getMetadata
+
+Gets the `Message's` custom metadata which is the metadata present in the `InAppSchemaData` created from the `Message` payload.
+
+```java
+@NonNull default Map<String, Object> getMetadata()
+```
+
+###### Returns
+
+* A `Map<String, Object>` containing the custom metadata present in the `Message` payload. Returns an empty map if no metadata is present.
+
+### recordDisplay
+
+Records a display event in the device's event history database.
+
+This method should only be used in conjunction with a `PresentationDelegate` to enforce show frequency rules even if the `Message` was suppressed.
+
+```java
+default void recordDisplay()
+```
+
 Below is the table of values returned by calling the `toString` method for each case, which are used as the XDM `eventType` in outgoing experience events:
 
 | Case                      | String value                      |

--- a/Documentation/sources/in-app-messaging/how-to-presentation-delegate.md
+++ b/Documentation/sources/in-app-messaging/how-to-presentation-delegate.md
@@ -171,6 +171,55 @@ public boolean canShow(Presentable<?> presentable) {
 }
 ```
 
+### Recording display events for suppressed messages
+
+When a message is suppressed via the `canShow` method, it may still be necessary to record the display event in the device's event history. This is important for enforcing show frequency rules based on display count, even when the message is not actually shown.
+
+Use the `recordDisplay()` method on the `Message` object to record the display event without showing the message:
+
+#### Kotlin
+```kotlin
+override fun canShow(presentable: Presentable<*>): Boolean {
+    if (!presentable.getPresentation() is InAppMessage) return true
+
+    currentMessagePresentable = presentable as Presentable<InAppMessage>
+    val message = MessagingUtils.getMessageForPresentable(currentMessagePresentable)
+
+    if (!showMessages) {
+        // Record the display event even though the message is suppressed
+        // This ensures frequency capping rules are still enforced
+        message?.recordDisplay()
+        return false
+    }
+
+    return true
+}
+```
+
+#### Java
+```java
+@Override
+public boolean canShow(Presentable<?> presentable) {
+    if (!(presentable.getPresentation() instanceof InAppMessage)) {
+        return true;
+    }
+
+    currentMessagePresentable = (Presentable<InAppMessage>) presentable;
+    Message message = MessagingUtils.getMessageForPresentable(currentMessagePresentable);
+
+    if (!showMessages) {
+        // Record the display event even though the message is suppressed
+        // This ensures frequency capping rules are still enforced
+        if (message != null) {
+            message.recordDisplay();
+        }
+        return false;
+    }
+
+    return true;
+}
+```
+
 Another option is to store a reference to the `Message` object, and call the `show()` method on it at a later time.
 
 Continuing with the above example, after you have stored the message that was triggered initially, you can choose to show it upon completion of the other workflow:

--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/Message.java
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/Message.java
@@ -12,6 +12,9 @@
 package com.adobe.marketing.mobile;
 
 import androidx.annotation.NonNull;
+
+import com.adobe.marketing.mobile.services.Log;
+
 import java.util.Collections;
 import java.util.Map;
 
@@ -24,6 +27,16 @@ public interface Message {
      *     the ensuing Edge Event
      */
     void track(final String interaction, final MessagingEdgeEventType eventType);
+
+    /**
+     * Records a display event in the device's event history database.
+     * 
+     * Should only be used in conjunction with a {@code PresentationDelegate} to enforce show frequency
+     * rules even if the {@code Message} was suppressed.
+     */
+    default void recordDisplay() {
+        Log.trace("Messaging", "Messaging", "recordDisplay protocol method was not implemented.");
+    }
 
     /** Shows this {@link Message}. */
     void show();

--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/Message.java
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/Message.java
@@ -12,9 +12,7 @@
 package com.adobe.marketing.mobile;
 
 import androidx.annotation.NonNull;
-
 import com.adobe.marketing.mobile.services.Log;
-
 import java.util.Collections;
 import java.util.Map;
 
@@ -30,9 +28,9 @@ public interface Message {
 
     /**
      * Records a display event in the device's event history database.
-     * 
-     * Should only be used in conjunction with a {@code PresentationDelegate} to enforce show frequency
-     * rules even if the {@code Message} was suppressed.
+     *
+     * <p>Should only be used in conjunction with a {@code PresentationDelegate} to enforce show
+     * frequency rules even if the {@code Message} was suppressed.
      */
     default void recordDisplay() {
         Log.trace("Messaging", "Messaging", "recordDisplay protocol method was not implemented.");

--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/PresentableMessageMapper.java
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/PresentableMessageMapper.java
@@ -308,6 +308,11 @@ class PresentableMessageMapper {
             messagingExtension.sendPropositionInteraction(propositionInteractionXdm);
         }
 
+        @Override
+        public void recordDisplay() {
+            recordEventHistory(null, MessagingEdgeEventType.DISPLAY);
+        }
+
         // ui management
         @Override
         public void show() {

--- a/code/messaging/src/test/java/com/adobe/marketing/mobile/messaging/PresentableMessageMapperTests.java
+++ b/code/messaging/src/test/java/com/adobe/marketing/mobile/messaging/PresentableMessageMapperTests.java
@@ -24,9 +24,11 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.adobe.marketing.mobile.Event;
 import com.adobe.marketing.mobile.ExtensionApi;
 import com.adobe.marketing.mobile.Message;
 import com.adobe.marketing.mobile.MessagingEdgeEventType;
+import com.adobe.marketing.mobile.MobileCore;
 import com.adobe.marketing.mobile.services.ServiceProvider;
 import com.adobe.marketing.mobile.services.ui.InAppMessage;
 import com.adobe.marketing.mobile.services.ui.Presentable;
@@ -1363,5 +1365,171 @@ public class PresentableMessageMapperTests {
                     // verify
                     assertNull(message);
                 });
+    }
+
+    // ========================================================================================
+    // recordDisplay tests
+    // ========================================================================================
+    @Test
+    public void test_recordDisplay_dispatchesEventHistoryWriteEvent() {
+        // setup
+        runUsingMockedServiceProvider(
+                () -> {
+                    try (MockedStatic<MobileCore> mobileCoreMockedStatic =
+                            Mockito.mockStatic(MobileCore.class)) {
+                        // Create a PropositionInfo with a valid activityId
+                        Map<String, Object> activityMap = new HashMap<>();
+                        activityMap.put("id", "mockActivityId");
+                        Map<String, Object> scopeDetails = new HashMap<>();
+                        scopeDetails.put("activity", activityMap);
+                        Map<String, Object> propositionInfoMap = new HashMap<>();
+                        propositionInfoMap.put("id", "mockPropositionId");
+                        propositionInfoMap.put("scope", "mockScope");
+                        propositionInfoMap.put("scopeDetails", scopeDetails);
+                        PropositionInfo propositionInfo =
+                                PropositionInfo.create(propositionInfoMap);
+
+                        try {
+                            internalMessage =
+                                    (PresentableMessageMapper.InternalMessage)
+                                            PresentableMessageMapper.getInstance()
+                                                    .createMessage(
+                                                            mockMessagingExtension,
+                                                            createPropositionItem(),
+                                                            new HashMap<>(),
+                                                            propositionInfo);
+                        } catch (Exception exception) {
+                            fail(exception.getMessage());
+                        }
+
+                        // test
+                        internalMessage.recordDisplay();
+
+                        // verify event history write event was dispatched
+                        ArgumentCaptor<Event> eventCaptor = ArgumentCaptor.forClass(Event.class);
+                        mobileCoreMockedStatic.verify(
+                                () -> MobileCore.dispatchEvent(eventCaptor.capture()));
+                        Event capturedEvent = eventCaptor.getValue();
+                        assertEquals(
+                                MessagingTestConstants.EventName.EVENT_HISTORY_WRITE,
+                                capturedEvent.getName());
+                        assertEquals(
+                                MessagingTestConstants.EventType.MESSAGING, capturedEvent.getType());
+                        assertEquals(
+                                MessagingTestConstants.EventSource.EVENT_HISTORY_WRITE,
+                                capturedEvent.getSource());
+
+                        // verify the event data contains iam history with DISPLAY event type
+                        Map<String, Object> eventData = capturedEvent.getEventData();
+                        assertNotNull(eventData);
+                        @SuppressWarnings("unchecked")
+                        Map<String, String> iamHistory =
+                                (Map<String, String>)
+                                        eventData.get(MessagingTestConstants.EventDataKeys.IAM_HISTORY);
+                        assertNotNull(iamHistory);
+                        assertEquals(
+                                MessagingEdgeEventType.DISPLAY.getPropositionEventType(),
+                                iamHistory.get("eventType"));
+                        assertEquals("mockActivityId", iamHistory.get("id"));
+                    }
+                });
+    }
+
+    @Test
+    public void test_recordDisplay_withNullPropositionInfo_doesNotDispatchEvent() {
+        // setup
+        runUsingMockedServiceProvider(
+                () -> {
+                    try (MockedStatic<MobileCore> mobileCoreMockedStatic =
+                            Mockito.mockStatic(MobileCore.class)) {
+                        try {
+                            internalMessage =
+                                    (PresentableMessageMapper.InternalMessage)
+                                            PresentableMessageMapper.getInstance()
+                                                    .createMessage(
+                                                            mockMessagingExtension,
+                                                            createPropositionItem(),
+                                                            new HashMap<>(),
+                                                            null);
+                        } catch (Exception exception) {
+                            fail(exception.getMessage());
+                        }
+
+                        // test
+                        internalMessage.recordDisplay();
+
+                        // verify no event was dispatched
+                        mobileCoreMockedStatic.verifyNoInteractions();
+                    }
+                });
+    }
+
+    @Test
+    public void test_recordDisplay_withEmptyActivityId_doesNotDispatchEvent() {
+        // setup
+        runUsingMockedServiceProvider(
+                () -> {
+                    try (MockedStatic<MobileCore> mobileCoreMockedStatic =
+                            Mockito.mockStatic(MobileCore.class)) {
+                        // Create a PropositionInfo with an empty activityId (no activity map)
+                        Map<String, Object> scopeDetails = new HashMap<>();
+                        scopeDetails.put("key", "value");
+                        Map<String, Object> propositionInfoMap = new HashMap<>();
+                        propositionInfoMap.put("id", "mockPropositionId");
+                        propositionInfoMap.put("scope", "mockScope");
+                        propositionInfoMap.put("scopeDetails", scopeDetails);
+                        PropositionInfo propositionInfo =
+                                PropositionInfo.create(propositionInfoMap);
+
+                        try {
+                            internalMessage =
+                                    (PresentableMessageMapper.InternalMessage)
+                                            PresentableMessageMapper.getInstance()
+                                                    .createMessage(
+                                                            mockMessagingExtension,
+                                                            createPropositionItem(),
+                                                            new HashMap<>(),
+                                                            propositionInfo);
+                        } catch (Exception exception) {
+                            fail(exception.getMessage());
+                        }
+
+                        // test
+                        internalMessage.recordDisplay();
+
+                        // verify no event was dispatched since activityId is empty
+                        mobileCoreMockedStatic.verifyNoInteractions();
+                    }
+                });
+    }
+
+    @Test
+    public void test_recordDisplay_DefaultInterfaceImplementation_doesNotThrow() {
+        // test - verify default interface implementation does not throw
+        Message message =
+                new Message() {
+                    @Override
+                    public void track(String interaction, MessagingEdgeEventType eventType) {}
+
+                    @Override
+                    public void show() {}
+
+                    @Override
+                    public void dismiss() {}
+
+                    @Override
+                    public String getId() {
+                        return "testId";
+                    }
+
+                    @Override
+                    public void setAutoTrack(boolean enabled) {}
+                };
+
+        // test - calling recordDisplay should not throw
+        message.recordDisplay();
+
+        // verify - no exception thrown, method completes successfully
+        // The default implementation just logs a trace message
     }
 }

--- a/code/messaging/src/test/java/com/adobe/marketing/mobile/messaging/PresentableMessageMapperTests.java
+++ b/code/messaging/src/test/java/com/adobe/marketing/mobile/messaging/PresentableMessageMapperTests.java
@@ -1414,7 +1414,8 @@ public class PresentableMessageMapperTests {
                                 MessagingTestConstants.EventName.EVENT_HISTORY_WRITE,
                                 capturedEvent.getName());
                         assertEquals(
-                                MessagingTestConstants.EventType.MESSAGING, capturedEvent.getType());
+                                MessagingTestConstants.EventType.MESSAGING,
+                                capturedEvent.getType());
                         assertEquals(
                                 MessagingTestConstants.EventSource.EVENT_HISTORY_WRITE,
                                 capturedEvent.getSource());
@@ -1425,7 +1426,8 @@ public class PresentableMessageMapperTests {
                         @SuppressWarnings("unchecked")
                         Map<String, String> iamHistory =
                                 (Map<String, String>)
-                                        eventData.get(MessagingTestConstants.EventDataKeys.IAM_HISTORY);
+                                        eventData.get(
+                                                MessagingTestConstants.EventDataKeys.IAM_HISTORY);
                         assertNotNull(iamHistory);
                         assertEquals(
                                 MessagingEdgeEventType.DISPLAY.getPropositionEventType(),

--- a/code/testapp/src/main/java/com/adobe/marketing/mobile/messagingsample/MainActivity.kt
+++ b/code/testapp/src/main/java/com/adobe/marketing/mobile/messagingsample/MainActivity.kt
@@ -33,6 +33,7 @@ import androidx.core.app.NotificationCompat
 import androidx.core.content.ContextCompat
 import androidx.lifecycle.lifecycleScope
 import com.adobe.marketing.mobile.*
+import com.adobe.marketing.mobile.messaging.MessagingUtils
 import com.adobe.marketing.mobile.messaging.NotificationInteractionReceiver
 import com.adobe.marketing.mobile.messagingsample.databinding.ActivityMainBinding
 import com.adobe.marketing.mobile.services.ServiceProvider
@@ -523,6 +524,8 @@ class CustomDelegate : PresentationDelegate {
 
         if(!showMessages) {
             println("message was suppressed: ${presentable.getPresentation().id}")
+            val message = MessagingUtils.getMessageForPresentable(currentMessagePresentable);
+            message?.recordDisplay()
 //            val message = MessagingUtils.getMessageForPresentable(currentMessagePresentable)
 //            message?.track("message suppressed", MessagingEdgeEventType.TRIGGER)
         }


### PR DESCRIPTION
## Description

- new API for recording display event
- tests for above change
- documentation for new api

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
