### PR TITLE
Fix content card duplication bug, auto dismiss card in inbox

### DIFF
--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/aepcomposeui/state/InboxUIState.kt
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/aepcomposeui/state/InboxUIState.kt
@@ -29,7 +29,6 @@ sealed interface InboxUIState {
      *
      * @param template The properties to be used for rendering the inbox
      * @param items List of AEP UI elements to display in the inbox
-     * @param displayed Whether the inbox display event has been tracked
      */
     data class Success(
         val template: InboxTemplate,

--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/ContentCardEventObserver.kt
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/ContentCardEventObserver.kt
@@ -27,9 +27,9 @@ import com.adobe.marketing.mobile.aepcomposeui.uimodels.SmallImageTemplate
  * [ContentCardUIEventListener] callback), then optionally the [ContentCardUIProvider] for flow updates.
  *
  * @param callback An optional callback to invoke when a content card event occurs.
- * @param provider An optional [ContentCardUIProvider] that owns the content card state.
- *   When provided, the observer will call [ContentCardUIProvider.onEvent] after handling
- *   so the provider can emit state updates to its flow.
+ * @param provider An optional [ContentCardUIProvider] for the same surface as your card list.
+ *   When provided, the observer notifies the provider after handling so [ContentCardUIProvider.getContentCardUIFlow]
+ *   collectors can receive updated card state without a manual refresh.
  */
 class ContentCardEventObserver @JvmOverloads constructor(
     private val callback: ContentCardUIEventListener? = null,

--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/ContentCardUIProvider.kt
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/ContentCardUIProvider.kt
@@ -80,14 +80,32 @@ class ContentCardUIProvider(val surface: Surface) : AepUIContentProvider {
      * Retrieves a flow of AepUI instances for the given surface.
      *
      * This function initiates the content fetch and returns a flow of [AepUI] instances
-     * that represent the UI templates. The flow emits updates whenever [refreshContent] is called
-     * or when [onEvent] is called to update a card's state.
+     * that represent the UI templates. The flow emits updates when [refreshContent] is called
+     * and when card UI events are processed (for example via [ContentCardEventObserver] with this provider).
      *
      * @return A [Flow] that emits a [Result] containing a list of [AepUI] instances.
      */
-    fun getContentCardUI(): Flow<Result<List<AepUI<*, *>>>> = flow {
+    fun getContentCardUIFlow(): Flow<Result<List<AepUI<*, *>>>> = flow {
         refreshContent()
         emitAll(aepUIFlow)
+    }
+
+    /**
+     * Retrieves a flow of AepUI instances for the given surface.
+     *
+     * Deprecated in favor of [getContentCardUIFlow] which is a non-suspend function and follows
+     * idiomatic Kotlin Flow design — the flow reference can be obtained without a coroutine context,
+     * and suspension occurs during collection rather than at the call site.
+     *
+     * @return A [Flow] that emits a [Result] containing a list of [AepUI] instances.
+     */
+    @Deprecated(
+        message = "Use getContentCardUIFlow() instead.",
+        replaceWith = ReplaceWith("getContentCardUIFlow()")
+    )
+    suspend fun getContentCardUI(): Flow<Result<List<AepUI<*, *>>>> {
+        refreshContent()
+        return aepUIFlow
     }
 
     /**
@@ -102,7 +120,7 @@ class ContentCardUIProvider(val surface: Surface) : AepUIContentProvider {
         val templateResult = fetchContent()
         _contentFlow.update { templateResult }
 
-        // Also update _aepUIFlow so getContentCardUI collectors receive refresh updates
+        // Also update _aepUIFlow so getContentCardUIFlow collectors receive refresh updates
         _aepUIFlow.update {
             if (templateResult.isSuccess) {
                 val aepUIList = templateResult.getOrDefault(emptyList())

--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/EdgePersonalizationResponseHandler.java
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/EdgePersonalizationResponseHandler.java
@@ -995,7 +995,7 @@ class EdgePersonalizationResponseHandler {
         for (final Surface surface : surfaces) {
             final List<Proposition> propositionsList = inMemoryPropositions.get(surface);
             if (!MessagingUtils.isNullOrEmpty(propositionsList)) {
-                propositionMap.put(surface, propositionsList);
+                propositionMap.put(surface, new ArrayList<>(propositionsList));
             }
         }
         return propositionMap;

--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/InboxEventObserver.kt
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/InboxEventObserver.kt
@@ -64,5 +64,6 @@ class InboxEventObserver(
 
     override fun onEvent(event: UIEvent<*, *>) {
         itemObserver.onEvent(event)
+        provider.inboxEventObserver.onEvent(event)
     }
 }

--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/MessagingInboxProvider.kt
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/MessagingInboxProvider.kt
@@ -197,7 +197,19 @@ class MessagingInboxProvider(
         }
 
         override fun onEvent(event: UIEvent<*, *>) {
-            // Currently no-op for item events
+            if (event is UIEvent.Dismiss) {
+                val currentState = _inboxStateFlow.value
+                if (currentState is InboxUIState.Success) {
+                    val dismissedId = event.aepUi.getTemplate().id
+                    _inboxStateFlow.update {
+                        currentState.copy(
+                            items = currentState.items.filter {
+                                it.getTemplate().id != dismissedId
+                            }
+                        )
+                    }
+                }
+            }
         }
     }
 }

--- a/code/messaging/src/test/java/com/adobe/marketing/mobile/messaging/ContentCardUIProviderTests.kt
+++ b/code/messaging/src/test/java/com/adobe/marketing/mobile/messaging/ContentCardUIProviderTests.kt
@@ -102,8 +102,103 @@ class ContentCardUIProviderTests {
     }
 
     @Test
-    fun `getContentCardUI returns success with valid template`() = runTest {
+    fun `getContentCardUIFlow returns success with valid template`() = runTest {
 
+        mockMessaging.`when`<Unit> {
+            Messaging.getPropositionsForSurfaces(any(), any())
+        }.thenAnswer { invocation ->
+            val callback = invocation.arguments[1] as AdobeCallbackWithError<Map<Surface, List<Proposition>>>
+            callback.call(mapOf(surface to listOf(proposition)))
+        }
+
+        val flow = contentCardUIProvider.getContentCardUIFlow()
+        val result = flow.first()
+
+        assertTrue(result.isSuccess)
+        assertNotNull(result.getOrNull())
+        assertTrue(result.getOrNull()?.isNotEmpty() == true)
+    }
+
+    @Test
+    fun `getContentCardUIFlow handles null proposition map`() = runTest {
+        mockMessaging.`when`<Unit> {
+            Messaging.getPropositionsForSurfaces(any(), any())
+        }.thenAnswer { invocation ->
+            val callback = invocation.arguments[1] as AdobeCallbackWithError<Map<Surface, List<Proposition>>>
+            callback.call(null)
+        }
+
+        val flow = contentCardUIProvider.getContentCardUIFlow()
+        val result = flow.first()
+        assertTrue(result.isFailure)
+    }
+
+    @Test
+    fun `getContentCardUIFlow handles empty proposition list`() = runTest {
+        mockMessaging.`when`<Unit> {
+            Messaging.getPropositionsForSurfaces(any(), any())
+        }.thenAnswer { invocation ->
+            val callback = invocation.arguments[1] as AdobeCallbackWithError<Map<Surface, List<Proposition>>>
+            callback.call(mapOf(surface to emptyList()))
+        }
+
+        val flow = contentCardUIProvider.getContentCardUIFlow()
+        val result = flow.first()
+        assertTrue(result.isSuccess)
+        assertTrue(result.getOrNull()?.isEmpty() == true)
+    }
+
+    @Test
+    fun `getContentCardUIFlow handles invalid schema type`() = runTest {
+        whenever(propositionItem.schema).thenReturn(SchemaType.HTML_CONTENT)
+
+        mockMessaging.`when`<Unit> {
+            Messaging.getPropositionsForSurfaces(any(), any())
+        }.thenAnswer { invocation ->
+            val callback = invocation.arguments[1] as AdobeCallbackWithError<Map<Surface, List<Proposition>>>
+            callback.call(mapOf(surface to listOf(proposition)))
+        }
+
+        val flow = contentCardUIProvider.getContentCardUIFlow()
+        val result = flow.first()
+        assertTrue(result.isSuccess)
+        assertTrue(result.getOrNull()?.isEmpty() == true)
+    }
+
+    @Test
+    fun `getContentCardUIFlow handles missing content`() = runTest {
+        whenever(contentCardSchemaData.content).thenReturn(null)
+
+        mockMessaging.`when`<Unit> {
+            Messaging.getPropositionsForSurfaces(any(), any())
+        }.thenAnswer { invocation ->
+            val callback = invocation.arguments[1] as AdobeCallbackWithError<Map<Surface, List<Proposition>>>
+            callback.call(mapOf(surface to listOf(proposition)))
+        }
+
+        val flow = contentCardUIProvider.getContentCardUIFlow()
+        val result = flow.first()
+        assertTrue(result.isSuccess)
+        assertTrue(result.getOrNull()?.isEmpty() == true)
+    }
+
+    @Test
+    fun `getContentCardUIFlow handles API failure`() = runTest {
+        mockMessaging.`when`<Unit> {
+            Messaging.getPropositionsForSurfaces(any(), any())
+        }.thenAnswer { invocation ->
+            val callback = invocation.arguments[1] as AdobeCallbackWithError<Map<Surface, List<Proposition>>>
+            callback.fail(AdobeError.UNEXPECTED_ERROR)
+        }
+
+        val flow = contentCardUIProvider.getContentCardUIFlow()
+        val result = flow.first()
+        assertTrue(result.isFailure)
+    }
+
+    @Suppress("DEPRECATION")
+    @Test
+    fun `deprecated getContentCardUI returns success with valid template`() = runTest {
         mockMessaging.`when`<Unit> {
             Messaging.getPropositionsForSurfaces(any(), any())
         }.thenAnswer { invocation ->
@@ -119,71 +214,26 @@ class ContentCardUIProviderTests {
         assertTrue(result.getOrNull()?.isNotEmpty() == true)
     }
 
+    @Suppress("DEPRECATION")
     @Test
-    fun `getContentCardUI handles null proposition map`() = runTest {
+    fun `deprecated getContentCardUI eagerly fetches content before returning flow`() = runTest {
+        var callCount = 0
         mockMessaging.`when`<Unit> {
             Messaging.getPropositionsForSurfaces(any(), any())
         }.thenAnswer { invocation ->
             val callback = invocation.arguments[1] as AdobeCallbackWithError<Map<Surface, List<Proposition>>>
-            callback.call(null)
-        }
-
-        val flow = contentCardUIProvider.getContentCardUI()
-        val result = flow.first()
-        assertTrue(result.isFailure)
-    }
-
-    @Test
-    fun `getContentCardUI handles empty proposition list`() = runTest {
-        mockMessaging.`when`<Unit> {
-            Messaging.getPropositionsForSurfaces(any(), any())
-        }.thenAnswer { invocation ->
-            val callback = invocation.arguments[1] as AdobeCallbackWithError<Map<Surface, List<Proposition>>>
-            callback.call(mapOf(surface to emptyList()))
-        }
-
-        val flow = contentCardUIProvider.getContentCardUI()
-        val result = flow.first()
-        assertTrue(result.isSuccess)
-        assertTrue(result.getOrNull()?.isEmpty() == true)
-    }
-
-    @Test
-    fun `getContentCardUI handles invalid schema type`() = runTest {
-        whenever(propositionItem.schema).thenReturn(SchemaType.HTML_CONTENT)
-
-        mockMessaging.`when`<Unit> {
-            Messaging.getPropositionsForSurfaces(any(), any())
-        }.thenAnswer { invocation ->
-            val callback = invocation.arguments[1] as AdobeCallbackWithError<Map<Surface, List<Proposition>>>
+            callCount++
             callback.call(mapOf(surface to listOf(proposition)))
         }
 
-        val flow = contentCardUIProvider.getContentCardUI()
-        val result = flow.first()
-        assertTrue(result.isSuccess)
-        assertTrue(result.getOrNull()?.isEmpty() == true)
+        // With the deprecated suspend version, refreshContent is called before the flow is returned
+        contentCardUIProvider.getContentCardUI()
+        assertTrue("refreshContent should have been called eagerly before collection", callCount == 1)
     }
 
+    @Suppress("DEPRECATION")
     @Test
-    fun `getContentCardUI handles missing content`() = runTest {
-        whenever(contentCardSchemaData.content).thenReturn(null)
-
-        mockMessaging.`when`<Unit> {
-            Messaging.getPropositionsForSurfaces(any(), any())
-        }.thenAnswer { invocation ->
-            val callback = invocation.arguments[1] as AdobeCallbackWithError<Map<Surface, List<Proposition>>>
-            callback.call(mapOf(surface to listOf(proposition)))
-        }
-
-        val flow = contentCardUIProvider.getContentCardUI()
-        val result = flow.first()
-        assertTrue(result.isSuccess)
-        assertTrue(result.getOrNull()?.isEmpty() == true)
-    }
-
-    @Test
-    fun `getContentCardUI handles API failure`() = runTest {
+    fun `deprecated getContentCardUI handles API failure`() = runTest {
         mockMessaging.`when`<Unit> {
             Messaging.getPropositionsForSurfaces(any(), any())
         }.thenAnswer { invocation ->
@@ -229,7 +279,7 @@ class ContentCardUIProviderTests {
     }
 
     @Test
-    fun `getContentCardUI handles proposition with no items`() = runTest {
+    fun `getContentCardUIFlow handles proposition with no items`() = runTest {
         whenever(proposition.items).thenReturn(emptyList())
 
         mockMessaging.`when`<Unit> {
@@ -239,14 +289,14 @@ class ContentCardUIProviderTests {
             callback.call(mapOf(surface to listOf(proposition)))
         }
 
-        val flow = contentCardUIProvider.getContentCardUI()
+        val flow = contentCardUIProvider.getContentCardUIFlow()
         val result = flow.first()
         assertTrue(result.isSuccess)
         assertTrue(result.getOrNull()?.isEmpty() == true)
     }
 
     @Test
-    fun `getContentCardUI handles null contentCardSchemaData`() = runTest {
+    fun `getContentCardUIFlow handles null contentCardSchemaData`() = runTest {
         whenever(propositionItem.contentCardSchemaData).thenReturn(null)
 
         mockMessaging.`when`<Unit> {
@@ -256,7 +306,7 @@ class ContentCardUIProviderTests {
             callback.call(mapOf(surface to listOf(proposition)))
         }
 
-        val flow = contentCardUIProvider.getContentCardUI()
+        val flow = contentCardUIProvider.getContentCardUIFlow()
         val result = flow.first()
         assertTrue(result.isSuccess)
         assertTrue(result.getOrNull()?.isEmpty() == true)
@@ -561,7 +611,7 @@ class ContentCardUIProviderTests {
     }
 
     @Test
-    fun `refreshContent updates getContentCardUI collectors`() = runTest {
+    fun `refreshContent updates getContentCardUIFlow collectors`() = runTest {
         var callCount = 0
         mockMessaging.`when`<Unit> {
             Messaging.getPropositionsForSurfaces(any(), any())
@@ -571,7 +621,7 @@ class ContentCardUIProviderTests {
             callback.call(mapOf(surface to listOf(proposition)))
         }
 
-        // Start collecting from getContentCardUI
+        // Start collecting from getContentCardUIFlow
         val results = mutableListOf<Result<List<AepUI<*, *>>>>()
         val job = launch {
             contentCardUIProvider.getContentCardUI().collect { result ->

--- a/code/messaging/src/test/java/com/adobe/marketing/mobile/messaging/ContentCardUIProviderTests.kt
+++ b/code/messaging/src/test/java/com/adobe/marketing/mobile/messaging/ContentCardUIProviderTests.kt
@@ -196,88 +196,6 @@ class ContentCardUIProviderTests {
         assertTrue(result.isFailure)
     }
 
-    @Suppress("DEPRECATION")
-    @Test
-    fun `deprecated getContentCardUI returns success with valid template`() = runTest {
-        mockMessaging.`when`<Unit> {
-            Messaging.getPropositionsForSurfaces(any(), any())
-        }.thenAnswer { invocation ->
-            val callback = invocation.arguments[1] as AdobeCallbackWithError<Map<Surface, List<Proposition>>>
-            callback.call(mapOf(surface to listOf(proposition)))
-        }
-
-        val flow = contentCardUIProvider.getContentCardUI()
-        val result = flow.first()
-
-        assertTrue(result.isSuccess)
-        assertNotNull(result.getOrNull())
-        assertTrue(result.getOrNull()?.isNotEmpty() == true)
-    }
-
-    @Suppress("DEPRECATION")
-    @Test
-    fun `deprecated getContentCardUI eagerly fetches content before returning flow`() = runTest {
-        var callCount = 0
-        mockMessaging.`when`<Unit> {
-            Messaging.getPropositionsForSurfaces(any(), any())
-        }.thenAnswer { invocation ->
-            val callback = invocation.arguments[1] as AdobeCallbackWithError<Map<Surface, List<Proposition>>>
-            callCount++
-            callback.call(mapOf(surface to listOf(proposition)))
-        }
-
-        // With the deprecated suspend version, refreshContent is called before the flow is returned
-        contentCardUIProvider.getContentCardUI()
-        assertTrue("refreshContent should have been called eagerly before collection", callCount == 1)
-    }
-
-    @Suppress("DEPRECATION")
-    @Test
-    fun `deprecated getContentCardUI handles API failure`() = runTest {
-        mockMessaging.`when`<Unit> {
-            Messaging.getPropositionsForSurfaces(any(), any())
-        }.thenAnswer { invocation ->
-            val callback = invocation.arguments[1] as AdobeCallbackWithError<Map<Surface, List<Proposition>>>
-            callback.fail(AdobeError.UNEXPECTED_ERROR)
-        }
-
-        val flow = contentCardUIProvider.getContentCardUI()
-        val result = flow.first()
-        assertTrue(result.isFailure)
-    }
-
-    @Test
-    fun `refreshContent triggers new content fetch`() = runTest {
-        mockMessaging.`when`<Unit> {
-            Messaging.getPropositionsForSurfaces(any(), any())
-        }.thenAnswer { invocation ->
-            val callback = invocation.arguments[1] as AdobeCallbackWithError<Map<Surface, List<Proposition>>>
-            callback.call(mapOf(surface to listOf(proposition)))
-        }
-
-        contentCardUIProvider.refreshContent()
-        val flow = contentCardUIProvider.getUIContent()
-        val result = flow.first()
-        assertTrue(result.isSuccess)
-    }
-
-    @Test
-    fun `getContent handles missing meta data`() = runTest {
-        whenever(contentCardSchemaData.meta).thenReturn(null)
-
-        mockMessaging.`when`<Unit> {
-            Messaging.getPropositionsForSurfaces(any(), any())
-        }.thenAnswer { invocation ->
-            val callback = invocation.arguments[1] as AdobeCallbackWithError<Map<Surface, List<Proposition>>>
-            callback.call(mapOf(surface to listOf(proposition)))
-        }
-
-        val flow = contentCardUIProvider.getUIContent()
-        val result = flow.first()
-        assertTrue(result.isSuccess)
-        assertTrue(result.getOrNull()?.isEmpty() == true)
-    }
-
     @Test
     fun `getContentCardUIFlow handles proposition with no items`() = runTest {
         whenever(proposition.items).thenReturn(emptyList())
@@ -307,6 +225,195 @@ class ContentCardUIProviderTests {
         }
 
         val flow = contentCardUIProvider.getContentCardUIFlow()
+        val result = flow.first()
+        assertTrue(result.isSuccess)
+        assertTrue(result.getOrNull()?.isEmpty() == true)
+    }
+
+    @Suppress("DEPRECATION")
+    @Test
+    fun `deprecated getContentCardUI returns success with valid template`() = runTest {
+        mockMessaging.`when`<Unit> {
+            Messaging.getPropositionsForSurfaces(any(), any())
+        }.thenAnswer { invocation ->
+            val callback = invocation.arguments[1] as AdobeCallbackWithError<Map<Surface, List<Proposition>>>
+            callback.call(mapOf(surface to listOf(proposition)))
+        }
+
+        val flow = contentCardUIProvider.getContentCardUI()
+        val result = flow.first()
+
+        assertTrue(result.isSuccess)
+        assertNotNull(result.getOrNull())
+        assertTrue(result.getOrNull()?.isNotEmpty() == true)
+    }
+
+    @Suppress("DEPRECATION")
+    @Test
+    fun `getContentCardUI eagerly fetches content before returning flow`() = runTest {
+        var callCount = 0
+        mockMessaging.`when`<Unit> {
+            Messaging.getPropositionsForSurfaces(any(), any())
+        }.thenAnswer { invocation ->
+            val callback = invocation.arguments[1] as AdobeCallbackWithError<Map<Surface, List<Proposition>>>
+            callCount++
+            callback.call(mapOf(surface to listOf(proposition)))
+        }
+
+        // With the deprecated suspend version, refreshContent is called before the flow is returned
+        contentCardUIProvider.getContentCardUI()
+        assertTrue("refreshContent should have been called eagerly before collection", callCount == 1)
+    }
+
+    @Suppress("DEPRECATION")
+    @Test
+    fun `getContentCardUI returns success with valid template`() = runTest {
+
+        mockMessaging.`when`<Unit> {
+            Messaging.getPropositionsForSurfaces(any(), any())
+        }.thenAnswer { invocation ->
+            val callback = invocation.arguments[1] as AdobeCallbackWithError<Map<Surface, List<Proposition>>>
+            callback.call(mapOf(surface to listOf(proposition)))
+        }
+
+        val flow = contentCardUIProvider.getContentCardUI()
+        val result = flow.first()
+
+        assertTrue(result.isSuccess)
+        assertNotNull(result.getOrNull())
+        assertTrue(result.getOrNull()?.isNotEmpty() == true)
+    }
+
+    @Suppress("DEPRECATION")
+    @Test
+    fun `getContentCardUI handles null proposition map`() = runTest {
+        mockMessaging.`when`<Unit> {
+            Messaging.getPropositionsForSurfaces(any(), any())
+        }.thenAnswer { invocation ->
+            val callback = invocation.arguments[1] as AdobeCallbackWithError<Map<Surface, List<Proposition>>>
+            callback.call(null)
+        }
+
+        val flow = contentCardUIProvider.getContentCardUI()
+        val result = flow.first()
+        assertTrue(result.isFailure)
+    }
+
+    @Suppress("DEPRECATION")
+    @Test
+    fun `getContentCardUI handles empty proposition list`() = runTest {
+        mockMessaging.`when`<Unit> {
+            Messaging.getPropositionsForSurfaces(any(), any())
+        }.thenAnswer { invocation ->
+            val callback = invocation.arguments[1] as AdobeCallbackWithError<Map<Surface, List<Proposition>>>
+            callback.call(mapOf(surface to emptyList()))
+        }
+
+        val flow = contentCardUIProvider.getContentCardUI()
+        val result = flow.first()
+        assertTrue(result.isSuccess)
+        assertTrue(result.getOrNull()?.isEmpty() == true)
+    }
+
+    @Suppress("DEPRECATION")
+    @Test
+    fun `getContentCardUI handles invalid schema type`() = runTest {
+        whenever(propositionItem.schema).thenReturn(SchemaType.HTML_CONTENT)
+
+        mockMessaging.`when`<Unit> {
+            Messaging.getPropositionsForSurfaces(any(), any())
+        }.thenAnswer { invocation ->
+            val callback = invocation.arguments[1] as AdobeCallbackWithError<Map<Surface, List<Proposition>>>
+            callback.call(mapOf(surface to listOf(proposition)))
+        }
+
+        val flow = contentCardUIProvider.getContentCardUI()
+        val result = flow.first()
+        assertTrue(result.isSuccess)
+        assertTrue(result.getOrNull()?.isEmpty() == true)
+    }
+
+    @Suppress("DEPRECATION")
+    @Test
+    fun `getContentCardUI handles missing content`() = runTest {
+        whenever(contentCardSchemaData.content).thenReturn(null)
+
+        mockMessaging.`when`<Unit> {
+            Messaging.getPropositionsForSurfaces(any(), any())
+        }.thenAnswer { invocation ->
+            val callback = invocation.arguments[1] as AdobeCallbackWithError<Map<Surface, List<Proposition>>>
+            callback.call(mapOf(surface to listOf(proposition)))
+        }
+
+        val flow = contentCardUIProvider.getContentCardUI()
+        val result = flow.first()
+        assertTrue(result.isSuccess)
+        assertTrue(result.getOrNull()?.isEmpty() == true)
+    }
+
+    @Suppress("DEPRECATION")
+    @Test
+    fun `getContentCardUI handles proposition with no items`() = runTest {
+        whenever(proposition.items).thenReturn(emptyList())
+
+        mockMessaging.`when`<Unit> {
+            Messaging.getPropositionsForSurfaces(any(), any())
+        }.thenAnswer { invocation ->
+            val callback = invocation.arguments[1] as AdobeCallbackWithError<Map<Surface, List<Proposition>>>
+            callback.call(mapOf(surface to listOf(proposition)))
+        }
+
+        val flow = contentCardUIProvider.getContentCardUI()
+        val result = flow.first()
+        assertTrue(result.isSuccess)
+        assertTrue(result.getOrNull()?.isEmpty() == true)
+    }
+
+    @Suppress("DEPRECATION")
+    @Test
+    fun `getContentCardUI handles null contentCardSchemaData`() = runTest {
+        whenever(propositionItem.contentCardSchemaData).thenReturn(null)
+
+        mockMessaging.`when`<Unit> {
+            Messaging.getPropositionsForSurfaces(any(), any())
+        }.thenAnswer { invocation ->
+            val callback = invocation.arguments[1] as AdobeCallbackWithError<Map<Surface, List<Proposition>>>
+            callback.call(mapOf(surface to listOf(proposition)))
+        }
+
+        val flow = contentCardUIProvider.getContentCardUI()
+        val result = flow.first()
+        assertTrue(result.isSuccess)
+        assertTrue(result.getOrNull()?.isEmpty() == true)
+    }
+
+    @Test
+    fun `refreshContent triggers new content fetch`() = runTest {
+        mockMessaging.`when`<Unit> {
+            Messaging.getPropositionsForSurfaces(any(), any())
+        }.thenAnswer { invocation ->
+            val callback = invocation.arguments[1] as AdobeCallbackWithError<Map<Surface, List<Proposition>>>
+            callback.call(mapOf(surface to listOf(proposition)))
+        }
+
+        contentCardUIProvider.refreshContent()
+        val flow = contentCardUIProvider.getUIContent()
+        val result = flow.first()
+        assertTrue(result.isSuccess)
+    }
+
+    @Test
+    fun `getContent handles missing meta data`() = runTest {
+        whenever(contentCardSchemaData.meta).thenReturn(null)
+
+        mockMessaging.`when`<Unit> {
+            Messaging.getPropositionsForSurfaces(any(), any())
+        }.thenAnswer { invocation ->
+            val callback = invocation.arguments[1] as AdobeCallbackWithError<Map<Surface, List<Proposition>>>
+            callback.call(mapOf(surface to listOf(proposition)))
+        }
+
+        val flow = contentCardUIProvider.getUIContent()
         val result = flow.first()
         assertTrue(result.isSuccess)
         assertTrue(result.getOrNull()?.isEmpty() == true)

--- a/code/messaging/src/test/java/com/adobe/marketing/mobile/messaging/EdgePersonalizationResponseHandlerTests.java
+++ b/code/messaging/src/test/java/com/adobe/marketing/mobile/messaging/EdgePersonalizationResponseHandlerTests.java
@@ -1909,6 +1909,140 @@ public class EdgePersonalizationResponseHandlerTests {
                 });
     }
 
+    @Test
+    public void
+            test_retrieveMessages_doesNotStoreContentCardsInTheSameMapAsOtherInMemoryPropositions() {
+        runUsingMockedServiceProvider(
+                () -> {
+                    try (MockedStatic<JSONRulesParser> ignored =
+                            Mockito.mockStatic(JSONRulesParser.class)) {
+                        when(JSONRulesParser.parse(anyString(), any(ExtensionApi.class)))
+                                .thenCallRealMethod();
+
+                        // setup a shared surface for inbox and content cards
+                        Surface surface = new Surface("apifeed");
+                        List<Surface> surfaces = Collections.singletonList(surface);
+
+                        // build an inbox proposition payload to populate inMemoryPropositions
+                        Map<String, Object> inboxItemData =
+                                MessagingTestUtils.getMapFromFile("inboxPropositionContent.json");
+                        Map<String, Object> inboxItem = new HashMap<>();
+                        inboxItem.put("id", "inbox-item-id-001");
+                        inboxItem.put("schema", SchemaType.INBOX.toString());
+                        inboxItem.put("data", inboxItemData);
+
+                        Map<String, Object> activityMap = new HashMap<>();
+                        activityMap.put("id", "test-inbox-activity-id");
+                        Map<String, Object> scopeDetails = new HashMap<>();
+                        scopeDetails.put("activity", activityMap);
+                        scopeDetails.put("decisionProvider", "AJO");
+
+                        Map<String, Object> inboxPropositionMap = new HashMap<>();
+                        inboxPropositionMap.put("id", "inbox-proposition-id-001");
+                        inboxPropositionMap.put("scope", surface.getUri());
+                        inboxPropositionMap.put("scopeDetails", scopeDetails);
+                        inboxPropositionMap.put(
+                                "items", Collections.singletonList(inboxItem));
+
+                        Map<String, Object> eventData = new HashMap<>();
+                        eventData.put(
+                                "payload",
+                                Collections.singletonList(inboxPropositionMap));
+                        eventData.put("requestEventId", "TESTING_ID");
+                        Event mockEvent = mock(Event.class);
+                        when(mockEvent.getEventData()).thenReturn(eventData);
+
+                        edgePersonalizationResponseHandler.setMessagesRequestEventId(
+                                "TESTING_ID", surfaces);
+                        edgePersonalizationResponseHandler
+                                .handleEdgePersonalizationNotification(mockEvent);
+
+                        eventData = new HashMap<>();
+                        eventData.put(ENDING_EVENT_ID, "TESTING_ID");
+                        mockEvent = mock(Event.class);
+                        when(mockEvent.getEventData()).thenReturn(eventData);
+                        edgePersonalizationResponseHandler.handleProcessCompletedEvent(
+                                mockEvent);
+
+                        // setup 2 qualified content cards in contentCardsBySurface
+                        MessageTestConfig config = new MessageTestConfig();
+                        config.count = 2;
+                        Map<Surface, List<Proposition>> qualifiedContentCards = new HashMap<>();
+                        qualifiedContentCards.put(
+                                surface,
+                                MessagingTestUtils.generateQualifiedContentCards(config));
+                        edgePersonalizationResponseHandler
+                                .setQualifiedContentCardsBySurface(qualifiedContentCards);
+
+                        reset(mockExtensionApi);
+                        ArgumentCaptor<Event> localCaptor =
+                                ArgumentCaptor.forClass(Event.class);
+
+                        // first call — dispatches 1 inbox + 2 content cards = 3 propositions
+                        edgePersonalizationResponseHandler.retrieveInMemoryPropositions(
+                                surfaces, mockEvent);
+
+                        // clear content cards — simulates a scenario where they are no longer
+                        // qualified
+                        edgePersonalizationResponseHandler.setQualifiedContentCardsBySurface(
+                                new HashMap<>());
+
+                        // second call — should dispatch only the 1 inbox proposition
+                        // without the fix, the 2 content cards leaked into inMemoryPropositions
+                        // on the first call, so the second call would wrongly return 3
+                        edgePersonalizationResponseHandler.retrieveInMemoryPropositions(
+                                surfaces, mockEvent);
+
+                        verify(mockExtensionApi, times(2)).dispatch(localCaptor.capture());
+                        List<Event> dispatchedEvents = localCaptor.getAllValues();
+
+                        List<Map<String, Object>> firstCallPropositions =
+                                DataReader.optTypedListOfMap(
+                                        Object.class,
+                                        dispatchedEvents.get(0).getEventData(),
+                                        "propositions",
+                                        null);
+                        List<Map<String, Object>> secondCallPropositions =
+                                DataReader.optTypedListOfMap(
+                                        Object.class,
+                                        dispatchedEvents.get(1).getEventData(),
+                                        "propositions",
+                                        null);
+
+                        // verify first call has 1 inbox and 2 content card (ruleset) propositions
+                        assertEquals(3, firstCallPropositions.size());
+                        assertEquals(
+                                SchemaType.INBOX,
+                                Proposition.fromEventData(firstCallPropositions.get(0))
+                                        .getItems()
+                                        .get(0)
+                                        .getSchema());
+                        assertEquals(
+                                SchemaType.RULESET,
+                                Proposition.fromEventData(firstCallPropositions.get(1))
+                                        .getItems()
+                                        .get(0)
+                                        .getSchema());
+                        assertEquals(
+                                SchemaType.RULESET,
+                                Proposition.fromEventData(firstCallPropositions.get(2))
+                                        .getItems()
+                                        .get(0)
+                                        .getSchema());
+
+                        // verify second call contains only the inbox proposition — no leaked
+                        // content cards
+                        assertEquals(1, secondCallPropositions.size());
+                        assertEquals(
+                                SchemaType.INBOX,
+                                Proposition.fromEventData(secondCallPropositions.get(0))
+                                        .getItems()
+                                        .get(0)
+                                        .getSchema());
+                    }
+                });
+    }
+
     // ========================================================================================
     // edgePersonalizationResponseHandler load cached propositions on instantiation
     // ========================================================================================

--- a/code/messaging/src/test/java/com/adobe/marketing/mobile/messaging/EdgePersonalizationResponseHandlerTests.java
+++ b/code/messaging/src/test/java/com/adobe/marketing/mobile/messaging/EdgePersonalizationResponseHandlerTests.java
@@ -1941,42 +1941,36 @@ public class EdgePersonalizationResponseHandlerTests {
                         inboxPropositionMap.put("id", "inbox-proposition-id-001");
                         inboxPropositionMap.put("scope", surface.getUri());
                         inboxPropositionMap.put("scopeDetails", scopeDetails);
-                        inboxPropositionMap.put(
-                                "items", Collections.singletonList(inboxItem));
+                        inboxPropositionMap.put("items", Collections.singletonList(inboxItem));
 
                         Map<String, Object> eventData = new HashMap<>();
-                        eventData.put(
-                                "payload",
-                                Collections.singletonList(inboxPropositionMap));
+                        eventData.put("payload", Collections.singletonList(inboxPropositionMap));
                         eventData.put("requestEventId", "TESTING_ID");
                         Event mockEvent = mock(Event.class);
                         when(mockEvent.getEventData()).thenReturn(eventData);
 
                         edgePersonalizationResponseHandler.setMessagesRequestEventId(
                                 "TESTING_ID", surfaces);
-                        edgePersonalizationResponseHandler
-                                .handleEdgePersonalizationNotification(mockEvent);
+                        edgePersonalizationResponseHandler.handleEdgePersonalizationNotification(
+                                mockEvent);
 
                         eventData = new HashMap<>();
                         eventData.put(ENDING_EVENT_ID, "TESTING_ID");
                         mockEvent = mock(Event.class);
                         when(mockEvent.getEventData()).thenReturn(eventData);
-                        edgePersonalizationResponseHandler.handleProcessCompletedEvent(
-                                mockEvent);
+                        edgePersonalizationResponseHandler.handleProcessCompletedEvent(mockEvent);
 
                         // setup 2 qualified content cards in contentCardsBySurface
                         MessageTestConfig config = new MessageTestConfig();
                         config.count = 2;
                         Map<Surface, List<Proposition>> qualifiedContentCards = new HashMap<>();
                         qualifiedContentCards.put(
-                                surface,
-                                MessagingTestUtils.generateQualifiedContentCards(config));
-                        edgePersonalizationResponseHandler
-                                .setQualifiedContentCardsBySurface(qualifiedContentCards);
+                                surface, MessagingTestUtils.generateQualifiedContentCards(config));
+                        edgePersonalizationResponseHandler.setQualifiedContentCardsBySurface(
+                                qualifiedContentCards);
 
                         reset(mockExtensionApi);
-                        ArgumentCaptor<Event> localCaptor =
-                                ArgumentCaptor.forClass(Event.class);
+                        ArgumentCaptor<Event> localCaptor = ArgumentCaptor.forClass(Event.class);
 
                         // first call — dispatches 1 inbox + 2 content cards = 3 propositions
                         edgePersonalizationResponseHandler.retrieveInMemoryPropositions(

--- a/code/messaging/src/test/java/com/adobe/marketing/mobile/messaging/InboxEventObserverTests.kt
+++ b/code/messaging/src/test/java/com/adobe/marketing/mobile/messaging/InboxEventObserverTests.kt
@@ -182,6 +182,8 @@ class InboxEventObserverTests {
     @Test
     fun `onEvent forwards to provided itemEventObserver`() {
         val mockProvider = mock(MessagingInboxProvider::class.java)
+        val mockInboxObserver = mock(AepInboxEventObserver::class.java)
+        `when`(mockProvider.inboxEventObserver).thenReturn(mockInboxObserver)
         val mockItemObserver = mock(AepUIEventObserver::class.java)
         val observer = InboxEventObserver(mockProvider, mockItemObserver)
 
@@ -200,6 +202,8 @@ class InboxEventObserverTests {
     @Test
     fun `onEvent with null itemEventObserver uses default ContentCardEventObserver`() {
         val mockProvider = mock(MessagingInboxProvider::class.java)
+        val mockInboxObserver = mock(AepInboxEventObserver::class.java)
+        `when`(mockProvider.inboxEventObserver).thenReturn(mockInboxObserver)
         val observer = InboxEventObserver(mockProvider, null)
 
         val mockAepUI = mock(AepUI::class.java)

--- a/code/messaging/src/test/java/com/adobe/marketing/mobile/messaging/MessagingInboxProviderTests.kt
+++ b/code/messaging/src/test/java/com/adobe/marketing/mobile/messaging/MessagingInboxProviderTests.kt
@@ -15,6 +15,7 @@ import com.adobe.marketing.mobile.AdobeCallbackWithError
 import com.adobe.marketing.mobile.AdobeError
 import com.adobe.marketing.mobile.Messaging
 import com.adobe.marketing.mobile.aepcomposeui.InboxEvent
+import com.adobe.marketing.mobile.aepcomposeui.UIEvent
 import com.adobe.marketing.mobile.aepcomposeui.state.InboxUIState
 import com.adobe.marketing.mobile.aepcomposeui.uimodels.AepInboxLayout
 import com.adobe.marketing.mobile.aepcomposeui.uimodels.AepText
@@ -837,6 +838,42 @@ class MessagingInboxProviderTests {
         val finalState = states.last()
         assertTrue("Final state should be Success", finalState is InboxUIState.Success)
         assertTrue("displayed flag should be true after update", (finalState as InboxUIState.Success).displayed)
+
+        job.cancel()
+    }
+
+    @Test
+    fun `onEvent Dismiss removes dismissed item from inbox state`() = runTest {
+        mockMessaging.`when`<Unit> {
+            Messaging.getPropositionsForSurfaces(any(), any())
+        }.thenAnswer { invocation ->
+            val callback =
+                invocation.arguments[1] as AdobeCallbackWithError<Map<Surface, List<Proposition>>>
+            callback.call(mapOf(surface to listOf(inboxProposition, proposition)))
+        }
+
+        val states = mutableListOf<InboxUIState>()
+        val job = launch {
+            messagingInboxProvider.getInboxUI().collect { state ->
+                states.add(state)
+            }
+        }
+
+        advanceUntilIdle()
+
+        assertTrue("Should have at least 2 states", states.size >= 2)
+        val initialSuccess = states[1] as InboxUIState.Success
+        assertEquals("Should have 1 item initially", 1, initialSuccess.items.size)
+
+        // Dismiss the only item
+        val itemToDismiss = initialSuccess.items.first()
+        messagingInboxProvider.inboxEventObserver.onEvent(UIEvent.Dismiss(itemToDismiss))
+
+        advanceUntilIdle()
+
+        assertTrue("Should have at least 3 states after dismiss", states.size >= 3)
+        val finalState = states.last() as InboxUIState.Success
+        assertTrue("Items should be empty after dismiss", finalState.items.isEmpty())
 
         job.cancel()
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

1.  `retrieveCachedPropositions()` now returns new ArrayList<>(propositionsList) — a shallow copy of each list — so the merge in `retrieveInMemoryPropositions()` never mutates the backing lists in `inMemoryPropositions`.          
  
2. `MessagingInboxProvider` removed content card from the list of card items provided to `AepInbox` on card dismiss event so its hidden from view.

3. Revert public API `getContentCardUI` to old implementation to ensure there's no breaking change. Introduce new `getContentCardUIFlow` API that complies with Kotlin flow conventions.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

1. `inMemoryPropositions` holds non-ruleset propositions (INBOX, JSON, HTML, DEFAULT_CONTENT). `retrieveCachedPropositions()` returned the original List<Proposition> references stored inside `inMemoryPropositions` rather than copies. When `retrieveInMemoryPropositions()` merged qualified content cards from `contentCardsBySurface` into the result, it mutated those same lists in-place — causing content cards to be written back into `inMemoryPropositions` as a side effect.                                                                                                                                                                                          
                                                                                                                                                                                                                                  When a content card was later disqualified it was correctly removed from `contentCardsBySurfac`e, but the leaked entry in `inMemoryPropositions` remained. Subsequent `getPropositionsForSurfaces` calls would then return those stale content cards even though they were no longer qualified.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
