### PR TITLE
Fix inbox proposition selection and color hex parsing

### DIFF
--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/aepcomposeui/state/InboxUIState.kt
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/aepcomposeui/state/InboxUIState.kt
@@ -34,7 +34,7 @@ sealed interface InboxUIState {
     data class Success(
         val template: InboxTemplate,
         val items: List<AepUI<*, *>>,
-        val displayed: Boolean = false
+        internal val displayed: Boolean = false
     ) : InboxUIState
 
     /**

--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/ContentCardEventObserver.kt
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/ContentCardEventObserver.kt
@@ -23,7 +23,8 @@ import com.adobe.marketing.mobile.aepcomposeui.uimodels.SmallImageTemplate
 
 /**
  * Implementation of [AepUIEventObserver] for handling content card events.
- * Propagates every event to the internally maintained a list of [AepUIEventObserver] instances.
+ * Propagates each event to an internally maintained chain: template event handlers (and optional
+ * [ContentCardUIEventListener] callback), then optionally the [ContentCardUIProvider] for flow updates.
  *
  * @param callback An optional callback to invoke when a content card event occurs.
  * @param provider An optional [ContentCardUIProvider] that owns the content card state.
@@ -53,7 +54,7 @@ class ContentCardEventObserver @JvmOverloads constructor(
     }
 
     private val observers: List<AepUIEventObserver> by lazy {
-        listOfNotNull(callbackObserver, provider)
+        listOfNotNull(callbackObserver, provider?.uiEventObserver)
     }
 
     override fun onEvent(event: UIEvent<*, *>) {

--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/ContentCardSchemaDataUtils.kt
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/ContentCardSchemaDataUtils.kt
@@ -612,7 +612,7 @@ internal object ContentCardSchemaDataUtils {
             Log.trace(
                 MessagingConstants.LOG_TAG,
                 SELF_TAG,
-                "Light color is null in inbox with id $inboxId"
+                "Light color is null or invalid in inbox with id $inboxId"
             )
             return null
         }
@@ -678,20 +678,24 @@ internal object ContentCardSchemaDataUtils {
  */
 internal fun String.toComposeColor(): Color? {
     val hex = removePrefix("#")
-    return when (hex.length) {
-        6 -> {
-            val r = hex.substring(0, 2).toInt(16)
-            val g = hex.substring(2, 4).toInt(16)
-            val b = hex.substring(4, 6).toInt(16)
-            Color(r, g, b)
+    return try {
+        when (hex.length) {
+            6 -> {
+                val r = hex.substring(0, 2).toInt(16)
+                val g = hex.substring(2, 4).toInt(16)
+                val b = hex.substring(4, 6).toInt(16)
+                Color(r, g, b)
+            }
+            8 -> {
+                val r = hex.substring(0, 2).toInt(16)
+                val g = hex.substring(2, 4).toInt(16)
+                val b = hex.substring(4, 6).toInt(16)
+                val a = hex.substring(6, 8).toInt(16)
+                Color(r, g, b, a)
+            }
+            else -> null
         }
-        8 -> {
-            val r = hex.substring(0, 2).toInt(16)
-            val g = hex.substring(2, 4).toInt(16)
-            val b = hex.substring(4, 6).toInt(16)
-            val a = hex.substring(6, 8).toInt(16)
-            Color(r, g, b, a)
-        }
-        else -> null
+    } catch (e: NumberFormatException) {
+        null
     }
 }

--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/ContentCardSchemaDataUtils.kt
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/ContentCardSchemaDataUtils.kt
@@ -14,7 +14,6 @@ package com.adobe.marketing.mobile.messaging
 import androidx.annotation.VisibleForTesting
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.graphics.Color
-import androidx.core.graphics.toColorInt
 import com.adobe.marketing.mobile.aepcomposeui.AepUI
 import com.adobe.marketing.mobile.aepcomposeui.ImageOnlyUI
 import com.adobe.marketing.mobile.aepcomposeui.LargeImageUI
@@ -608,7 +607,7 @@ internal object ContentCardSchemaDataUtils {
     ): AepColor? {
         val lightColor =
             DataReader.optString(contentMap, MessagingConstants.Inbox.UIKeys.LIGHT, null)
-                ?.let { Color(it.toColorInt()) }
+                ?.toComposeColor()
         if (lightColor == null) {
             Log.trace(
                 MessagingConstants.LOG_TAG,
@@ -618,7 +617,7 @@ internal object ContentCardSchemaDataUtils {
             return null
         }
         val darkColor = DataReader.optString(contentMap, MessagingConstants.Inbox.UIKeys.DARK, null)
-            ?.let { Color(it.toColorInt()) }
+            ?.toComposeColor()
         return AepColor(lightColor, darkColor)
     }
 
@@ -669,5 +668,30 @@ internal object ContentCardSchemaDataUtils {
      */
     internal fun getReadStatus(activityId: String): Boolean? {
         return readStateStoreCollection?.getBoolean(activityId, false)
+    }
+}
+
+/**
+ * Parses a hex color string in `#RRGGBBAA` format into a Compose [Color].
+ *
+ * @return The parsed [Color], or null if the string is not a valid 6- or 8-digit hex color.
+ */
+internal fun String.toComposeColor(): Color? {
+    val hex = removePrefix("#")
+    return when (hex.length) {
+        6 -> {
+            val r = hex.substring(0, 2).toInt(16)
+            val g = hex.substring(2, 4).toInt(16)
+            val b = hex.substring(4, 6).toInt(16)
+            Color(r, g, b)
+        }
+        8 -> {
+            val r = hex.substring(0, 2).toInt(16)
+            val g = hex.substring(2, 4).toInt(16)
+            val b = hex.substring(4, 6).toInt(16)
+            val a = hex.substring(6, 8).toInt(16)
+            Color(r, g, b, a)
+        }
+        else -> null
     }
 }

--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/ContentCardUIProvider.kt
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/ContentCardUIProvider.kt
@@ -39,7 +39,7 @@ import kotlin.coroutines.resume
  *
  * @property surface The surface for which content needs to be fetched.
  */
-class ContentCardUIProvider(val surface: Surface) : AepUIContentProvider, AepUIEventObserver {
+class ContentCardUIProvider(val surface: Surface) : AepUIContentProvider {
     companion object {
         private const val SELF_TAG: String = "ContentCardUIProvider"
     }
@@ -51,30 +51,29 @@ class ContentCardUIProvider(val surface: Surface) : AepUIContentProvider, AepUIE
     private val aepUIFlow: StateFlow<Result<List<AepUI<*, *>>>> = _aepUIFlow.asStateFlow()
 
     /**
-     * Receives a content card UI event and updates the flow. Called by [ContentCardEventObserver]
-     * after the event has been handled. When the handler mutates the card in place (same reference),
-     * we use a copy so [StateFlow] sees a distinct value and emits.
-     *
-     * @param event The [UIEvent] whose [UIEvent.aepUi] holds the updated card state.
+     * Internal observer that receives content card UI events and updates the flow.
+     * Kept internal to prevent integrating apps from calling this directly.
      */
-    override fun onEvent(event: UIEvent<*, *>) {
-        val updatedCard = event.aepUi
-        val currentResult = _aepUIFlow.value
-        if (!currentResult.isSuccess) {
-            return
-        }
-        val currentList = currentResult.getOrNull() ?: emptyList()
-        val cardId = updatedCard.getTemplate().id
-        val updatedList = currentList.map { aepUI ->
-            if (aepUI.getTemplate().id != cardId) {
-                aepUI
+    internal val uiEventObserver: AepUIEventObserver = object : AepUIEventObserver {
+        override fun onEvent(event: UIEvent<*, *>) {
+            val updatedCard = event.aepUi
+            val currentResult = _aepUIFlow.value
+            if (!currentResult.isSuccess) {
+                return
             }
-            // in-place mutation: copy so StateFlow emits
-            else if (aepUI === updatedCard) {
-                copyAepUI(updatedCard)
-            } else updatedCard
+            val currentList = currentResult.getOrNull() ?: emptyList()
+            val cardId = updatedCard.getTemplate().id
+            val updatedList = currentList.map { aepUI ->
+                if (aepUI.getTemplate().id != cardId) {
+                    aepUI
+                }
+                // in-place mutation: copy so StateFlow emits
+                else if (aepUI === updatedCard) {
+                    copyAepUI(updatedCard)
+                } else updatedCard
+            }
+            _aepUIFlow.update { Result.success(updatedList) }
         }
-        _aepUIFlow.update { Result.success(updatedList) }
     }
 
     /**

--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/InboxEventObserver.kt
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/InboxEventObserver.kt
@@ -52,7 +52,7 @@ class InboxEventObserver(
     }
 
     private val inboxObservers by lazy {
-        listOf(provider, trackingObserver)
+        listOf(provider.inboxEventObserver, trackingObserver)
     }
 
     private val itemObserver: AepUIEventObserver by lazy {

--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/InboxEventObserver.kt
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/InboxEventObserver.kt
@@ -18,12 +18,11 @@ import com.adobe.marketing.mobile.aepcomposeui.observers.AepInboxEventObserver
 import com.adobe.marketing.mobile.aepcomposeui.observers.AepUIEventObserver
 
 /**
- * Messaging implementation of [AepInboxEventObserver].
- * Propagates [InboxEvent] to an internally maintained list of [AepUIEventObserver], and
- * item-level [UIEvent] to the provided [AepUIEventObserver] or a default [ContentCardEventObserver] when null.
+ * Messaging implementation of [AepInboxEventObserver] for use with [AepInbox].
+ * Handles inbox-level events and Adobe Journey Optimizer tracking inside the SDK, and forwards
+ * item-level [UIEvent] instances to [itemEventObserver] or to a default [ContentCardEventObserver] when null.
  *
- * @param provider The [MessagingInboxProvider] that owns inbox state; the observer calls
- *   [MessagingInboxProvider.onInboxEvent] so the provider updates its state.
+ * @param provider The [MessagingInboxProvider] that owns inbox state
  * @param itemEventObserver Optional [AepUIEventObserver] for item-level events (e.g. [ContentCardEventObserver]).
  *   When null, a default [ContentCardEventObserver] with null callback is used.
  */

--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/MessagingInboxProvider.kt
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/MessagingInboxProvider.kt
@@ -136,6 +136,7 @@ class MessagingInboxProvider(
             )
             return Result.failure(Throwable("No inbox proposition found for surface: ${surface.uri}"))
         }
+        // IDS response has the propositions ordered by priority and last modified time, so the first proposition with the inbox schema should be the one to display
         val highestPriorityInbox = inboxPropositionList.first()
         val contentCardPropositions =
             propositionsMap[surface]?.filter { it.items.isNotEmpty() && it.items[0].schema == SchemaType.CONTENT_CARD }

--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/MessagingInboxProvider.kt
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/MessagingInboxProvider.kt
@@ -37,7 +37,7 @@ import kotlin.coroutines.resume
  */
 class MessagingInboxProvider(
     val surface: Surface
-) : AepInboxContentProvider, AepInboxEventObserver {
+) : AepInboxContentProvider {
     data class InboxProposition(
         val inbox: Proposition,
         val contentCards: List<Proposition>
@@ -184,17 +184,20 @@ class MessagingInboxProvider(
         }
 
     /**
-     * Handles state updates needed for inbox events.
+     * Internal observer that handles state updates needed for inbox events.
+     * Kept internal to prevent integrating apps from calling these methods directly.
      */
-    override fun onInboxEvent(event: InboxEvent) {
-        when (event) {
-            is InboxEvent.Display -> {
-                _inboxStateFlow.update { event.inboxUIState.copy(displayed = true) }
+    internal val inboxEventObserver: AepInboxEventObserver = object : AepInboxEventObserver {
+        override fun onInboxEvent(event: InboxEvent) {
+            when (event) {
+                is InboxEvent.Display -> {
+                    _inboxStateFlow.update { event.inboxUIState.copy(displayed = true) }
+                }
             }
         }
-    }
 
-    override fun onEvent(event: UIEvent<*, *>) {
-        // Currently no-op for item events
+        override fun onEvent(event: UIEvent<*, *>) {
+            // Currently no-op for item events
+        }
     }
 }

--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/MessagingInboxProvider.kt
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/MessagingInboxProvider.kt
@@ -136,9 +136,7 @@ class MessagingInboxProvider(
             )
             return Result.failure(Throwable("No inbox proposition found for surface: ${surface.uri}"))
         }
-        val highestPriorityInbox = inboxPropositionList.first { proposition ->
-            proposition.priority == inboxPropositionList.maxOf { it.priority }
-        }
+        val highestPriorityInbox = inboxPropositionList.first()
         val contentCardPropositions =
             propositionsMap[surface]?.filter { it.items.isNotEmpty() && it.items[0].schema == SchemaType.CONTENT_CARD }
                 ?: emptyList()

--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/MessagingInboxProvider.kt
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/MessagingInboxProvider.kt
@@ -136,7 +136,9 @@ class MessagingInboxProvider(
             )
             return Result.failure(Throwable("No inbox proposition found for surface: ${surface.uri}"))
         }
-        val highestPriorityInbox = inboxPropositionList.sortedByDescending { it.rank }.first()
+        val highestPriorityInbox = inboxPropositionList.first { proposition ->
+            proposition.priority == inboxPropositionList.maxOf { it.priority }
+        }
         val contentCardPropositions =
             propositionsMap[surface]?.filter { it.items.isNotEmpty() && it.items[0].schema == SchemaType.CONTENT_CARD }
                 ?: emptyList()

--- a/code/messaging/src/test/java/com/adobe/marketing/mobile/messaging/ContentCardObserverTests.kt
+++ b/code/messaging/src/test/java/com/adobe/marketing/mobile/messaging/ContentCardObserverTests.kt
@@ -14,6 +14,7 @@ package com.adobe.marketing.mobile.messaging
 import com.adobe.marketing.mobile.aepcomposeui.AepUI
 import com.adobe.marketing.mobile.aepcomposeui.UIAction
 import com.adobe.marketing.mobile.aepcomposeui.UIEvent
+import com.adobe.marketing.mobile.aepcomposeui.observers.AepUIEventObserver
 import com.adobe.marketing.mobile.aepcomposeui.state.SmallImageCardUIState
 import com.adobe.marketing.mobile.aepcomposeui.uimodels.AepUITemplateType
 import com.adobe.marketing.mobile.aepcomposeui.uimodels.SmallImageTemplate
@@ -93,14 +94,16 @@ class ContentCardObserverTests {
     }
 
     @Test
-    fun `Content card event observer calls provider onEvent when provider is set`() {
+    fun `Content card event observer calls provider uiEventObserver onEvent when provider is set`() {
         val callback = mock(ContentCardUIEventListener::class.java)
         val provider = mock(ContentCardUIProvider::class.java)
+        val mockUiEventObserver = mock(AepUIEventObserver::class.java)
+        `when`(provider.uiEventObserver).thenReturn(mockUiEventObserver)
         val observer = ContentCardEventObserver(callback, provider)
         val event = UIEvent.Display(mockAepUI)
 
         observer.onEvent(event)
 
-        verify(provider, times(1)).onEvent(event)
+        verify(mockUiEventObserver, times(1)).onEvent(event)
     }
 }

--- a/code/messaging/src/test/java/com/adobe/marketing/mobile/messaging/ContentCardSchemaDataUtilsTest.kt
+++ b/code/messaging/src/test/java/com/adobe/marketing/mobile/messaging/ContentCardSchemaDataUtilsTest.kt
@@ -1318,4 +1318,14 @@ class ContentCardSchemaDataUtilsTest {
     fun `test toComposeColor with lowercase hex is parsed correctly`() {
         assertEquals(androidx.compose.ui.graphics.Color.Red, "#ff0000".toComposeColor())
     }
+
+    @Test
+    fun `test toComposeColor with invalid hex characters returns null`() {
+        assertNull("#GGGGGG".toComposeColor())
+    }
+
+    @Test
+    fun `test toComposeColor with invalid 8-char hex characters returns null`() {
+        assertNull("#FF0000ZZ".toComposeColor())
+    }
 }

--- a/code/messaging/src/test/java/com/adobe/marketing/mobile/messaging/ContentCardSchemaDataUtilsTest.kt
+++ b/code/messaging/src/test/java/com/adobe/marketing/mobile/messaging/ContentCardSchemaDataUtilsTest.kt
@@ -746,7 +746,7 @@ class ContentCardSchemaDataUtilsTest {
     @Test
     fun `test createAepColor with valid light color only`() {
         val colorMap = mapOf(
-            MessagingConstants.Inbox.UIKeys.LIGHT to "#FFFF0000"
+            MessagingConstants.Inbox.UIKeys.LIGHT to "#FF0000FF"
         )
         val result = ContentCardSchemaDataUtils.createAepColor(colorMap, "inboxId")
         assertNotNull(result)
@@ -757,8 +757,8 @@ class ContentCardSchemaDataUtilsTest {
     @Test
     fun `test createAepColor with light and dark colors`() {
         val colorMap = mapOf(
-            MessagingConstants.Inbox.UIKeys.LIGHT to "#FFFF0000",
-            MessagingConstants.Inbox.UIKeys.DARK to "#FF00FF00"
+            MessagingConstants.Inbox.UIKeys.LIGHT to "#FF0000FF",
+            MessagingConstants.Inbox.UIKeys.DARK to "#00FF00FF"
         )
         val result = ContentCardSchemaDataUtils.createAepColor(colorMap, "inboxId")
         assertNotNull(result)
@@ -1242,5 +1242,80 @@ class ContentCardSchemaDataUtilsTest {
 
         val result = ContentCardSchemaDataUtils.isInbox(proposition)
         assertFalse(result)
+    }
+
+    // Tests for toComposeColor
+    @Test
+    fun `test toComposeColor with 6-char RGB hex returns opaque color`() {
+        assertEquals(androidx.compose.ui.graphics.Color.Red, "#FF0000".toComposeColor())
+    }
+
+    @Test
+    fun `test toComposeColor with 6-char RGB hex green`() {
+        assertEquals(androidx.compose.ui.graphics.Color.Green, "#00FF00".toComposeColor())
+    }
+
+    @Test
+    fun `test toComposeColor with 6-char RGB hex blue`() {
+        assertEquals(androidx.compose.ui.graphics.Color.Blue, "#0000FF".toComposeColor())
+    }
+
+    @Test
+    fun `test toComposeColor with 6-char RGB hex black`() {
+        assertEquals(androidx.compose.ui.graphics.Color.Black, "#000000".toComposeColor())
+    }
+
+    @Test
+    fun `test toComposeColor with 6-char RGB hex white`() {
+        assertEquals(androidx.compose.ui.graphics.Color.White, "#FFFFFF".toComposeColor())
+    }
+
+    @Test
+    fun `test toComposeColor with 8-char RRGGBBAA hex fully opaque red`() {
+        assertEquals(androidx.compose.ui.graphics.Color.Red, "#FF0000FF".toComposeColor())
+    }
+
+    @Test
+    fun `test toComposeColor with 8-char RRGGBBAA hex fully opaque green`() {
+        assertEquals(androidx.compose.ui.graphics.Color.Green, "#00FF00FF".toComposeColor())
+    }
+
+    @Test
+    fun `test toComposeColor with 8-char RRGGBBAA hex zero alpha`() {
+        val result = "#FF000000".toComposeColor()
+        assertNotNull(result)
+        assertEquals(androidx.compose.ui.graphics.Color(255, 0, 0, 0), result)
+    }
+
+    @Test
+    fun `test toComposeColor with 8-char RRGGBBAA hex semi-transparent`() {
+        val result = "#FF000080".toComposeColor()
+        assertNotNull(result)
+        assertEquals(androidx.compose.ui.graphics.Color(255, 0, 0, 128), result)
+    }
+
+    @Test
+    fun `test toComposeColor with 5-char hex returns null`() {
+        assertNull("#FFFFF".toComposeColor())
+    }
+
+    @Test
+    fun `test toComposeColor with 7-char hex returns null`() {
+        assertNull("#FFFFFFF".toComposeColor())
+    }
+
+    @Test
+    fun `test toComposeColor with empty string returns null`() {
+        assertNull("".toComposeColor())
+    }
+
+    @Test
+    fun `test toComposeColor with only hash returns null`() {
+        assertNull("#".toComposeColor())
+    }
+
+    @Test
+    fun `test toComposeColor with lowercase hex is parsed correctly`() {
+        assertEquals(androidx.compose.ui.graphics.Color.Red, "#ff0000".toComposeColor())
     }
 }

--- a/code/messaging/src/test/java/com/adobe/marketing/mobile/messaging/ContentCardUIProviderTests.kt
+++ b/code/messaging/src/test/java/com/adobe/marketing/mobile/messaging/ContentCardUIProviderTests.kt
@@ -671,7 +671,7 @@ class ContentCardUIProviderTests {
             firstCard.getTemplate(),
             firstCard.getState().copy(displayed = true)
         )
-        contentCardUIProvider.onEvent(UIEvent.Display(updatedCard))
+        contentCardUIProvider.uiEventObserver.onEvent(UIEvent.Display(updatedCard))
 
         // Wait for the update to propagate
         advanceUntilIdle()
@@ -721,7 +721,7 @@ class ContentCardUIProviderTests {
         // Mutate the same card in place (as handlers do), then call onEvent with that reference.
         // Provider uses copyAepUI so StateFlow sees a distinct value and emits.
         firstCard.updateState(firstCard.getState().copy(displayed = true))
-        contentCardUIProvider.onEvent(UIEvent.Display(firstCard))
+        contentCardUIProvider.uiEventObserver.onEvent(UIEvent.Display(firstCard))
 
         advanceUntilIdle()
 

--- a/code/messaging/src/test/java/com/adobe/marketing/mobile/messaging/InboxEventObserverTests.kt
+++ b/code/messaging/src/test/java/com/adobe/marketing/mobile/messaging/InboxEventObserverTests.kt
@@ -15,6 +15,7 @@ import com.adobe.marketing.mobile.MessagingEdgeEventType
 import com.adobe.marketing.mobile.aepcomposeui.AepUI
 import com.adobe.marketing.mobile.aepcomposeui.InboxEvent
 import com.adobe.marketing.mobile.aepcomposeui.UIEvent
+import com.adobe.marketing.mobile.aepcomposeui.observers.AepInboxEventObserver
 import com.adobe.marketing.mobile.aepcomposeui.observers.AepUIEventObserver
 import com.adobe.marketing.mobile.aepcomposeui.state.InboxUIState
 import com.adobe.marketing.mobile.aepcomposeui.state.SmallImageCardUIState
@@ -57,6 +58,8 @@ class InboxEventObserverTests {
     @Test
     fun `onInboxEvent Display performs tracking and calls provider onInboxEvent`() {
         val mockProvider = mock(MessagingInboxProvider::class.java)
+        val mockInboxEventObserver = mock(AepInboxEventObserver::class.java)
+        `when`(mockProvider.inboxEventObserver).thenReturn(mockInboxEventObserver)
         val observer = InboxEventObserver(mockProvider, null)
 
         val mockPropositionItem = mock(PropositionItem::class.java)
@@ -69,24 +72,27 @@ class InboxEventObserverTests {
         observer.onInboxEvent(event)
 
         verify(mockPropositionItem, times(1)).track(MessagingEdgeEventType.DISPLAY)
-        verify(mockProvider, times(1)).onInboxEvent(event)
+        verify(mockInboxEventObserver, times(1)).onInboxEvent(event)
     }
 
     @Test
     fun `onInboxEvent Display does not track but calls provider onInboxEvent even when no proposition item in mapper`() {
         val mockProvider = mock(MessagingInboxProvider::class.java)
+        val mockInboxEventObserver = mock(AepInboxEventObserver::class.java)
+        `when`(mockProvider.inboxEventObserver).thenReturn(mockInboxEventObserver)
         val observer = InboxEventObserver(mockProvider, null)
 
         val successState = createSuccessState("noMappingId")
         val event = InboxEvent.Display(successState)
         observer.onInboxEvent(event)
 
-        verify(mockProvider, times(1)).onInboxEvent(event)
+        verify(mockInboxEventObserver, times(1)).onInboxEvent(event)
     }
 
     @Test
     fun `onInboxEvent Display does not track but calls provider onInboxEvent even  when no inbox proposition item is stored for given id`() {
         val mockProvider = mock(MessagingInboxProvider::class.java)
+        `when`(mockProvider.inboxEventObserver).thenReturn(mock(AepInboxEventObserver::class.java))
         val observer = InboxEventObserver(mockProvider, null)
 
         val mockPropositionItem = mock(PropositionItem::class.java)
@@ -102,6 +108,7 @@ class InboxEventObserverTests {
     @Test
     fun `onInboxEvent Display tracks correct inbox proposition for multiple inboxes`() {
         val mockProvider = mock(MessagingInboxProvider::class.java)
+        `when`(mockProvider.inboxEventObserver).thenReturn(mock(AepInboxEventObserver::class.java))
         val observer = InboxEventObserver(mockProvider, null)
 
         val mockPropositionItem1 = mock(PropositionItem::class.java)
@@ -128,6 +135,8 @@ class InboxEventObserverTests {
         // e.g. configuration change re-entry where the provider's surviving state has displayed=true.
         // The provider is always notified; only tracking is guarded by the displayed flag.
         val mockProvider = mock(MessagingInboxProvider::class.java)
+        val mockInboxEventObserver = mock(AepInboxEventObserver::class.java)
+        `when`(mockProvider.inboxEventObserver).thenReturn(mockInboxEventObserver)
         val observer = InboxEventObserver(mockProvider, null)
 
         val mockPropositionItem = mock(PropositionItem::class.java)
@@ -139,7 +148,7 @@ class InboxEventObserverTests {
         observer.onInboxEvent(event)
 
         verify(mockPropositionItem, never()).track(MessagingEdgeEventType.DISPLAY)
-        verify(mockProvider, times(1)).onInboxEvent(event)
+        verify(mockInboxEventObserver, times(1)).onInboxEvent(event)
     }
 
     @Test
@@ -149,6 +158,8 @@ class InboxEventObserverTests {
         // 2. displayed=true  → tracking skipped, provider still called
         // 3. displayed=false → tracking fires again, provider called
         val mockProvider = mock(MessagingInboxProvider::class.java)
+        val mockInboxEventObserver = mock(AepInboxEventObserver::class.java)
+        `when`(mockProvider.inboxEventObserver).thenReturn(mockInboxEventObserver)
         val observer = InboxEventObserver(mockProvider, null)
 
         val mockPropositionItem = mock(PropositionItem::class.java)
@@ -164,8 +175,8 @@ class InboxEventObserverTests {
         observer.onInboxEvent(eventNotDisplayed) // step 3: tracks again + provider called
 
         verify(mockPropositionItem, times(2)).track(MessagingEdgeEventType.DISPLAY)
-        verify(mockProvider, times(2)).onInboxEvent(eventNotDisplayed)
-        verify(mockProvider, times(1)).onInboxEvent(eventDisplayed)
+        verify(mockInboxEventObserver, times(2)).onInboxEvent(eventNotDisplayed)
+        verify(mockInboxEventObserver, times(1)).onInboxEvent(eventDisplayed)
     }
 
     @Test

--- a/code/messaging/src/test/java/com/adobe/marketing/mobile/messaging/MessagingInboxProviderTests.kt
+++ b/code/messaging/src/test/java/com/adobe/marketing/mobile/messaging/MessagingInboxProviderTests.kt
@@ -713,102 +713,48 @@ class MessagingInboxProviderTests {
     }
 
     @Test
-    fun `fetchInbox selects inbox proposition with highest priority`() = runTest {
-        val lowPriorityInboxProp = mock(Proposition::class.java)
-        val highPriorityInboxProp = mock(Proposition::class.java)
-        val lowPriorityInboxItem = mock(PropositionItem::class.java)
-        val highPriorityInboxItem = mock(PropositionItem::class.java)
+    fun `fetchInbox selects first inbox proposition in the list`() = runTest {
+        val firstInboxProp = mock(Proposition::class.java)
+        val secondInboxProp = mock(Proposition::class.java)
+        val firstInboxItem = mock(PropositionItem::class.java)
+        val secondInboxItem = mock(PropositionItem::class.java)
 
-        whenever(lowPriorityInboxItem.schema).thenReturn(SchemaType.INBOX)
-        whenever(highPriorityInboxItem.schema).thenReturn(SchemaType.INBOX)
-        whenever(lowPriorityInboxProp.items).thenReturn(listOf(lowPriorityInboxItem))
-        whenever(highPriorityInboxProp.items).thenReturn(listOf(highPriorityInboxItem))
-        whenever(lowPriorityInboxProp.priority).thenReturn(10)
-        whenever(highPriorityInboxProp.priority).thenReturn(50)
+        whenever(firstInboxItem.schema).thenReturn(SchemaType.INBOX)
+        whenever(secondInboxItem.schema).thenReturn(SchemaType.INBOX)
+        whenever(firstInboxProp.items).thenReturn(listOf(firstInboxItem))
+        whenever(secondInboxProp.items).thenReturn(listOf(secondInboxItem))
 
-        val lowPriorityTemplate = InboxTemplate(
-            id = "low-priority-inbox",
-            heading = AepText("Low Priority Inbox"),
+        val firstTemplate = InboxTemplate(
+            id = "first-inbox",
+            heading = AepText("First Inbox"),
             layout = AepInboxLayout.VERTICAL,
             capacity = 10,
             emptyMessage = AepText("No messages")
         )
-        val highPriorityTemplate = InboxTemplate(
-            id = "high-priority-inbox",
-            heading = AepText("High Priority Inbox"),
+        val secondTemplate = InboxTemplate(
+            id = "second-inbox",
+            heading = AepText("Second Inbox"),
             layout = AepInboxLayout.VERTICAL,
             capacity = 10,
             emptyMessage = AepText("No messages")
         )
-        every { ContentCardSchemaDataUtils.createInboxTemplate(lowPriorityInboxProp) } returns lowPriorityTemplate
-        every { ContentCardSchemaDataUtils.createInboxTemplate(highPriorityInboxProp) } returns highPriorityTemplate
+        every { ContentCardSchemaDataUtils.createInboxTemplate(firstInboxProp) } returns firstTemplate
+        every { ContentCardSchemaDataUtils.createInboxTemplate(secondInboxProp) } returns secondTemplate
 
         mockMessaging.`when`<Unit> {
             Messaging.getPropositionsForSurfaces(any(), any())
         }.thenAnswer { invocation ->
             val callback =
                 invocation.arguments[1] as AdobeCallbackWithError<Map<Surface, List<Proposition>>>
-            callback.call(mapOf(surface to listOf(lowPriorityInboxProp, highPriorityInboxProp)))
+            callback.call(mapOf(surface to listOf(firstInboxProp, secondInboxProp)))
         }
 
         val states = messagingInboxProvider.getInboxUI().take(2).toList()
 
         assertTrue("Second state should be Success", states[1] is InboxUIState.Success)
         assertEquals(
-            "Should select the inbox proposition with the highest priority",
-            "high-priority-inbox",
-            (states[1] as InboxUIState.Success).template.id
-        )
-    }
-
-    @Test
-    fun `fetchInbox selects latest modified inbox proposition when priorities are equal`() = runTest {
-        // The propositions list is ordered latest-modified first.
-        // Both have the same priority, so the first element (latest modified) should win.
-        val olderInboxProp = mock(Proposition::class.java)
-        val newerInboxProp = mock(Proposition::class.java)
-        val olderInboxItem = mock(PropositionItem::class.java)
-        val newerInboxItem = mock(PropositionItem::class.java)
-
-        whenever(olderInboxItem.schema).thenReturn(SchemaType.INBOX)
-        whenever(newerInboxItem.schema).thenReturn(SchemaType.INBOX)
-        whenever(olderInboxProp.items).thenReturn(listOf(olderInboxItem))
-        whenever(newerInboxProp.items).thenReturn(listOf(newerInboxItem))
-        whenever(olderInboxProp.priority).thenReturn(25)
-        whenever(newerInboxProp.priority).thenReturn(25)
-
-        val olderTemplate = InboxTemplate(
-            id = "older-inbox",
-            heading = AepText("Older Inbox"),
-            layout = AepInboxLayout.VERTICAL,
-            capacity = 10,
-            emptyMessage = AepText("No messages")
-        )
-        val newerTemplate = InboxTemplate(
-            id = "newer-inbox",
-            heading = AepText("Newer Inbox"),
-            layout = AepInboxLayout.VERTICAL,
-            capacity = 10,
-            emptyMessage = AepText("No messages")
-        )
-        every { ContentCardSchemaDataUtils.createInboxTemplate(olderInboxProp) } returns olderTemplate
-        every { ContentCardSchemaDataUtils.createInboxTemplate(newerInboxProp) } returns newerTemplate
-
-        mockMessaging.`when`<Unit> {
-            Messaging.getPropositionsForSurfaces(any(), any())
-        }.thenAnswer { invocation ->
-            val callback =
-                invocation.arguments[1] as AdobeCallbackWithError<Map<Surface, List<Proposition>>>
-            // List is ordered latest-modified first: newerInboxProp comes before olderInboxProp
-            callback.call(mapOf(surface to listOf(newerInboxProp, olderInboxProp)))
-        }
-
-        val states = messagingInboxProvider.getInboxUI().take(2).toList()
-
-        assertTrue("Second state should be Success", states[1] is InboxUIState.Success)
-        assertEquals(
-            "Should select the latest modified inbox proposition when priorities are equal",
-            "newer-inbox",
+            "Should select the first inbox proposition in the server-ordered list",
+            "first-inbox",
             (states[1] as InboxUIState.Success).template.id
         )
     }

--- a/code/messaging/src/test/java/com/adobe/marketing/mobile/messaging/MessagingInboxProviderTests.kt
+++ b/code/messaging/src/test/java/com/adobe/marketing/mobile/messaging/MessagingInboxProviderTests.kt
@@ -827,7 +827,7 @@ class MessagingInboxProviderTests {
         assertFalse("Initial displayed flag should be false", initialSuccess.displayed)
 
         // Update the state by notifying the provider of display event
-        messagingInboxProvider.onInboxEvent(InboxEvent.Display(initialSuccess))
+        messagingInboxProvider.inboxEventObserver.onInboxEvent(InboxEvent.Display(initialSuccess))
 
         // Wait for the update to propagate
         advanceUntilIdle()

--- a/code/messaging/src/test/java/com/adobe/marketing/mobile/messaging/MessagingInboxProviderTests.kt
+++ b/code/messaging/src/test/java/com/adobe/marketing/mobile/messaging/MessagingInboxProviderTests.kt
@@ -713,54 +713,103 @@ class MessagingInboxProviderTests {
     }
 
     @Test
-    fun `getInboxUI picks inbox proposition with highest rank when multiple exist`() = runTest {
-        val lowRankInboxProp = mock(Proposition::class.java)
-        val highRankInboxProp = mock(Proposition::class.java)
-        val lowRankInboxItem = mock(PropositionItem::class.java)
-        val highRankInboxItem = mock(PropositionItem::class.java)
+    fun `fetchInbox selects inbox proposition with highest priority`() = runTest {
+        val lowPriorityInboxProp = mock(Proposition::class.java)
+        val highPriorityInboxProp = mock(Proposition::class.java)
+        val lowPriorityInboxItem = mock(PropositionItem::class.java)
+        val highPriorityInboxItem = mock(PropositionItem::class.java)
 
-        whenever(lowRankInboxItem.schema).thenReturn(SchemaType.INBOX)
-        whenever(highRankInboxItem.schema).thenReturn(SchemaType.INBOX)
-        whenever(lowRankInboxProp.items).thenReturn(listOf(lowRankInboxItem))
-        whenever(highRankInboxProp.items).thenReturn(listOf(highRankInboxItem))
-        whenever(lowRankInboxProp.rank).thenReturn(5)
-        whenever(highRankInboxProp.rank).thenReturn(10)
+        whenever(lowPriorityInboxItem.schema).thenReturn(SchemaType.INBOX)
+        whenever(highPriorityInboxItem.schema).thenReturn(SchemaType.INBOX)
+        whenever(lowPriorityInboxProp.items).thenReturn(listOf(lowPriorityInboxItem))
+        whenever(highPriorityInboxProp.items).thenReturn(listOf(highPriorityInboxItem))
+        whenever(lowPriorityInboxProp.priority).thenReturn(10)
+        whenever(highPriorityInboxProp.priority).thenReturn(50)
 
-        val lowRankTemplate = InboxTemplate(
-            id = "low-rank-inbox",
-            heading = AepText("Low Rank Inbox"),
+        val lowPriorityTemplate = InboxTemplate(
+            id = "low-priority-inbox",
+            heading = AepText("Low Priority Inbox"),
             layout = AepInboxLayout.VERTICAL,
             capacity = 10,
             emptyMessage = AepText("No messages")
         )
-        val highRankTemplate = InboxTemplate(
-            id = "high-rank-inbox",
-            heading = AepText("High Rank Inbox"),
+        val highPriorityTemplate = InboxTemplate(
+            id = "high-priority-inbox",
+            heading = AepText("High Priority Inbox"),
             layout = AepInboxLayout.VERTICAL,
             capacity = 10,
             emptyMessage = AepText("No messages")
         )
-        every { ContentCardSchemaDataUtils.createInboxTemplate(lowRankInboxProp) } returns lowRankTemplate
-        every { ContentCardSchemaDataUtils.createInboxTemplate(highRankInboxProp) } returns highRankTemplate
+        every { ContentCardSchemaDataUtils.createInboxTemplate(lowPriorityInboxProp) } returns lowPriorityTemplate
+        every { ContentCardSchemaDataUtils.createInboxTemplate(highPriorityInboxProp) } returns highPriorityTemplate
 
         mockMessaging.`when`<Unit> {
             Messaging.getPropositionsForSurfaces(any(), any())
         }.thenAnswer { invocation ->
             val callback =
                 invocation.arguments[1] as AdobeCallbackWithError<Map<Surface, List<Proposition>>>
-            // Include both inbox propositions and a content card proposition
-            callback.call(mapOf(surface to listOf(lowRankInboxProp, highRankInboxProp, proposition)))
+            callback.call(mapOf(surface to listOf(lowPriorityInboxProp, highPriorityInboxProp)))
         }
 
-        val flow = messagingInboxProvider.getInboxUI()
-        val states = flow.take(2).toList()
+        val states = messagingInboxProvider.getInboxUI().take(2).toList()
 
         assertTrue("Second state should be Success", states[1] is InboxUIState.Success)
-        val successState = states[1] as InboxUIState.Success
         assertEquals(
-            "Should use the inbox proposition with the highest rank",
-            "high-rank-inbox",
-            successState.template.id
+            "Should select the inbox proposition with the highest priority",
+            "high-priority-inbox",
+            (states[1] as InboxUIState.Success).template.id
+        )
+    }
+
+    @Test
+    fun `fetchInbox selects latest modified inbox proposition when priorities are equal`() = runTest {
+        // The propositions list is ordered latest-modified first.
+        // Both have the same priority, so the first element (latest modified) should win.
+        val olderInboxProp = mock(Proposition::class.java)
+        val newerInboxProp = mock(Proposition::class.java)
+        val olderInboxItem = mock(PropositionItem::class.java)
+        val newerInboxItem = mock(PropositionItem::class.java)
+
+        whenever(olderInboxItem.schema).thenReturn(SchemaType.INBOX)
+        whenever(newerInboxItem.schema).thenReturn(SchemaType.INBOX)
+        whenever(olderInboxProp.items).thenReturn(listOf(olderInboxItem))
+        whenever(newerInboxProp.items).thenReturn(listOf(newerInboxItem))
+        whenever(olderInboxProp.priority).thenReturn(25)
+        whenever(newerInboxProp.priority).thenReturn(25)
+
+        val olderTemplate = InboxTemplate(
+            id = "older-inbox",
+            heading = AepText("Older Inbox"),
+            layout = AepInboxLayout.VERTICAL,
+            capacity = 10,
+            emptyMessage = AepText("No messages")
+        )
+        val newerTemplate = InboxTemplate(
+            id = "newer-inbox",
+            heading = AepText("Newer Inbox"),
+            layout = AepInboxLayout.VERTICAL,
+            capacity = 10,
+            emptyMessage = AepText("No messages")
+        )
+        every { ContentCardSchemaDataUtils.createInboxTemplate(olderInboxProp) } returns olderTemplate
+        every { ContentCardSchemaDataUtils.createInboxTemplate(newerInboxProp) } returns newerTemplate
+
+        mockMessaging.`when`<Unit> {
+            Messaging.getPropositionsForSurfaces(any(), any())
+        }.thenAnswer { invocation ->
+            val callback =
+                invocation.arguments[1] as AdobeCallbackWithError<Map<Surface, List<Proposition>>>
+            // List is ordered latest-modified first: newerInboxProp comes before olderInboxProp
+            callback.call(mapOf(surface to listOf(newerInboxProp, olderInboxProp)))
+        }
+
+        val states = messagingInboxProvider.getInboxUI().take(2).toList()
+
+        assertTrue("Second state should be Success", states[1] is InboxUIState.Success)
+        assertEquals(
+            "Should select the latest modified inbox proposition when priorities are equal",
+            "newer-inbox",
+            (states[1] as InboxUIState.Success).template.id
         )
     }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

1. Select inbox proposition based on priority and implicit IDS ordering based on last modified date.
2. Fix logic to parse hex color code for unread background color sepcified in inbox propositions.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
