### PR TITLE
Fix for adbinapp://dismiss deeplink handling without query parameters

### DIFF
--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/MessagingFullscreenEventListener.java
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/MessagingFullscreenEventListener.java
@@ -173,16 +173,18 @@ class MessagingFullscreenEventListener implements InAppMessageEventListener {
         }
 
         // url decode the query parameters if present
-        final String queryParams;
-        try {
-            queryParams = URLDecoder.decode(uri.getQuery(), StandardCharsets.UTF_8.toString());
-        } catch (final UnsupportedEncodingException | NullPointerException exception) {
-            Log.debug(
-                    MessagingConstants.LOG_TAG,
-                    SELF_TAG,
-                    "UnsupportedEncodingException occurred when decoding query parameters %s.",
-                    uri.getQuery());
-            return false;
+        String queryParams = null;
+        if (uri.getQuery() != null) {
+            try {
+                queryParams = URLDecoder.decode(uri.getQuery(), StandardCharsets.UTF_8.toString());
+            } catch (final UnsupportedEncodingException | NullPointerException exception) {
+                Log.debug(
+                        MessagingConstants.LOG_TAG,
+                        SELF_TAG,
+                        "UnsupportedEncodingException occurred when decoding query parameters %s.",
+                        uri.getQuery());
+                return false;
+            }
         }
 
         // Populate message data

--- a/code/messaging/src/test/java/com/adobe/marketing/mobile/messaging/MessagingFullscreenEventListenerTests.java
+++ b/code/messaging/src/test/java/com/adobe/marketing/mobile/messaging/MessagingFullscreenEventListenerTests.java
@@ -453,9 +453,9 @@ public class MessagingFullscreenEventListenerTests {
                             eventListener.onUrlLoading(mockInAppPresentable, "adbinapp://dismiss");
 
                     // verify no message tracking call and message settings weren't created
-                    Assert.assertFalse(result);
+                    Assert.assertTrue(result);
                     verify(mockMessage, times(0)).track(any(), any(MessagingEdgeEventType.class));
-                    verify(mockPresentableMessageMapper, times(0))
+                    verify(mockPresentableMessageMapper, times(1))
                             .getMessageFromPresentableId(anyString());
                 });
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

In app messages URL handling allows user to dismiss the InApp by using specific URL : "adbinapp://dismiss".
https://developer.adobe.com/client-sdks/edge/adobe-journey-optimizer/in-app-message/tutorials/handle-clicks/
There are actions that can be appended to theis for a track event to be sent. For example:
- adbinapp://dismiss?interaction=imageLiked 
- adbinapp://dismiss?interaction=close

In android "adbinapp://dismiss" itself does not work and makes the inapp webview to navigate to a webpage of the same url and leads to page not found error appearing on the screen.
This is because current implementation expects some query parameters.

Updating this handling to allow deeplink without any parameters too to be able to dismiss the in app message.


## Related Issue

https://jira.corp.adobe.com/browse/MOB-24595

## Motivation and Context

Expected behaviour as per documentation and iOS behaviour would be achieved.

## How Has This Been Tested?

These changes have been tested by creating a campaign with custom html template. Added a button in the in app with link (href) to "adbinapp://dismiss".
Original behaviour : IAM is not dismissed webview shows an error : 
Updated behaviour: IAM gets dismissed

## Screenshots (if appropriate):
Current behaviour (Erraneous)
<img width="470" height="935" alt="image" src="https://github.com/user-attachments/assets/452487e7-499a-473c-8bfd-b21bbf6959c4" />
Updated behaviour with fix (Expected):
<img width="460" height="931" alt="image" src="https://github.com/user-attachments/assets/8a37fd53-d9a3-437f-99e1-959122b57670" />

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
