### PR TITLE
Clean up content cards no longer returned by personalization response from in-memory cache

### DIFF
--- a/code/messaging/src/androidTest/java/com/adobe/marketing/mobile/messaging/MessagingPublicAPITests.java
+++ b/code/messaging/src/androidTest/java/com/adobe/marketing/mobile/messaging/MessagingPublicAPITests.java
@@ -885,6 +885,163 @@ public class MessagingPublicAPITests {
     // Content Card Tests
     // --------------------------------------------------------------------------------------------
     @Test
+    public void testContentCard_Removal() throws InterruptedException {
+        // setup
+        final List<Surface> surfacePaths = new ArrayList<>();
+        Surface surface1 = new Surface("promos/feed1");
+        surfacePaths.add(surface1);
+        Surface surface2 = new Surface("promos/feed2");
+        surfacePaths.add(surface2);
+        final List<Map<String, Object>> expectedSurfaces = new ArrayList<>();
+        expectedSurfaces.add(
+                new HashMap<String, Object>() {
+                    {
+                        put(
+                                "uri",
+                                "mobileapp://com.adobe.marketing.mobile.messaging.test/promos/feed1");
+                    }
+                });
+        expectedSurfaces.add(
+                new HashMap<String, Object>() {
+                    {
+                        put(
+                                "uri",
+                                "mobileapp://com.adobe.marketing.mobile.messaging.test/promos/feed2");
+                    }
+                });
+
+        // setup mock server response for content card propositions
+        setMockNetworkResponseForPersonalizationRequests("multipleContentCardNetworkResponse.json");
+
+        // test retrieving propositions from server
+        Messaging.updatePropositionsForSurfaces(surfacePaths);
+        TestHelper.sleep(500);
+
+        // verify messaging request content event
+        final List<Event> messagingRequestEvents =
+                getDispatchedEventsWith(
+                        MessagingTestConstants.EventType.MESSAGING, EventSource.REQUEST_CONTENT);
+        assertEquals(1, messagingRequestEvents.size());
+        final Map<String, Object> messagingEventData = messagingRequestEvents.get(0).getEventData();
+        assertEquals(true, messagingEventData.get("updatepropositions"));
+        assertEquals(expectedSurfaces, messagingEventData.get("surfaces"));
+
+        // verify edge request content event
+        final List<Event> edgePersonalizationRequestEvents =
+                getDispatchedEventsWith(
+                        MessagingTestConstants.EventType.EDGE, EventSource.REQUEST_CONTENT);
+        assertEquals(1, edgePersonalizationRequestEvents.size());
+        final Map<String, Object> edgeEventData =
+                edgePersonalizationRequestEvents.get(0).getEventData();
+        final Map<String, Object> xdmDataMap =
+                DataReader.optTypedMap(Object.class, edgeEventData, "xdm", null);
+        final Map<String, Object> queryDataMap =
+                DataReader.optTypedMap(Object.class, edgeEventData, "query", null);
+        final Map<String, Object> personalizationDataMap =
+                DataReader.optTypedMap(Object.class, queryDataMap, "personalization", null);
+        final List<String> surfacesList =
+                DataReader.optStringList(personalizationDataMap, "surfaces", null);
+        assertEquals("personalization.request", xdmDataMap.get("eventType"));
+        assertEquals(2, surfacesList.size());
+        assertEquals(
+                "mobileapp://com.adobe.marketing.mobile.messaging.test/promos/feed1",
+                surfacesList.get(0));
+        assertEquals(
+                "mobileapp://com.adobe.marketing.mobile.messaging.test/promos/feed2",
+                surfacesList.get(1));
+
+        // dispatch content card qualification event
+        MobileCore.dispatchEvent(
+                new Event.Builder(
+                                "Places entry event", EventType.PLACES, EventSource.REQUEST_CONTENT)
+                        .setEventData(
+                                new HashMap<String, Object>() {
+                                    {
+                                        put("regionEventType", "entered");
+                                    }
+                                })
+                        .build());
+        TestHelper.sleep(500);
+
+        // retrieve qualified content cards
+        CountDownLatch latch = new CountDownLatch(1);
+        final Map<Surface, List<Proposition>> qualifiedCardPropositions = new HashMap<>();
+        Messaging.getPropositionsForSurfaces(
+                surfacePaths,
+                new AdobeCallbackWithError<Map<Surface, List<Proposition>>>() {
+                    @Override
+                    public void fail(AdobeError adobeError) {
+                        latch.countDown();
+                    }
+
+                    @Override
+                    public void call(Map<Surface, List<Proposition>> surfaceListMap) {
+                        qualifiedCardPropositions.putAll(surfaceListMap);
+                        latch.countDown();
+                    }
+                });
+
+        // verify qualified content card is returned
+        assertTrue(latch.await(1000, TimeUnit.SECONDS));
+        assertEquals(2, qualifiedCardPropositions.size());
+        List<Proposition> contentCardList1 = qualifiedCardPropositions.get(surface1);
+        assertNotNull(contentCardList1);
+        assertEquals(2, contentCardList1.size());
+        assertEquals(
+                SchemaType.CONTENT_CARD, contentCardList1.get(0).getItems().get(0).getSchema());
+        List<Proposition> contentCardList2 = qualifiedCardPropositions.get(surface2);
+        assertNotNull(contentCardList2);
+        assertEquals(1, contentCardList2.size());
+        assertEquals(
+                SchemaType.CONTENT_CARD, contentCardList2.get(0).getItems().get(0).getSchema());
+
+        setMockNetworkResponseForPersonalizationRequests(
+                "contentCardWithTriggersNetworkResponse.json");
+
+        // test retrieving propositions from server
+        Messaging.updatePropositionsForSurfaces(surfacePaths);
+        TestHelper.sleep(500);
+
+        // dispatch content card qualification event
+        MobileCore.dispatchEvent(
+                new Event.Builder(
+                                "Places entry event", EventType.PLACES, EventSource.REQUEST_CONTENT)
+                        .setEventData(
+                                new HashMap<String, Object>() {
+                                    {
+                                        put("regionEventType", "entered");
+                                    }
+                                })
+                        .build());
+        TestHelper.sleep(500);
+
+        // retrieve qualified content cards
+        CountDownLatch latch1 = new CountDownLatch(1);
+        final Map<Surface, List<Proposition>> qualifiedCardPropositions1 = new HashMap<>();
+        Messaging.getPropositionsForSurfaces(
+                surfacePaths,
+                new AdobeCallbackWithError<Map<Surface, List<Proposition>>>() {
+                    @Override
+                    public void fail(AdobeError adobeError) {
+                        latch1.countDown();
+                    }
+
+                    @Override
+                    public void call(Map<Surface, List<Proposition>> surfaceListMap) {
+                        qualifiedCardPropositions1.putAll(surfaceListMap);
+                        latch1.countDown();
+                    }
+                });
+
+        // verify empty qualified content card list is returned
+        assertTrue(latch1.await(1000, TimeUnit.SECONDS));
+        assertEquals(1, qualifiedCardPropositions1.size());
+        List<Proposition> contentCardList3 = qualifiedCardPropositions1.get(surface1);
+        assertNotNull(contentCardList3);
+        assertEquals(1, contentCardList3.size());
+    }
+
+    @Test
     public void testContentCard_Qualification() throws InterruptedException {
         // setup
         final List<Surface> surfacePaths = new ArrayList<>();

--- a/code/messaging/src/androidTest/resources/multipleContentCardNetworkResponse.json
+++ b/code/messaging/src/androidTest/resources/multipleContentCardNetworkResponse.json
@@ -1,0 +1,1372 @@
+{
+    "requestId": "mockRequestId",
+    "handle": [
+        {
+            "payload": [
+                {
+                    "id": "c2aa4a73-a534-44c2-baa4-a12980e5bb9d",
+                    "scope": "mobileapp://com.adobe.marketing.mobile.messaging.test/promos/feed1",
+                    "scopeDetails": {
+                        "decisionProvider": "AJO",
+                        "correlationID": "b5095046-7fd7-4961-871f-9d68f2dc335f",
+                        "characteristics": {
+                            "eventToken": "eyJtZXNzYWdlRXhlY3V0aW9uIjp7Im1lc3NhZ2VFeGVjdXRpb25JRCI6Ik5BIiwibWVzc2FnZUlEIjoiYjUwOTUwNDYtN2ZkNy00OTYxLTg3MWYtOWQ2OGYyZGMzMzVmIiwibWVzc2FnZVB1YmxpY2F0aW9uSUQiOiJiNzFlNDhiYS1mNzY3LTQ5NWItOWQxMS01YzA3MTg4NWNkODkiLCJtZXNzYWdlVHlwZSI6Im1hcmtldGluZyIsImNhbXBhaWduSUQiOiI5YzhlYzAzNS02YjNiLTQ3MGUtOGFlNS1lNTM5YzcxMjM4MDkiLCJjYW1wYWlnblZlcnNpb25JRCI6IjdkZGEyZGM2LTE5MjMtNGU2My1iZWFjLTU0ZGM3ODczNjFlYiIsImNhbXBhaWduQWN0aW9uSUQiOiJjN2MxNDk3ZS1lNWEzLTQ0MjMtYWUzNy1iYTc2ZTFlNDQzNDIifSwibWVzc2FnZVByb2ZpbGUiOnsibWVzc2FnZVByb2ZpbGVJRCI6IjQ0YWQ1NTA3LTZlODItNGY2MS05N2U1LTUzMmNhNmZkMDhhOCIsImNoYW5uZWwiOnsiX2lkIjoiaHR0cHM6Ly9ucy5hZG9iZS5jb20veGRtL2NoYW5uZWxzL3dlYiIsIl90eXBlIjoiaHR0cHM6Ly9ucy5hZG9iZS5jb20veGRtL2NoYW5uZWwtdHlwZXMvd2ViIn19fQ=="
+                        },
+                        "activity": {
+                            "id": "a43122c4-bf19-499f-b507-087a028d1769#fa035681-15ce-488e-859e-200bb2ca90ac"
+                        }
+                    },
+                    "items": [
+                        {
+                            "id": "9d6eff2c-39a7-4aa1-9657-d642e26c5176",
+                            "schema": "https://ns.adobe.com/personalization/ruleset-item",
+                            "data": {
+                                "version": 1,
+                                "rules": [
+                                    {
+                                        "condition": {
+                                            "type": "group",
+                                            "definition": {
+                                                "logic": "and",
+                                                "conditions": [
+                                                    {
+                                                        "type": "historical",
+                                                        "definition": {
+                                                            "value": 0,
+                                                            "matcher": "eq",
+                                                            "events": [
+                                                                {
+                                                                    "iam.eventType": "disqualify",
+                                                                    "iam.id": "a43122c4-bf19-499f-b507-087a028d1769#fa035681-15ce-488e-859e-200bb2ca90ac"
+                                                                }
+                                                            ]
+                                                        }
+                                                    },
+                                                    {
+                                                        "type": "matcher",
+                                                        "definition": {
+                                                            "key": "~timestampu",
+                                                            "matcher": "lt",
+                                                            "values": [
+                                                                2019715200
+                                                            ]
+                                                        }
+                                                    },
+                                                    {
+                                                        "type": "group",
+                                                        "definition": {
+                                                            "logic": "or",
+                                                            "conditions": [
+                                                                {
+                                                                    "type": "group",
+                                                                    "definition": {
+                                                                        "logic": "and",
+                                                                        "conditions": [
+                                                                            {
+                                                                                "definition": {
+                                                                                    "key": "~type",
+                                                                                    "matcher": "eq",
+                                                                                    "values": [
+                                                                                        "com.adobe.eventType.places"
+                                                                                    ]
+                                                                                },
+                                                                                "type": "matcher"
+                                                                            },
+                                                                            {
+                                                                                "definition": {
+                                                                                    "key": "~source",
+                                                                                    "matcher": "eq",
+                                                                                    "values": [
+                                                                                        "com.adobe.eventSource.requestContent"
+                                                                                    ]
+                                                                                },
+                                                                                "type": "matcher"
+                                                                            },
+                                                                            {
+                                                                                "definition": {
+                                                                                    "key": "regionEventType",
+                                                                                    "matcher": "eq",
+                                                                                    "values": [
+                                                                                        "entered"
+                                                                                    ]
+                                                                                },
+                                                                                "type": "matcher"
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                },
+                                                                {
+                                                                    "type": "historical",
+                                                                    "definition": {
+                                                                        "searchType": "mostRecent",
+                                                                        "value": 1,
+                                                                        "matcher": "ge",
+                                                                        "events": [
+                                                                            {
+                                                                                "iam.eventType": "unqualify",
+                                                                                "iam.id": "a43122c4-bf19-499f-b507-087a028d1769#fa035681-15ce-488e-859e-200bb2ca90ac"
+                                                                            },
+                                                                            {
+                                                                                "iam.eventType": "trigger",
+                                                                                "iam.id": "a43122c4-bf19-499f-b507-087a028d1769#fa035681-15ce-488e-859e-200bb2ca90ac"
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                },
+                                                                {
+                                                                    "type": "historical",
+                                                                    "definition": {
+                                                                        "searchType": "mostRecent",
+                                                                        "value": 1,
+                                                                        "matcher": "eq",
+                                                                        "events": [
+                                                                            {
+                                                                                "iam.eventType": "unqualify",
+                                                                                "iam.id": "a43122c4-bf19-499f-b507-087a028d1769#fa035681-15ce-488e-859e-200bb2ca90ac"
+                                                                            },
+                                                                            {
+                                                                                "iam.eventType": "qualify",
+                                                                                "iam.id": "a43122c4-bf19-499f-b507-087a028d1769#fa035681-15ce-488e-859e-200bb2ca90ac"
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                }
+                                                            ]
+                                                        }
+                                                    }
+                                                ]
+                                            }
+                                        },
+                                        "consequences": [
+                                            {
+                                                "id": "183639c4-cb37-458e-a8ef-4e130d767ebf",
+                                                "type": "schema",
+                                                "detail": {
+                                                    "id": "183639c4-cb37-458e-a8ef-4e130d767ebf",
+                                                    "schema": "https://ns.adobe.com/personalization/message/content-card",
+                                                    "data": {
+                                                        "expiryDate": 1723163897,
+                                                        "meta": {
+                                                            "feedName": "testFeed",
+                                                            "campaignName": "testCampaign",
+                                                            "surface": "mobileapp://com.adobe.marketing.mobile.messaging.test/promos/feed1"
+                                                        },
+                                                        "content": {
+                                                            "title": "Guacamole!",
+                                                            "body": "I'm the queen of Nacho Picchu and I'm really glad to meet you. To spice up this big tortilla chip, I command you to find a big dip.",
+                                                            "imageUrl": "https://d14dq8eoa1si34.cloudfront.net/2a6ef2f0-1167-11eb-88c6-b512a5ef09a7/urn:aaid:aem:d4b77a01-610a-4c3f-9be6-5ebe1bd13da3/oak:1.0::ci:fa54b394b6f987d974d8619833083519/8933c829-3ab2-38e8-a1ee-00d4f562fff8",
+                                                            "actionUrl": "https://luma.com/guacamolethemusical",
+                                                            "actionTitle": "guacamole!"
+                                                        },
+                                                        "contentType": "application/json",
+                                                        "publishedDate": 1691541497
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "condition": {
+                                            "type": "group",
+                                            "definition": {
+                                                "logic": "and",
+                                                "conditions": [
+                                                    {
+                                                        "type": "historical",
+                                                        "definition": {
+                                                            "value": 0,
+                                                            "matcher": "eq",
+                                                            "events": [
+                                                                {
+                                                                    "iam.eventType": "disqualify",
+                                                                    "iam.id": "a43122c4-bf19-499f-b507-087a028d1769#fa035681-15ce-488e-859e-200bb2ca90ac"
+                                                                }
+                                                            ]
+                                                        }
+                                                    },
+                                                    {
+                                                        "type": "matcher",
+                                                        "definition": {
+                                                            "key": "~timestampu",
+                                                            "matcher": "lt",
+                                                            "values": [
+                                                                2019715200
+                                                            ]
+                                                        }
+                                                    },
+                                                    {
+                                                        "type": "group",
+                                                        "definition": {
+                                                            "logic": "and",
+                                                            "conditions": [
+                                                                {
+                                                                    "definition": {
+                                                                        "key": "~type",
+                                                                        "matcher": "eq",
+                                                                        "values": [
+                                                                            "com.adobe.eventType.places"
+                                                                        ]
+                                                                    },
+                                                                    "type": "matcher"
+                                                                },
+                                                                {
+                                                                    "definition": {
+                                                                        "key": "~source",
+                                                                        "matcher": "eq",
+                                                                        "values": [
+                                                                            "com.adobe.eventSource.requestContent"
+                                                                        ]
+                                                                    },
+                                                                    "type": "matcher"
+                                                                },
+                                                                {
+                                                                    "definition": {
+                                                                        "key": "regionEventType",
+                                                                        "matcher": "eq",
+                                                                        "values": [
+                                                                            "entered"
+                                                                        ]
+                                                                    },
+                                                                    "type": "matcher"
+                                                                }
+                                                            ]
+                                                        }
+                                                    },
+                                                    {
+                                                        "type": "historical",
+                                                        "definition": {
+                                                            "searchType": "mostRecent",
+                                                            "value": 1,
+                                                            "matcher": "ne",
+                                                            "events": [
+                                                                {
+                                                                    "iam.eventType": "unqualify",
+                                                                    "iam.id": "a43122c4-bf19-499f-b507-087a028d1769#fa035681-15ce-488e-859e-200bb2ca90ac"
+                                                                },
+                                                                {
+                                                                    "iam.eventType": "qualify",
+                                                                    "iam.id": "a43122c4-bf19-499f-b507-087a028d1769#fa035681-15ce-488e-859e-200bb2ca90ac"
+                                                                }
+                                                            ]
+                                                        }
+                                                    }
+                                                ]
+                                            }
+                                        },
+                                        "consequences": [
+                                            {
+                                                "id": "48181acd-22b3-edae-bc8a-447868a7df7c",
+                                                "type": "schema",
+                                                "detail": {
+                                                    "id": "48181acd-22b3-edae-bc8a-447868a7df7c",
+                                                    "schema": "https://ns.adobe.com/personalization/eventHistoryOperation",
+                                                    "data": {
+                                                        "operation": "insert",
+                                                        "content": {
+                                                            "iam.eventType": "qualify",
+                                                            "iam.id": "a43122c4-bf19-499f-b507-087a028d1769#fa035681-15ce-488e-859e-200bb2ca90ac"
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "condition": {
+                                            "type": "group",
+                                            "definition": {
+                                                "logic": "and",
+                                                "conditions": [
+                                                    {
+                                                        "type": "historical",
+                                                        "definition": {
+                                                            "value": 0,
+                                                            "matcher": "eq",
+                                                            "events": [
+                                                                {
+                                                                    "iam.eventType": "disqualify",
+                                                                    "iam.id": "a43122c4-bf19-499f-b507-087a028d1769#fa035681-15ce-488e-859e-200bb2ca90ac"
+                                                                }
+                                                            ]
+                                                        }
+                                                    },
+                                                    {
+                                                        "type": "group",
+                                                        "definition": {
+                                                            "logic": "and",
+                                                            "conditions": [
+                                                                {
+                                                                    "definition": {
+                                                                        "key": "~type",
+                                                                        "matcher": "eq",
+                                                                        "values": [
+                                                                            "com.adobe.eventType.places"
+                                                                        ]
+                                                                    },
+                                                                    "type": "matcher"
+                                                                },
+                                                                {
+                                                                    "definition": {
+                                                                        "key": "~source",
+                                                                        "matcher": "eq",
+                                                                        "values": [
+                                                                            "com.adobe.eventSource.requestContent"
+                                                                        ]
+                                                                    },
+                                                                    "type": "matcher"
+                                                                },
+                                                                {
+                                                                    "definition": {
+                                                                        "key": "regionEventType",
+                                                                        "matcher": "eq",
+                                                                        "values": [
+                                                                            "exited"
+                                                                        ]
+                                                                    },
+                                                                    "type": "matcher"
+                                                                }
+                                                            ]
+                                                        }
+                                                    },
+                                                    {
+                                                        "type": "historical",
+                                                        "definition": {
+                                                            "searchType": "mostRecent",
+                                                            "value": 0,
+                                                            "matcher": "ne",
+                                                            "events": [
+                                                                {
+                                                                    "iam.eventType": "unqualify",
+                                                                    "iam.id": "a43122c4-bf19-499f-b507-087a028d1769#fa035681-15ce-488e-859e-200bb2ca90ac"
+                                                                },
+                                                                {
+                                                                    "iam.eventType": "qualify",
+                                                                    "iam.id": "a43122c4-bf19-499f-b507-087a028d1769#fa035681-15ce-488e-859e-200bb2ca90ac"
+                                                                }
+                                                            ]
+                                                        }
+                                                    }
+                                                ]
+                                            }
+                                        },
+                                        "consequences": [
+                                            {
+                                                "id": "48181acd-22b3-edae-bc8a-447868a7df7c",
+                                                "type": "schema",
+                                                "detail": {
+                                                    "id": "48181acd-22b3-edae-bc8a-447868a7df7c",
+                                                    "schema": "https://ns.adobe.com/personalization/eventHistoryOperation",
+                                                    "data": {
+                                                        "operation": "insert",
+                                                        "content": {
+                                                            "iam.eventType": "unqualify",
+                                                            "iam.id": "a43122c4-bf19-499f-b507-087a028d1769#fa035681-15ce-488e-859e-200bb2ca90ac"
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "condition": {
+                                            "type": "group",
+                                            "definition": {
+                                                "logic": "and",
+                                                "conditions": [
+                                                    {
+                                                        "type": "group",
+                                                        "definition": {
+                                                            "logic": "and",
+                                                            "conditions": [
+                                                                {
+                                                                    "definition": {
+                                                                        "key": "~type",
+                                                                        "matcher": "eq",
+                                                                        "values": [
+                                                                            "com.adobe.eventType.edge"
+                                                                        ]
+                                                                    },
+                                                                    "type": "matcher"
+                                                                },
+                                                                {
+                                                                    "definition": {
+                                                                        "key": "~source",
+                                                                        "matcher": "eq",
+                                                                        "values": [
+                                                                            "com.adobe.eventSource.requestContent"
+                                                                        ]
+                                                                    },
+                                                                    "type": "matcher"
+                                                                },
+                                                                {
+                                                                    "definition": {
+                                                                        "key": "xdm.eventType",
+                                                                        "matcher": "eq",
+                                                                        "values": [
+                                                                            "decisioning.propositionDismiss"
+                                                                        ]
+                                                                    },
+                                                                    "type": "matcher"
+                                                                },
+                                                                {
+                                                                    "definition": {
+                                                                        "key": "xdm._experience.decisioning.propositions.0.scopeDetails.activity.id",
+                                                                        "matcher": "eq",
+                                                                        "values": [
+                                                                            "a43122c4-bf19-499f-b507-087a028d1769#fa035681-15ce-488e-859e-200bb2ca90ac"
+                                                                        ]
+                                                                    },
+                                                                    "type": "matcher"
+                                                                }
+                                                            ]
+                                                        }
+                                                    },
+                                                    {
+                                                        "type": "matcher",
+                                                        "definition": {
+                                                            "key": "~timestampu",
+                                                            "matcher": "lt",
+                                                            "values": [
+                                                                2019715200
+                                                            ]
+                                                        }
+                                                    }
+                                                ]
+                                            }
+                                        },
+                                        "consequences": [
+                                            {
+                                                "id": "48181acd-22b3-edae-bc8a-447868a7df7c",
+                                                "type": "schema",
+                                                "detail": {
+                                                    "id": "48181acd-22b3-edae-bc8a-447868a7df7c",
+                                                    "schema": "https://ns.adobe.com/personalization/eventHistoryOperation",
+                                                    "data": {
+                                                        "operation": "insertIfNotExists",
+                                                        "content": {
+                                                            "iam.eventType": "disqualify",
+                                                            "iam.id": "a43122c4-bf19-499f-b507-087a028d1769#fa035681-15ce-488e-859e-200bb2ca90ac"
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "id": "c2aa4a73-a534-44c2-baa4-a12980e5bb9f",
+                    "scope": "mobileapp://com.adobe.marketing.mobile.messaging.test/promos/feed1",
+                    "scopeDetails": {
+                        "decisionProvider": "AJO",
+                        "correlationID": "b5095046-7fd7-4961-871f-9d68f2dc335f",
+                        "characteristics": {
+                            "eventToken": "eyJtZXNzYWdlRXhlY3V0aW9uIjp7Im1lc3NhZ2VFeGVjdXRpb25JRCI6Ik5BIiwibWVzc2FnZUlEIjoiYjUwOTUwNDYtN2ZkNy00OTYxLTg3MWYtOWQ2OGYyZGMzMzVmIiwibWVzc2FnZVB1YmxpY2F0aW9uSUQiOiJiNzFlNDhiYS1mNzY3LTQ5NWItOWQxMS01YzA3MTg4NWNkODkiLCJtZXNzYWdlVHlwZSI6Im1hcmtldGluZyIsImNhbXBhaWduSUQiOiI5YzhlYzAzNS02YjNiLTQ3MGUtOGFlNS1lNTM5YzcxMjM4MDkiLCJjYW1wYWlnblZlcnNpb25JRCI6IjdkZGEyZGM2LTE5MjMtNGU2My1iZWFjLTU0ZGM3ODczNjFlYiIsImNhbXBhaWduQWN0aW9uSUQiOiJjN2MxNDk3ZS1lNWEzLTQ0MjMtYWUzNy1iYTc2ZTFlNDQzNDIifSwibWVzc2FnZVByb2ZpbGUiOnsibWVzc2FnZVByb2ZpbGVJRCI6IjQ0YWQ1NTA3LTZlODItNGY2MS05N2U1LTUzMmNhNmZkMDhhOCIsImNoYW5uZWwiOnsiX2lkIjoiaHR0cHM6Ly9ucy5hZG9iZS5jb20veGRtL2NoYW5uZWxzL3dlYiIsIl90eXBlIjoiaHR0cHM6Ly9ucy5hZG9iZS5jb20veGRtL2NoYW5uZWwtdHlwZXMvd2ViIn19fQ=="
+                        },
+                        "activity": {
+                            "id": "a43122c4-bf19-499f-b507-087a028d1769#fa035681-15ce-488e-859e-200bb2ca90af"
+                        }
+                    },
+                    "items": [
+                        {
+                            "id": "9d6eff2c-39a7-4aa1-9657-d642e26c517f",
+                            "schema": "https://ns.adobe.com/personalization/ruleset-item",
+                            "data": {
+                                "version": 1,
+                                "rules": [
+                                    {
+                                        "condition": {
+                                            "type": "group",
+                                            "definition": {
+                                                "logic": "and",
+                                                "conditions": [
+                                                    {
+                                                        "type": "historical",
+                                                        "definition": {
+                                                            "value": 0,
+                                                            "matcher": "eq",
+                                                            "events": [
+                                                                {
+                                                                    "iam.eventType": "disqualify",
+                                                                    "iam.id": "a43122c4-bf19-499f-b507-087a028d1769#fa035681-15ce-488e-859e-200bb2ca90af"
+                                                                }
+                                                            ]
+                                                        }
+                                                    },
+                                                    {
+                                                        "type": "matcher",
+                                                        "definition": {
+                                                            "key": "~timestampu",
+                                                            "matcher": "lt",
+                                                            "values": [
+                                                                2019715200
+                                                            ]
+                                                        }
+                                                    },
+                                                    {
+                                                        "type": "group",
+                                                        "definition": {
+                                                            "logic": "or",
+                                                            "conditions": [
+                                                                {
+                                                                    "type": "group",
+                                                                    "definition": {
+                                                                        "logic": "and",
+                                                                        "conditions": [
+                                                                            {
+                                                                                "definition": {
+                                                                                    "key": "~type",
+                                                                                    "matcher": "eq",
+                                                                                    "values": [
+                                                                                        "com.adobe.eventType.places"
+                                                                                    ]
+                                                                                },
+                                                                                "type": "matcher"
+                                                                            },
+                                                                            {
+                                                                                "definition": {
+                                                                                    "key": "~source",
+                                                                                    "matcher": "eq",
+                                                                                    "values": [
+                                                                                        "com.adobe.eventSource.requestContent"
+                                                                                    ]
+                                                                                },
+                                                                                "type": "matcher"
+                                                                            },
+                                                                            {
+                                                                                "definition": {
+                                                                                    "key": "regionEventType",
+                                                                                    "matcher": "eq",
+                                                                                    "values": [
+                                                                                        "entered"
+                                                                                    ]
+                                                                                },
+                                                                                "type": "matcher"
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                },
+                                                                {
+                                                                    "type": "historical",
+                                                                    "definition": {
+                                                                        "searchType": "mostRecent",
+                                                                        "value": 1,
+                                                                        "matcher": "ge",
+                                                                        "events": [
+                                                                            {
+                                                                                "iam.eventType": "unqualify",
+                                                                                "iam.id": "a43122c4-bf19-499f-b507-087a028d1769#fa035681-15ce-488e-859e-200bb2ca90af"
+                                                                            },
+                                                                            {
+                                                                                "iam.eventType": "trigger",
+                                                                                "iam.id": "a43122c4-bf19-499f-b507-087a028d1769#fa035681-15ce-488e-859e-200bb2ca90af"
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                },
+                                                                {
+                                                                    "type": "historical",
+                                                                    "definition": {
+                                                                        "searchType": "mostRecent",
+                                                                        "value": 1,
+                                                                        "matcher": "eq",
+                                                                        "events": [
+                                                                            {
+                                                                                "iam.eventType": "unqualify",
+                                                                                "iam.id": "a43122c4-bf19-499f-b507-087a028d1769#fa035681-15ce-488e-859e-200bb2ca90af"
+                                                                            },
+                                                                            {
+                                                                                "iam.eventType": "qualify",
+                                                                                "iam.id": "a43122c4-bf19-499f-b507-087a028d1769#fa035681-15ce-488e-859e-200bb2ca90af"
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                }
+                                                            ]
+                                                        }
+                                                    }
+                                                ]
+                                            }
+                                        },
+                                        "consequences": [
+                                            {
+                                                "id": "183639c4-cb37-458e-a8ef-4e130d767ebg",
+                                                "type": "schema",
+                                                "detail": {
+                                                    "id": "183639c4-cb37-458e-a8ef-4e130d767ebg",
+                                                    "schema": "https://ns.adobe.com/personalization/message/content-card",
+                                                    "data": {
+                                                        "expiryDate": 1723163897,
+                                                        "meta": {
+                                                            "feedName": "testFeed",
+                                                            "campaignName": "testCampaign",
+                                                            "surface": "mobileapp://com.adobe.marketing.mobile.messaging.test/promos/feed1"
+                                                        },
+                                                        "content": {
+                                                            "title": "Guacamole!",
+                                                            "body": "I'm the queen of Nacho Picchu and I'm really glad to meet you. To spice up this big tortilla chip, I command you to find a big dip.",
+                                                            "imageUrl": "https://d14dq8eoa1si34.cloudfront.net/2a6ef2f0-1167-11eb-88c6-b512a5ef09a7/urn:aaid:aem:d4b77a01-610a-4c3f-9be6-5ebe1bd13da3/oak:1.0::ci:fa54b394b6f987d974d8619833083519/8933c829-3ab2-38e8-a1ee-00d4f562fff8",
+                                                            "actionUrl": "https://luma.com/guacamolethemusical",
+                                                            "actionTitle": "guacamole!"
+                                                        },
+                                                        "contentType": "application/json",
+                                                        "publishedDate": 1691541497
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "condition": {
+                                            "type": "group",
+                                            "definition": {
+                                                "logic": "and",
+                                                "conditions": [
+                                                    {
+                                                        "type": "historical",
+                                                        "definition": {
+                                                            "value": 0,
+                                                            "matcher": "eq",
+                                                            "events": [
+                                                                {
+                                                                    "iam.eventType": "disqualify",
+                                                                    "iam.id": "a43122c4-bf19-499f-b507-087a028d1769#fa035681-15ce-488e-859e-200bb2ca90af"
+                                                                }
+                                                            ]
+                                                        }
+                                                    },
+                                                    {
+                                                        "type": "matcher",
+                                                        "definition": {
+                                                            "key": "~timestampu",
+                                                            "matcher": "lt",
+                                                            "values": [
+                                                                2019715200
+                                                            ]
+                                                        }
+                                                    },
+                                                    {
+                                                        "type": "group",
+                                                        "definition": {
+                                                            "logic": "and",
+                                                            "conditions": [
+                                                                {
+                                                                    "definition": {
+                                                                        "key": "~type",
+                                                                        "matcher": "eq",
+                                                                        "values": [
+                                                                            "com.adobe.eventType.places"
+                                                                        ]
+                                                                    },
+                                                                    "type": "matcher"
+                                                                },
+                                                                {
+                                                                    "definition": {
+                                                                        "key": "~source",
+                                                                        "matcher": "eq",
+                                                                        "values": [
+                                                                            "com.adobe.eventSource.requestContent"
+                                                                        ]
+                                                                    },
+                                                                    "type": "matcher"
+                                                                },
+                                                                {
+                                                                    "definition": {
+                                                                        "key": "regionEventType",
+                                                                        "matcher": "eq",
+                                                                        "values": [
+                                                                            "entered"
+                                                                        ]
+                                                                    },
+                                                                    "type": "matcher"
+                                                                }
+                                                            ]
+                                                        }
+                                                    },
+                                                    {
+                                                        "type": "historical",
+                                                        "definition": {
+                                                            "searchType": "mostRecent",
+                                                            "value": 1,
+                                                            "matcher": "ne",
+                                                            "events": [
+                                                                {
+                                                                    "iam.eventType": "unqualify",
+                                                                    "iam.id": "a43122c4-bf19-499f-b507-087a028d1769#fa035681-15ce-488e-859e-200bb2ca90af"
+                                                                },
+                                                                {
+                                                                    "iam.eventType": "qualify",
+                                                                    "iam.id": "a43122c4-bf19-499f-b507-087a028d1769#fa035681-15ce-488e-859e-200bb2ca90af"
+                                                                }
+                                                            ]
+                                                        }
+                                                    }
+                                                ]
+                                            }
+                                        },
+                                        "consequences": [
+                                            {
+                                                "id": "48181acd-22b3-edae-bc8a-447868a7df7f",
+                                                "type": "schema",
+                                                "detail": {
+                                                    "id": "48181acd-22b3-edae-bc8a-447868a7df7f",
+                                                    "schema": "https://ns.adobe.com/personalization/eventHistoryOperation",
+                                                    "data": {
+                                                        "operation": "insert",
+                                                        "content": {
+                                                            "iam.eventType": "qualify",
+                                                            "iam.id": "a43122c4-bf19-499f-b507-087a028d1769#fa035681-15ce-488e-859e-200bb2ca90af"
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "condition": {
+                                            "type": "group",
+                                            "definition": {
+                                                "logic": "and",
+                                                "conditions": [
+                                                    {
+                                                        "type": "historical",
+                                                        "definition": {
+                                                            "value": 0,
+                                                            "matcher": "eq",
+                                                            "events": [
+                                                                {
+                                                                    "iam.eventType": "disqualify",
+                                                                    "iam.id": "a43122c4-bf19-499f-b507-087a028d1769#fa035681-15ce-488e-859e-200bb2ca90af"
+                                                                }
+                                                            ]
+                                                        }
+                                                    },
+                                                    {
+                                                        "type": "group",
+                                                        "definition": {
+                                                            "logic": "and",
+                                                            "conditions": [
+                                                                {
+                                                                    "definition": {
+                                                                        "key": "~type",
+                                                                        "matcher": "eq",
+                                                                        "values": [
+                                                                            "com.adobe.eventType.places"
+                                                                        ]
+                                                                    },
+                                                                    "type": "matcher"
+                                                                },
+                                                                {
+                                                                    "definition": {
+                                                                        "key": "~source",
+                                                                        "matcher": "eq",
+                                                                        "values": [
+                                                                            "com.adobe.eventSource.requestContent"
+                                                                        ]
+                                                                    },
+                                                                    "type": "matcher"
+                                                                },
+                                                                {
+                                                                    "definition": {
+                                                                        "key": "regionEventType",
+                                                                        "matcher": "eq",
+                                                                        "values": [
+                                                                            "exited"
+                                                                        ]
+                                                                    },
+                                                                    "type": "matcher"
+                                                                }
+                                                            ]
+                                                        }
+                                                    },
+                                                    {
+                                                        "type": "historical",
+                                                        "definition": {
+                                                            "searchType": "mostRecent",
+                                                            "value": 0,
+                                                            "matcher": "ne",
+                                                            "events": [
+                                                                {
+                                                                    "iam.eventType": "unqualify",
+                                                                    "iam.id": "a43122c4-bf19-499f-b507-087a028d1769#fa035681-15ce-488e-859e-200bb2ca90af"
+                                                                },
+                                                                {
+                                                                    "iam.eventType": "qualify",
+                                                                    "iam.id": "a43122c4-bf19-499f-b507-087a028d1769#fa035681-15ce-488e-859e-200bb2ca90af"
+                                                                }
+                                                            ]
+                                                        }
+                                                    }
+                                                ]
+                                            }
+                                        },
+                                        "consequences": [
+                                            {
+                                                "id": "48181acd-22b3-edae-bc8a-447868a7df7f",
+                                                "type": "schema",
+                                                "detail": {
+                                                    "id": "48181acd-22b3-edae-bc8a-447868a7df7f",
+                                                    "schema": "https://ns.adobe.com/personalization/eventHistoryOperation",
+                                                    "data": {
+                                                        "operation": "insert",
+                                                        "content": {
+                                                            "iam.eventType": "unqualify",
+                                                            "iam.id": "a43122c4-bf19-499f-b507-087a028d1769#fa035681-15ce-488e-859e-200bb2ca90af"
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "condition": {
+                                            "type": "group",
+                                            "definition": {
+                                                "logic": "and",
+                                                "conditions": [
+                                                    {
+                                                        "type": "group",
+                                                        "definition": {
+                                                            "logic": "and",
+                                                            "conditions": [
+                                                                {
+                                                                    "definition": {
+                                                                        "key": "~type",
+                                                                        "matcher": "eq",
+                                                                        "values": [
+                                                                            "com.adobe.eventType.edge"
+                                                                        ]
+                                                                    },
+                                                                    "type": "matcher"
+                                                                },
+                                                                {
+                                                                    "definition": {
+                                                                        "key": "~source",
+                                                                        "matcher": "eq",
+                                                                        "values": [
+                                                                            "com.adobe.eventSource.requestContent"
+                                                                        ]
+                                                                    },
+                                                                    "type": "matcher"
+                                                                },
+                                                                {
+                                                                    "definition": {
+                                                                        "key": "xdm.eventType",
+                                                                        "matcher": "eq",
+                                                                        "values": [
+                                                                            "decisioning.propositionDismiss"
+                                                                        ]
+                                                                    },
+                                                                    "type": "matcher"
+                                                                },
+                                                                {
+                                                                    "definition": {
+                                                                        "key": "xdm._experience.decisioning.propositions.0.scopeDetails.activity.id",
+                                                                        "matcher": "eq",
+                                                                        "values": [
+                                                                            "a43122c4-bf19-499f-b507-087a028d1769#fa035681-15ce-488e-859e-200bb2ca90af"
+                                                                        ]
+                                                                    },
+                                                                    "type": "matcher"
+                                                                }
+                                                            ]
+                                                        }
+                                                    },
+                                                    {
+                                                        "type": "matcher",
+                                                        "definition": {
+                                                            "key": "~timestampu",
+                                                            "matcher": "lt",
+                                                            "values": [
+                                                                2019715200
+                                                            ]
+                                                        }
+                                                    }
+                                                ]
+                                            }
+                                        },
+                                        "consequences": [
+                                            {
+                                                "id": "48181acd-22b3-edae-bc8a-447868a7df7f",
+                                                "type": "schema",
+                                                "detail": {
+                                                    "id": "48181acd-22b3-edae-bc8a-447868a7df7f",
+                                                    "schema": "https://ns.adobe.com/personalization/eventHistoryOperation",
+                                                    "data": {
+                                                        "operation": "insertIfNotExists",
+                                                        "content": {
+                                                            "iam.eventType": "disqualify",
+                                                            "iam.id": "a43122c4-bf19-499f-b507-087a028d1769#fa035681-15ce-488e-859e-200bb2ca90af"
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "id": "c2aa4a73-a534-44c2-baa4-a12980e5bb9e",
+                    "scope": "mobileapp://com.adobe.marketing.mobile.messaging.test/promos/feed2",
+                    "scopeDetails": {
+                        "decisionProvider": "AJO",
+                        "correlationID": "b5095046-7fd7-4961-871f-9d68f2dc335e",
+                        "characteristics": {
+                            "eventToken": "eyJtZXNzYWdlRXhlY3V0aW9uIjp7Im1lc3NhZ2VFeGVjdXRpb25JRCI6Ik5BIiwibWVzc2FnZUlEIjoiYjUwOTUwNDYtN2ZkNy00OTYxLTg3MWYtOWQ2OGYyZGMzMzVmIiwibWVzc2FnZVB1YmxpY2F0aW9uSUQiOiJiNzFlNDhiYS1mNzY3LTQ5NWItOWQxMS01YzA3MTg4NWNkODkiLCJtZXNzYWdlVHlwZSI6Im1hcmtldGluZyIsImNhbXBhaWduSUQiOiI5YzhlYzAzNS02YjNiLTQ3MGUtOGFlNS1lNTM5YzcxMjM4MDkiLCJjYW1wYWlnblZlcnNpb25JRCI6IjdkZGEyZGM2LTE5MjMtNGU2My1iZWFjLTU0ZGM3ODczNjFlYiIsImNhbXBhaWduQWN0aW9uSUQiOiJjN2MxNDk3ZS1lNWEzLTQ0MjMtYWUzNy1iYTc2ZTFlNDQzNDIifSwibWVzc2FnZVByb2ZpbGUiOnsibWVzc2FnZVByb2ZpbGVJRCI6IjQ0YWQ1NTA3LTZlODItNGY2MS05N2U1LTUzMmNhNmZkMDhhOCIsImNoYW5uZWwiOnsiX2lkIjoiaHR0cHM6Ly9ucy5hZG9iZS5jb20veGRtL2NoYW5uZWxzL3dlYiIsIl90eXBlIjoiaHR0cHM6Ly9ucy5hZG9iZS5jb20veGRtL2NoYW5uZWwtdHlwZXMvd2ViIn19fQ=="
+                        },
+                        "activity": {
+                            "id": "a43122c4-bf19-499f-b507-087a028d1769#fa035681-15ce-488e-859e-200bb2ca90ae"
+                        }
+                    },
+                    "items": [
+                        {
+                            "id": "9d6eff2c-39a7-4aa1-9657-d642e26c517e",
+                            "schema": "https://ns.adobe.com/personalization/ruleset-item",
+                            "data": {
+                                "version": 1,
+                                "rules": [
+                                    {
+                                        "condition": {
+                                            "type": "group",
+                                            "definition": {
+                                                "logic": "and",
+                                                "conditions": [
+                                                    {
+                                                        "type": "historical",
+                                                        "definition": {
+                                                            "value": 0,
+                                                            "matcher": "eq",
+                                                            "events": [
+                                                                {
+                                                                    "iam.eventType": "disqualify",
+                                                                    "iam.id": "a43122c4-bf19-499f-b507-087a028d1769#fa035681-15ce-488e-859e-200bb2ca90ae"
+                                                                }
+                                                            ]
+                                                        }
+                                                    },
+                                                    {
+                                                        "type": "matcher",
+                                                        "definition": {
+                                                            "key": "~timestampu",
+                                                            "matcher": "lt",
+                                                            "values": [
+                                                                2019715200
+                                                            ]
+                                                        }
+                                                    },
+                                                    {
+                                                        "type": "group",
+                                                        "definition": {
+                                                            "logic": "or",
+                                                            "conditions": [
+                                                                {
+                                                                    "type": "group",
+                                                                    "definition": {
+                                                                        "logic": "and",
+                                                                        "conditions": [
+                                                                            {
+                                                                                "definition": {
+                                                                                    "key": "~type",
+                                                                                    "matcher": "eq",
+                                                                                    "values": [
+                                                                                        "com.adobe.eventType.places"
+                                                                                    ]
+                                                                                },
+                                                                                "type": "matcher"
+                                                                            },
+                                                                            {
+                                                                                "definition": {
+                                                                                    "key": "~source",
+                                                                                    "matcher": "eq",
+                                                                                    "values": [
+                                                                                        "com.adobe.eventSource.requestContent"
+                                                                                    ]
+                                                                                },
+                                                                                "type": "matcher"
+                                                                            },
+                                                                            {
+                                                                                "definition": {
+                                                                                    "key": "regionEventType",
+                                                                                    "matcher": "eq",
+                                                                                    "values": [
+                                                                                        "entered"
+                                                                                    ]
+                                                                                },
+                                                                                "type": "matcher"
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                },
+                                                                {
+                                                                    "type": "historical",
+                                                                    "definition": {
+                                                                        "searchType": "mostRecent",
+                                                                        "value": 1,
+                                                                        "matcher": "ge",
+                                                                        "events": [
+                                                                            {
+                                                                                "iam.eventType": "unqualify",
+                                                                                "iam.id": "a43122c4-bf19-499f-b507-087a028d1769#fa035681-15ce-488e-859e-200bb2ca90ae"
+                                                                            },
+                                                                            {
+                                                                                "iam.eventType": "trigger",
+                                                                                "iam.id": "a43122c4-bf19-499f-b507-087a028d1769#fa035681-15ce-488e-859e-200bb2ca90ae"
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                },
+                                                                {
+                                                                    "type": "historical",
+                                                                    "definition": {
+                                                                        "searchType": "mostRecent",
+                                                                        "value": 1,
+                                                                        "matcher": "eq",
+                                                                        "events": [
+                                                                            {
+                                                                                "iam.eventType": "unqualify",
+                                                                                "iam.id": "a43122c4-bf19-499f-b507-087a028d1769#fa035681-15ce-488e-859e-200bb2ca90ae"
+                                                                            },
+                                                                            {
+                                                                                "iam.eventType": "qualify",
+                                                                                "iam.id": "a43122c4-bf19-499f-b507-087a028d1769#fa035681-15ce-488e-859e-200bb2ca90ae"
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                }
+                                                            ]
+                                                        }
+                                                    }
+                                                ]
+                                            }
+                                        },
+                                        "consequences": [
+                                            {
+                                                "id": "183639c4-cb37-458e-a8ef-4e130d767ebe",
+                                                "type": "schema",
+                                                "detail": {
+                                                    "id": "183639c4-cb37-458e-a8ef-4e130d767ebe",
+                                                    "schema": "https://ns.adobe.com/personalization/message/content-card",
+                                                    "data": {
+                                                        "expiryDate": 1723163897,
+                                                        "meta": {
+                                                            "feedName": "testFeed",
+                                                            "campaignName": "testCampaign",
+                                                            "surface": "mobileapp://com.adobe.marketing.mobile.messaging.test/promos/feed2"
+                                                        },
+                                                        "content": {
+                                                            "title": "Guacamole!",
+                                                            "body": "I'm the queen of Nacho Picchu and I'm really glad to meet you. To spice up this big tortilla chip, I command you to find a big dip.",
+                                                            "imageUrl": "https://d14dq8eoa1si34.cloudfront.net/2a6ef2f0-1167-11eb-88c6-b512a5ef09a7/urn:aaid:aem:d4b77a01-610a-4c3f-9be6-5ebe1bd13da3/oak:1.0::ci:fa54b394b6f987d974d8619833083519/8933c829-3ab2-38e8-a1ee-00d4f562fff8",
+                                                            "actionUrl": "https://luma.com/guacamolethemusical",
+                                                            "actionTitle": "guacamole!"
+                                                        },
+                                                        "contentType": "application/json",
+                                                        "publishedDate": 1691541497
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "condition": {
+                                            "type": "group",
+                                            "definition": {
+                                                "logic": "and",
+                                                "conditions": [
+                                                    {
+                                                        "type": "historical",
+                                                        "definition": {
+                                                            "value": 0,
+                                                            "matcher": "eq",
+                                                            "events": [
+                                                                {
+                                                                    "iam.eventType": "disqualify",
+                                                                    "iam.id": "a43122c4-bf19-499f-b507-087a028d1769#fa035681-15ce-488e-859e-200bb2ca90aee"
+                                                                }
+                                                            ]
+                                                        }
+                                                    },
+                                                    {
+                                                        "type": "matcher",
+                                                        "definition": {
+                                                            "key": "~timestampu",
+                                                            "matcher": "lt",
+                                                            "values": [
+                                                                2019715200
+                                                            ]
+                                                        }
+                                                    },
+                                                    {
+                                                        "type": "group",
+                                                        "definition": {
+                                                            "logic": "and",
+                                                            "conditions": [
+                                                                {
+                                                                    "definition": {
+                                                                        "key": "~type",
+                                                                        "matcher": "eq",
+                                                                        "values": [
+                                                                            "com.adobe.eventType.places"
+                                                                        ]
+                                                                    },
+                                                                    "type": "matcher"
+                                                                },
+                                                                {
+                                                                    "definition": {
+                                                                        "key": "~source",
+                                                                        "matcher": "eq",
+                                                                        "values": [
+                                                                            "com.adobe.eventSource.requestContent"
+                                                                        ]
+                                                                    },
+                                                                    "type": "matcher"
+                                                                },
+                                                                {
+                                                                    "definition": {
+                                                                        "key": "regionEventType",
+                                                                        "matcher": "eq",
+                                                                        "values": [
+                                                                            "entered"
+                                                                        ]
+                                                                    },
+                                                                    "type": "matcher"
+                                                                }
+                                                            ]
+                                                        }
+                                                    },
+                                                    {
+                                                        "type": "historical",
+                                                        "definition": {
+                                                            "searchType": "mostRecent",
+                                                            "value": 1,
+                                                            "matcher": "ne",
+                                                            "events": [
+                                                                {
+                                                                    "iam.eventType": "unqualify",
+                                                                    "iam.id": "a43122c4-bf19-499f-b507-087a028d1769#fa035681-15ce-488e-859e-200bb2ca90ae"
+                                                                },
+                                                                {
+                                                                    "iam.eventType": "qualify",
+                                                                    "iam.id": "a43122c4-bf19-499f-b507-087a028d1769#fa035681-15ce-488e-859e-200bb2ca90ae"
+                                                                }
+                                                            ]
+                                                        }
+                                                    }
+                                                ]
+                                            }
+                                        },
+                                        "consequences": [
+                                            {
+                                                "id": "48181acd-22b3-edae-bc8a-447868a7df7e",
+                                                "type": "schema",
+                                                "detail": {
+                                                    "id": "48181acd-22b3-edae-bc8a-447868a7df7e",
+                                                    "schema": "https://ns.adobe.com/personalization/eventHistoryOperation",
+                                                    "data": {
+                                                        "operation": "insert",
+                                                        "content": {
+                                                            "iam.eventType": "qualify",
+                                                            "iam.id": "a43122c4-bf19-499f-b507-087a028d1769#fa035681-15ce-488e-859e-200bb2ca90ae"
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "condition": {
+                                            "type": "group",
+                                            "definition": {
+                                                "logic": "and",
+                                                "conditions": [
+                                                    {
+                                                        "type": "historical",
+                                                        "definition": {
+                                                            "value": 0,
+                                                            "matcher": "eq",
+                                                            "events": [
+                                                                {
+                                                                    "iam.eventType": "disqualify",
+                                                                    "iam.id": "a43122c4-bf19-499f-b507-087a028d1769#fa035681-15ce-488e-859e-200bb2ca90ae"
+                                                                }
+                                                            ]
+                                                        }
+                                                    },
+                                                    {
+                                                        "type": "group",
+                                                        "definition": {
+                                                            "logic": "and",
+                                                            "conditions": [
+                                                                {
+                                                                    "definition": {
+                                                                        "key": "~type",
+                                                                        "matcher": "eq",
+                                                                        "values": [
+                                                                            "com.adobe.eventType.places"
+                                                                        ]
+                                                                    },
+                                                                    "type": "matcher"
+                                                                },
+                                                                {
+                                                                    "definition": {
+                                                                        "key": "~source",
+                                                                        "matcher": "eq",
+                                                                        "values": [
+                                                                            "com.adobe.eventSource.requestContent"
+                                                                        ]
+                                                                    },
+                                                                    "type": "matcher"
+                                                                },
+                                                                {
+                                                                    "definition": {
+                                                                        "key": "regionEventType",
+                                                                        "matcher": "eq",
+                                                                        "values": [
+                                                                            "exited"
+                                                                        ]
+                                                                    },
+                                                                    "type": "matcher"
+                                                                }
+                                                            ]
+                                                        }
+                                                    },
+                                                    {
+                                                        "type": "historical",
+                                                        "definition": {
+                                                            "searchType": "mostRecent",
+                                                            "value": 0,
+                                                            "matcher": "ne",
+                                                            "events": [
+                                                                {
+                                                                    "iam.eventType": "unqualify",
+                                                                    "iam.id": "a43122c4-bf19-499f-b507-087a028d1769#fa035681-15ce-488e-859e-200bb2ca90ae"
+                                                                },
+                                                                {
+                                                                    "iam.eventType": "qualify",
+                                                                    "iam.id": "a43122c4-bf19-499f-b507-087a028d1769#fa035681-15ce-488e-859e-200bb2ca90ae"
+                                                                }
+                                                            ]
+                                                        }
+                                                    }
+                                                ]
+                                            }
+                                        },
+                                        "consequences": [
+                                            {
+                                                "id": "48181acd-22b3-edae-bc8a-447868a7df7e",
+                                                "type": "schema",
+                                                "detail": {
+                                                    "id": "48181acd-22b3-edae-bc8a-447868a7df7e",
+                                                    "schema": "https://ns.adobe.com/personalization/eventHistoryOperation",
+                                                    "data": {
+                                                        "operation": "insert",
+                                                        "content": {
+                                                            "iam.eventType": "unqualify",
+                                                            "iam.id": "a43122c4-bf19-499f-b507-087a028d1769#fa035681-15ce-488e-859e-200bb2ca90ae"
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "condition": {
+                                            "type": "group",
+                                            "definition": {
+                                                "logic": "and",
+                                                "conditions": [
+                                                    {
+                                                        "type": "group",
+                                                        "definition": {
+                                                            "logic": "and",
+                                                            "conditions": [
+                                                                {
+                                                                    "definition": {
+                                                                        "key": "~type",
+                                                                        "matcher": "eq",
+                                                                        "values": [
+                                                                            "com.adobe.eventType.edge"
+                                                                        ]
+                                                                    },
+                                                                    "type": "matcher"
+                                                                },
+                                                                {
+                                                                    "definition": {
+                                                                        "key": "~source",
+                                                                        "matcher": "eq",
+                                                                        "values": [
+                                                                            "com.adobe.eventSource.requestContent"
+                                                                        ]
+                                                                    },
+                                                                    "type": "matcher"
+                                                                },
+                                                                {
+                                                                    "definition": {
+                                                                        "key": "xdm.eventType",
+                                                                        "matcher": "eq",
+                                                                        "values": [
+                                                                            "decisioning.propositionDismiss"
+                                                                        ]
+                                                                    },
+                                                                    "type": "matcher"
+                                                                },
+                                                                {
+                                                                    "definition": {
+                                                                        "key": "xdm._experience.decisioning.propositions.0.scopeDetails.activity.id",
+                                                                        "matcher": "eq",
+                                                                        "values": [
+                                                                            "a43122c4-bf19-499f-b507-087a028d1769#fa035681-15ce-488e-859e-200bb2ca90ae"
+                                                                        ]
+                                                                    },
+                                                                    "type": "matcher"
+                                                                }
+                                                            ]
+                                                        }
+                                                    },
+                                                    {
+                                                        "type": "matcher",
+                                                        "definition": {
+                                                            "key": "~timestampu",
+                                                            "matcher": "lt",
+                                                            "values": [
+                                                                2019715200
+                                                            ]
+                                                        }
+                                                    }
+                                                ]
+                                            }
+                                        },
+                                        "consequences": [
+                                            {
+                                                "id": "48181acd-22b3-edae-bc8a-447868a7df7e",
+                                                "type": "schema",
+                                                "detail": {
+                                                    "id": "48181acd-22b3-edae-bc8a-447868a7df7c",
+                                                    "schema": "https://ns.adobe.com/personalization/eventHistoryOperation",
+                                                    "data": {
+                                                        "operation": "insertIfNotExists",
+                                                        "content": {
+                                                            "iam.eventType": "disqualify",
+                                                            "iam.id": "a43122c4-bf19-499f-b507-087a028d1769#fa035681-15ce-488e-859e-200bb2ca90ae"
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            ],
+            "type": "personalization:decisions"
+        }
+    ]
+}

--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/EdgePersonalizationResponseHandler.java
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/EdgePersonalizationResponseHandler.java
@@ -298,6 +298,9 @@ class EdgePersonalizationResponseHandler {
                                 "Unable to run completion logic for a personalization request event"
                                         + " - error occurred: %s",
                                 adobeError.getErrorName());
+                        if (handler != null) {
+                            handler.handle.call(false);
+                        }
                     }
 
                     // the callback is called by Edge extension when a request's stream has been
@@ -687,7 +690,7 @@ class EdgePersonalizationResponseHandler {
                                     EventType.MESSAGING,
                                     EventSource.REQUEST_CONTENT)
                             .build();
-            updateQualifiedContentCardsForEvent(event);
+            removeOrReplaceContentCards(event, requestedSurfaces);
         }
 
         // collect and update launch rules engine for in-app and event history
@@ -769,81 +772,185 @@ class EdgePersonalizationResponseHandler {
     }
 
     /**
-     * Checks to see if the user has qualified for any content cards based on provided {@link
-     * Event}.
+     * Incrementally updates the content card cache for surfaces qualified by the rules engine.
      *
-     * @param event may result in content card qualification.
+     * <p>Called during rules engine processing (e.g. lifecycle or generic events). For each surface
+     * qualified by the provided {@link Event}:
+     *
+     * <ul>
+     *   <li>If a proposition already exists in the cache, it is removed and re-added (replaced) so
+     *       the latest data is reflected without duplicates.
+     *   <li>If a proposition is new (not previously in the cache), a {@code TRIGGER} event is sent
+     *       to Edge Network and the proposition is added to the cache.
+     * </ul>
+     *
+     * <p>This method is additive — it does not remove surfaces that return no results. Use {@link
+     * #removeOrReplaceContentCards(Event, List)} for authoritative refreshes that should clear
+     * stale surfaces.
+     *
+     * @param event the rules engine {@link Event} that may result in content card qualification.
      */
-    void updateQualifiedContentCardsForEvent(final Event event) {
+    @SuppressWarnings("NestedIfDepth")
+    void addOrReplaceContentCards(final Event event) {
         final Map<Surface, List<Proposition>> qualifiedContentCardsBySurface =
                 getPropositionsFromContentCardRulesEngine(event);
         for (final Map.Entry<Surface, List<Proposition>> entry :
                 qualifiedContentCardsBySurface.entrySet()) {
-            addOrReplaceContentCards(entry.getValue(), entry.getKey());
+            final List<Proposition> propositions = entry.getValue();
+            final Surface surface = entry.getKey();
+            List<Proposition> existingPropositionsArray = contentCardsBySurface.get(surface);
+            if (existingPropositionsArray == null) {
+                existingPropositionsArray = new ArrayList<>();
+            }
+
+            int startingCount = existingPropositionsArray.size();
+            // Track proposition items that are new so we can fire TRIGGER events for them
+            List<PropositionItem> newPropositionItems = new ArrayList<>();
+
+            for (final Proposition proposition : propositions) {
+                if (existingPropositionsArray.contains(proposition)) {
+                    // Remove the stale entry so the updated proposition is added at the end
+                    existingPropositionsArray.remove(proposition);
+                } else {
+                    // Proposition is new — collect its first item for a batched TRIGGER event
+                    final List<PropositionItem> propItems = proposition.getItems();
+                    if (!propItems.isEmpty()) {
+                        newPropositionItems.add(propItems.get(0));
+                    }
+                }
+                existingPropositionsArray.add(proposition);
+
+                // Store qualified content cards as schema data in the ContentCardMapper for later
+                // use by the UI layer
+                final ContentCardSchemaData propositionAsContentCard =
+                        proposition.getItems().get(0).getContentCardSchemaData();
+                ContentCardMapper.getInstance()
+                        .storeContentCardSchemaData(propositionAsContentCard);
+            }
+
+            contentCardsBySurface.put(surface, existingPropositionsArray);
+
+            // Send batched trigger events for new proposition items only
+            if (!newPropositionItems.isEmpty()) {
+                sendBatchedPropositionInteraction(
+                        newPropositionItems, null, MessagingEdgeEventType.TRIGGER);
+            }
+
+            int newCount = existingPropositionsArray.size();
+            if (startingCount != newCount) {
+                final Locale locale =
+                        ServiceProvider.getInstance().getDeviceInfoService().getActiveLocale();
+                String message =
+                        newCount > 0
+                                ? String.format(
+                                        locale,
+                                        "User has qualified for %d content card(s) for surface %s",
+                                        newCount,
+                                        surface.getUri())
+                                : String.format(
+                                        locale,
+                                        "User has not qualified for any content card(s) for surface"
+                                                + " %s",
+                                        surface.getUri());
+                Log.trace(MessagingConstants.LOG_TAG, SELF_TAG, message);
+            }
         }
     }
 
     /**
-     * Manages qualified content cards by surface. Prevents multiple entries for the same
-     * proposition in {@code contentCardsBySurface}. If an existing entry for a proposition is
-     * found, it is replaced with the value in propositions. If no prior entry exists for a
-     * proposition, a `trigger` event will be sent and written to event history).
+     * Authoritatively refreshes the content card cache using the response from a personalization
+     * network request.
      *
-     * @param propositions list of qualified {@link Proposition}s for the given surface.
-     * @param surface {@link Surface} to which qualified propositions belong.
+     * <p>Called after a personalization response stream completes. Treats the response as the
+     * source of truth for the requested surfaces:
+     *
+     * <ul>
+     *   <li>Any requested surface that returned no qualified propositions is removed from the
+     *       cache, preventing stale cards from persisting after a server-side change.
+     *   <li>For surfaces that did return propositions, the cached list is fully replaced (not
+     *       merged) with the new results.
+     *   <li>Propositions that are new (not previously in the cache) generate a {@code TRIGGER}
+     *       event sent to Edge Network.
+     * </ul>
+     *
+     * @param event the personalization response {@link Event} used to query the rules engine.
+     * @param requestedSurfaces the list of {@link Surface}s that were included in the originating
+     *     personalization request; used to identify surfaces that should be cleared if absent from
+     *     the response.
      */
-    @SuppressWarnings("NestedIfDepth")
-    private void addOrReplaceContentCards(
-            final List<Proposition> propositions, final Surface surface) {
-        List<Proposition> existingPropositionsArray = contentCardsBySurface.get(surface);
-        if (existingPropositionsArray == null) {
-            existingPropositionsArray = new ArrayList<>();
-        }
+    void removeOrReplaceContentCards(final Event event, final List<Surface> requestedSurfaces) {
+        final Map<Surface, List<Proposition>> qualifiedContentCardsBySurface =
+                getPropositionsFromContentCardRulesEngine(event);
 
-        int startingCount = existingPropositionsArray.size();
-        List<PropositionItem> newPropositionItems = new ArrayList<>();
-
-        for (final Proposition proposition : propositions) {
-            if (existingPropositionsArray.contains(proposition)) {
-                existingPropositionsArray.remove(proposition);
-            } else {
-                final List<PropositionItem> propItems = proposition.getItems();
-                if (!propItems.isEmpty()) {
-                    newPropositionItems.add(propItems.get(0));
-                }
+        // Clear any requested surface that returned no qualified propositions in this response.
+        // This ensures cards removed server-side are also evicted from the local cache.
+        for (final Surface surface : requestedSurfaces) {
+            if (!qualifiedContentCardsBySurface.containsKey(surface)) {
+                contentCardsBySurface.remove(surface);
             }
-            existingPropositionsArray.add(proposition);
-
-            // store qualified content cards as schema data in the ContentCardMapper for later use
-            final ContentCardSchemaData propositionAsContentCard =
-                    proposition.getItems().get(0).getContentCardSchemaData();
-            ContentCardMapper.getInstance().storeContentCardSchemaData(propositionAsContentCard);
         }
 
-        contentCardsBySurface.put(surface, existingPropositionsArray);
+        // Fully replace cached propositions for surfaces that have qualified content cards
+        for (final Map.Entry<Surface, List<Proposition>> entry :
+                qualifiedContentCardsBySurface.entrySet()) {
+            final List<Proposition> propositions = entry.getValue();
+            final Surface surface = entry.getKey();
+            List<Proposition> existingPropositionsArray = contentCardsBySurface.get(surface);
+            if (existingPropositionsArray == null) {
+                existingPropositionsArray = new ArrayList<>();
+            }
 
-        // Send batched trigger events for new proposition items
-        if (!newPropositionItems.isEmpty()) {
-            sendBatchedPropositionInteraction(
-                    newPropositionItems, null, MessagingEdgeEventType.TRIGGER);
-        }
+            int startingCount = existingPropositionsArray.size();
+            // Build a fresh list from the response rather than mutating the existing one
+            List<Proposition> newPropositionsArray = new ArrayList<>();
+            // Track proposition items that are genuinely new so we can fire TRIGGER events
+            List<PropositionItem> newPropositionItems = new ArrayList<>();
 
-        int newCount = existingPropositionsArray.size();
-        if (startingCount != newCount) {
-            final Locale locale =
-                    ServiceProvider.getInstance().getDeviceInfoService().getActiveLocale();
-            String message =
-                    newCount > 0
-                            ? String.format(
-                                    locale,
-                                    "User has qualified for %d content card(s) for surface %s",
-                                    newCount,
-                                    surface.getUri())
-                            : String.format(
-                                    locale,
-                                    "User has not qualified for any content card(s) for surface %s",
-                                    surface.getUri());
-            Log.trace(MessagingConstants.LOG_TAG, SELF_TAG, message);
+            for (final Proposition proposition : propositions) {
+                if (!existingPropositionsArray.contains(proposition)) {
+                    // Proposition is new — collect its first item for a batched TRIGGER event
+                    final List<PropositionItem> propItems = proposition.getItems();
+                    if (!propItems.isEmpty()) {
+                        newPropositionItems.add(propItems.get(0));
+                    }
+                }
+                newPropositionsArray.add(proposition);
+
+                // Store qualified content cards as schema data in the ContentCardMapper for later
+                // use by the UI layer
+                final ContentCardSchemaData propositionAsContentCard =
+                        proposition.getItems().get(0).getContentCardSchemaData();
+                ContentCardMapper.getInstance()
+                        .storeContentCardSchemaData(propositionAsContentCard);
+            }
+
+            // Replace the cached list entirely with the fresh response data
+            contentCardsBySurface.put(surface, newPropositionsArray);
+
+            // Send batched trigger events for new proposition items only
+            if (!newPropositionItems.isEmpty()) {
+                sendBatchedPropositionInteraction(
+                        newPropositionItems, null, MessagingEdgeEventType.TRIGGER);
+            }
+
+            int newCount = existingPropositionsArray.size();
+            if (startingCount != newCount) {
+                final Locale locale =
+                        ServiceProvider.getInstance().getDeviceInfoService().getActiveLocale();
+                String message =
+                        newCount > 0
+                                ? String.format(
+                                        locale,
+                                        "User has qualified for %d content card(s) for surface %s",
+                                        newCount,
+                                        surface.getUri())
+                                : String.format(
+                                        locale,
+                                        "User has not qualified for any content card(s) for surface"
+                                                + " %s",
+                                        surface.getUri());
+                Log.trace(MessagingConstants.LOG_TAG, SELF_TAG, message);
+            }
         }
     }
 
@@ -995,7 +1102,7 @@ class EdgePersonalizationResponseHandler {
         for (final Surface surface : surfaces) {
             final List<Proposition> propositionsList = inMemoryPropositions.get(surface);
             if (!MessagingUtils.isNullOrEmpty(propositionsList)) {
-                propositionMap.put(surface, new ArrayList<>(propositionsList));
+                propositionMap.put(surface, propositionsList);
             }
         }
         return propositionMap;

--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/EdgePersonalizationResponseHandler.java
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/EdgePersonalizationResponseHandler.java
@@ -1102,7 +1102,7 @@ class EdgePersonalizationResponseHandler {
         for (final Surface surface : surfaces) {
             final List<Proposition> propositionsList = inMemoryPropositions.get(surface);
             if (!MessagingUtils.isNullOrEmpty(propositionsList)) {
-                propositionMap.put(surface, propositionsList);
+                propositionMap.put(surface, new ArrayList<>(propositionsList));
             }
         }
         return propositionMap;

--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/MessagingExtension.java
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/MessagingExtension.java
@@ -297,7 +297,7 @@ public final class MessagingExtension extends Extension {
             return;
         }
         messagingRulesEngine.processEvent(event);
-        edgePersonalizationResponseHandler.updateQualifiedContentCardsForEvent(event);
+        edgePersonalizationResponseHandler.addOrReplaceContentCards(event);
     }
 
     /**


### PR DESCRIPTION
## Description

 **EdgePersonalizationResponseHandler.java**                                                                                                                                                                                          
                                                                                                                                                                                                                                                        
1. Rename + refactor: updateQualifiedContentCardsForEvent → split into two methods: The old single method is replaced by two distinct methods with different responsibilities
- **addOrReplaceContentCards(event)** — Called on rules engine events (e.g., lifecycle/generic events). It adds newly qualified propositions to the cache, replacing any existing entry for the same proposition. Fires `TRIGGER` events only for new propositions (not already in cache). Used for incremental qualification.                                                                                                                                   
- **removeOrReplaceContentCards(event, requestedSurfaces)** — Called after a personalization network response completes. The key difference is it uses the `requestedSurfaces` list to clear surfaces that returned no results from the cache. Then it replaces (not appends) the proposition list for surfaces that did return results. This prevents stale content cards from lingering after a refresh — e.g., if a card was dismissed server-side, it gets removed  locally.

2. Call site change in the response handler: Where the old code called `updateQualifiedContentCardsForEvent(event)` during network response processing, it now calls `removeOrReplaceContentCards(event, requestedSurfaces)`, passing the surfaces that were originally requested so stale surfaces can be pruned. 

**MessagingExtension.java**

1. A single line change to align with the rename: the rules engine event processor now calls `addOrReplaceContentCards(event)` instead of `updateQualifiedContentCardsForEvent(event)`.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

The problem being solved is stale content card caching. Previously, if a server-side refresh returned fewer cards (or none) for a surface, the old cards would remain in the local cache indefinitely. The new `removeOrReplaceContentCards` method fixes this by treating a network response as authoritative — it clears any surface that came back empty, and fully replaces (rather than merges) the proposition list for surfaces that returned results. The `addOrReplaceContentCards` path is preserved for the incremental/rules-engine qualification flow.

## How Has This Been Tested?

Added new `testContentCard_Removal` in `MessagingPublicAPITests`

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
