### PR TITLE
Content Card Cache Cleanup

### DIFF
--- a/code/messaging/src/androidTest/java/com/adobe/marketing/mobile/messaging/MessagingPublicAPITests.java
+++ b/code/messaging/src/androidTest/java/com/adobe/marketing/mobile/messaging/MessagingPublicAPITests.java
@@ -982,7 +982,7 @@ public class MessagingPublicAPITests {
                 });
 
         // verify qualified content card is returned
-        assertTrue(latch.await(1000, TimeUnit.SECONDS));
+        assertTrue(latch.await(5, TimeUnit.SECONDS));
         assertEquals(2, qualifiedCardPropositions.size());
         List<Proposition> contentCardList1 = qualifiedCardPropositions.get(surface1);
         assertNotNull(contentCardList1);
@@ -1034,7 +1034,7 @@ public class MessagingPublicAPITests {
                 });
 
         // verify empty qualified content card list is returned
-        assertTrue(latch1.await(1000, TimeUnit.SECONDS));
+        assertTrue(latch1.await(5, TimeUnit.SECONDS));
         assertEquals(1, qualifiedCardPropositions1.size());
         List<Proposition> contentCardList3 = qualifiedCardPropositions1.get(surface1);
         assertNotNull(contentCardList3);

--- a/code/messaging/src/androidTest/java/com/adobe/marketing/mobile/messaging/MessagingPublicAPITests.java
+++ b/code/messaging/src/androidTest/java/com/adobe/marketing/mobile/messaging/MessagingPublicAPITests.java
@@ -885,6 +885,163 @@ public class MessagingPublicAPITests {
     // Content Card Tests
     // --------------------------------------------------------------------------------------------
     @Test
+    public void testContentCard_Removal() throws InterruptedException {
+        // setup
+        final List<Surface> surfacePaths = new ArrayList<>();
+        Surface surface1 = new Surface("promos/feed1");
+        surfacePaths.add(surface1);
+        Surface surface2 = new Surface("promos/feed2");
+        surfacePaths.add(surface2);
+        final List<Map<String, Object>> expectedSurfaces = new ArrayList<>();
+        expectedSurfaces.add(
+                new HashMap<String, Object>() {
+                    {
+                        put(
+                                "uri",
+                                "mobileapp://com.adobe.marketing.mobile.messaging.test/promos/feed1");
+                    }
+                });
+        expectedSurfaces.add(
+                new HashMap<String, Object>() {
+                    {
+                        put(
+                                "uri",
+                                "mobileapp://com.adobe.marketing.mobile.messaging.test/promos/feed2");
+                    }
+                });
+
+        // setup mock server response for content card propositions
+        setMockNetworkResponseForPersonalizationRequests("multipleContentCardNetworkResponse.json");
+
+        // test retrieving propositions from server
+        Messaging.updatePropositionsForSurfaces(surfacePaths);
+        TestHelper.sleep(500);
+
+        // verify messaging request content event
+        final List<Event> messagingRequestEvents =
+                getDispatchedEventsWith(
+                        MessagingTestConstants.EventType.MESSAGING, EventSource.REQUEST_CONTENT);
+        assertEquals(1, messagingRequestEvents.size());
+        final Map<String, Object> messagingEventData = messagingRequestEvents.get(0).getEventData();
+        assertEquals(true, messagingEventData.get("updatepropositions"));
+        assertEquals(expectedSurfaces, messagingEventData.get("surfaces"));
+
+        // verify edge request content event
+        final List<Event> edgePersonalizationRequestEvents =
+                getDispatchedEventsWith(
+                        MessagingTestConstants.EventType.EDGE, EventSource.REQUEST_CONTENT);
+        assertEquals(1, edgePersonalizationRequestEvents.size());
+        final Map<String, Object> edgeEventData =
+                edgePersonalizationRequestEvents.get(0).getEventData();
+        final Map<String, Object> xdmDataMap =
+                DataReader.optTypedMap(Object.class, edgeEventData, "xdm", null);
+        final Map<String, Object> queryDataMap =
+                DataReader.optTypedMap(Object.class, edgeEventData, "query", null);
+        final Map<String, Object> personalizationDataMap =
+                DataReader.optTypedMap(Object.class, queryDataMap, "personalization", null);
+        final List<String> surfacesList =
+                DataReader.optStringList(personalizationDataMap, "surfaces", null);
+        assertEquals("personalization.request", xdmDataMap.get("eventType"));
+        assertEquals(2, surfacesList.size());
+        assertEquals(
+                "mobileapp://com.adobe.marketing.mobile.messaging.test/promos/feed1",
+                surfacesList.get(0));
+        assertEquals(
+                "mobileapp://com.adobe.marketing.mobile.messaging.test/promos/feed2",
+                surfacesList.get(1));
+
+        // dispatch content card qualification event
+        MobileCore.dispatchEvent(
+                new Event.Builder(
+                                "Places entry event", EventType.PLACES, EventSource.REQUEST_CONTENT)
+                        .setEventData(
+                                new HashMap<String, Object>() {
+                                    {
+                                        put("regionEventType", "entered");
+                                    }
+                                })
+                        .build());
+        TestHelper.sleep(500);
+
+        // retrieve qualified content cards
+        CountDownLatch latch = new CountDownLatch(1);
+        final Map<Surface, List<Proposition>> qualifiedCardPropositions = new HashMap<>();
+        Messaging.getPropositionsForSurfaces(
+                surfacePaths,
+                new AdobeCallbackWithError<Map<Surface, List<Proposition>>>() {
+                    @Override
+                    public void fail(AdobeError adobeError) {
+                        latch.countDown();
+                    }
+
+                    @Override
+                    public void call(Map<Surface, List<Proposition>> surfaceListMap) {
+                        qualifiedCardPropositions.putAll(surfaceListMap);
+                        latch.countDown();
+                    }
+                });
+
+        // verify qualified content card is returned
+        assertTrue(latch.await(1000, TimeUnit.SECONDS));
+        assertEquals(2, qualifiedCardPropositions.size());
+        List<Proposition> contentCardList1 = qualifiedCardPropositions.get(surface1);
+        assertNotNull(contentCardList1);
+        assertEquals(2, contentCardList1.size());
+        assertEquals(
+                SchemaType.CONTENT_CARD, contentCardList1.get(0).getItems().get(0).getSchema());
+        List<Proposition> contentCardList2 = qualifiedCardPropositions.get(surface2);
+        assertNotNull(contentCardList2);
+        assertEquals(1, contentCardList2.size());
+        assertEquals(
+                SchemaType.CONTENT_CARD, contentCardList2.get(0).getItems().get(0).getSchema());
+
+        setMockNetworkResponseForPersonalizationRequests(
+                "contentCardWithTriggersNetworkResponse.json");
+
+        // test retrieving propositions from server
+        Messaging.updatePropositionsForSurfaces(surfacePaths);
+        TestHelper.sleep(500);
+
+        // dispatch content card qualification event
+        MobileCore.dispatchEvent(
+                new Event.Builder(
+                                "Places entry event", EventType.PLACES, EventSource.REQUEST_CONTENT)
+                        .setEventData(
+                                new HashMap<String, Object>() {
+                                    {
+                                        put("regionEventType", "entered");
+                                    }
+                                })
+                        .build());
+        TestHelper.sleep(500);
+
+        // retrieve qualified content cards
+        CountDownLatch latch1 = new CountDownLatch(1);
+        final Map<Surface, List<Proposition>> qualifiedCardPropositions1 = new HashMap<>();
+        Messaging.getPropositionsForSurfaces(
+                surfacePaths,
+                new AdobeCallbackWithError<Map<Surface, List<Proposition>>>() {
+                    @Override
+                    public void fail(AdobeError adobeError) {
+                        latch1.countDown();
+                    }
+
+                    @Override
+                    public void call(Map<Surface, List<Proposition>> surfaceListMap) {
+                        qualifiedCardPropositions1.putAll(surfaceListMap);
+                        latch1.countDown();
+                    }
+                });
+
+        // verify empty qualified content card list is returned
+        assertTrue(latch1.await(1000, TimeUnit.SECONDS));
+        assertEquals(1, qualifiedCardPropositions1.size());
+        List<Proposition> contentCardList3 = qualifiedCardPropositions1.get(surface1);
+        assertNotNull(contentCardList3);
+        assertEquals(1, contentCardList3.size());
+    }
+
+    @Test
     public void testContentCard_Qualification() throws InterruptedException {
         // setup
         final List<Surface> surfacePaths = new ArrayList<>();

--- a/code/messaging/src/androidTest/resources/multipleContentCardNetworkResponse.json
+++ b/code/messaging/src/androidTest/resources/multipleContentCardNetworkResponse.json
@@ -1,0 +1,1372 @@
+{
+    "requestId": "mockRequestId",
+    "handle": [
+        {
+            "payload": [
+                {
+                    "id": "c2aa4a73-a534-44c2-baa4-a12980e5bb9d",
+                    "scope": "mobileapp://com.adobe.marketing.mobile.messaging.test/promos/feed1",
+                    "scopeDetails": {
+                        "decisionProvider": "AJO",
+                        "correlationID": "b5095046-7fd7-4961-871f-9d68f2dc335f",
+                        "characteristics": {
+                            "eventToken": "eyJtZXNzYWdlRXhlY3V0aW9uIjp7Im1lc3NhZ2VFeGVjdXRpb25JRCI6Ik5BIiwibWVzc2FnZUlEIjoiYjUwOTUwNDYtN2ZkNy00OTYxLTg3MWYtOWQ2OGYyZGMzMzVmIiwibWVzc2FnZVB1YmxpY2F0aW9uSUQiOiJiNzFlNDhiYS1mNzY3LTQ5NWItOWQxMS01YzA3MTg4NWNkODkiLCJtZXNzYWdlVHlwZSI6Im1hcmtldGluZyIsImNhbXBhaWduSUQiOiI5YzhlYzAzNS02YjNiLTQ3MGUtOGFlNS1lNTM5YzcxMjM4MDkiLCJjYW1wYWlnblZlcnNpb25JRCI6IjdkZGEyZGM2LTE5MjMtNGU2My1iZWFjLTU0ZGM3ODczNjFlYiIsImNhbXBhaWduQWN0aW9uSUQiOiJjN2MxNDk3ZS1lNWEzLTQ0MjMtYWUzNy1iYTc2ZTFlNDQzNDIifSwibWVzc2FnZVByb2ZpbGUiOnsibWVzc2FnZVByb2ZpbGVJRCI6IjQ0YWQ1NTA3LTZlODItNGY2MS05N2U1LTUzMmNhNmZkMDhhOCIsImNoYW5uZWwiOnsiX2lkIjoiaHR0cHM6Ly9ucy5hZG9iZS5jb20veGRtL2NoYW5uZWxzL3dlYiIsIl90eXBlIjoiaHR0cHM6Ly9ucy5hZG9iZS5jb20veGRtL2NoYW5uZWwtdHlwZXMvd2ViIn19fQ=="
+                        },
+                        "activity": {
+                            "id": "a43122c4-bf19-499f-b507-087a028d1769#fa035681-15ce-488e-859e-200bb2ca90ac"
+                        }
+                    },
+                    "items": [
+                        {
+                            "id": "9d6eff2c-39a7-4aa1-9657-d642e26c5176",
+                            "schema": "https://ns.adobe.com/personalization/ruleset-item",
+                            "data": {
+                                "version": 1,
+                                "rules": [
+                                    {
+                                        "condition": {
+                                            "type": "group",
+                                            "definition": {
+                                                "logic": "and",
+                                                "conditions": [
+                                                    {
+                                                        "type": "historical",
+                                                        "definition": {
+                                                            "value": 0,
+                                                            "matcher": "eq",
+                                                            "events": [
+                                                                {
+                                                                    "iam.eventType": "disqualify",
+                                                                    "iam.id": "a43122c4-bf19-499f-b507-087a028d1769#fa035681-15ce-488e-859e-200bb2ca90ac"
+                                                                }
+                                                            ]
+                                                        }
+                                                    },
+                                                    {
+                                                        "type": "matcher",
+                                                        "definition": {
+                                                            "key": "~timestampu",
+                                                            "matcher": "lt",
+                                                            "values": [
+                                                                2019715200
+                                                            ]
+                                                        }
+                                                    },
+                                                    {
+                                                        "type": "group",
+                                                        "definition": {
+                                                            "logic": "or",
+                                                            "conditions": [
+                                                                {
+                                                                    "type": "group",
+                                                                    "definition": {
+                                                                        "logic": "and",
+                                                                        "conditions": [
+                                                                            {
+                                                                                "definition": {
+                                                                                    "key": "~type",
+                                                                                    "matcher": "eq",
+                                                                                    "values": [
+                                                                                        "com.adobe.eventType.places"
+                                                                                    ]
+                                                                                },
+                                                                                "type": "matcher"
+                                                                            },
+                                                                            {
+                                                                                "definition": {
+                                                                                    "key": "~source",
+                                                                                    "matcher": "eq",
+                                                                                    "values": [
+                                                                                        "com.adobe.eventSource.requestContent"
+                                                                                    ]
+                                                                                },
+                                                                                "type": "matcher"
+                                                                            },
+                                                                            {
+                                                                                "definition": {
+                                                                                    "key": "regionEventType",
+                                                                                    "matcher": "eq",
+                                                                                    "values": [
+                                                                                        "entered"
+                                                                                    ]
+                                                                                },
+                                                                                "type": "matcher"
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                },
+                                                                {
+                                                                    "type": "historical",
+                                                                    "definition": {
+                                                                        "searchType": "mostRecent",
+                                                                        "value": 1,
+                                                                        "matcher": "ge",
+                                                                        "events": [
+                                                                            {
+                                                                                "iam.eventType": "unqualify",
+                                                                                "iam.id": "a43122c4-bf19-499f-b507-087a028d1769#fa035681-15ce-488e-859e-200bb2ca90ac"
+                                                                            },
+                                                                            {
+                                                                                "iam.eventType": "trigger",
+                                                                                "iam.id": "a43122c4-bf19-499f-b507-087a028d1769#fa035681-15ce-488e-859e-200bb2ca90ac"
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                },
+                                                                {
+                                                                    "type": "historical",
+                                                                    "definition": {
+                                                                        "searchType": "mostRecent",
+                                                                        "value": 1,
+                                                                        "matcher": "eq",
+                                                                        "events": [
+                                                                            {
+                                                                                "iam.eventType": "unqualify",
+                                                                                "iam.id": "a43122c4-bf19-499f-b507-087a028d1769#fa035681-15ce-488e-859e-200bb2ca90ac"
+                                                                            },
+                                                                            {
+                                                                                "iam.eventType": "qualify",
+                                                                                "iam.id": "a43122c4-bf19-499f-b507-087a028d1769#fa035681-15ce-488e-859e-200bb2ca90ac"
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                }
+                                                            ]
+                                                        }
+                                                    }
+                                                ]
+                                            }
+                                        },
+                                        "consequences": [
+                                            {
+                                                "id": "183639c4-cb37-458e-a8ef-4e130d767ebf",
+                                                "type": "schema",
+                                                "detail": {
+                                                    "id": "183639c4-cb37-458e-a8ef-4e130d767ebf",
+                                                    "schema": "https://ns.adobe.com/personalization/message/content-card",
+                                                    "data": {
+                                                        "expiryDate": 1723163897,
+                                                        "meta": {
+                                                            "feedName": "testFeed",
+                                                            "campaignName": "testCampaign",
+                                                            "surface": "mobileapp://com.adobe.marketing.mobile.messaging.test/promos/feed1"
+                                                        },
+                                                        "content": {
+                                                            "title": "Guacamole!",
+                                                            "body": "I'm the queen of Nacho Picchu and I'm really glad to meet you. To spice up this big tortilla chip, I command you to find a big dip.",
+                                                            "imageUrl": "https://d14dq8eoa1si34.cloudfront.net/2a6ef2f0-1167-11eb-88c6-b512a5ef09a7/urn:aaid:aem:d4b77a01-610a-4c3f-9be6-5ebe1bd13da3/oak:1.0::ci:fa54b394b6f987d974d8619833083519/8933c829-3ab2-38e8-a1ee-00d4f562fff8",
+                                                            "actionUrl": "https://luma.com/guacamolethemusical",
+                                                            "actionTitle": "guacamole!"
+                                                        },
+                                                        "contentType": "application/json",
+                                                        "publishedDate": 1691541497
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "condition": {
+                                            "type": "group",
+                                            "definition": {
+                                                "logic": "and",
+                                                "conditions": [
+                                                    {
+                                                        "type": "historical",
+                                                        "definition": {
+                                                            "value": 0,
+                                                            "matcher": "eq",
+                                                            "events": [
+                                                                {
+                                                                    "iam.eventType": "disqualify",
+                                                                    "iam.id": "a43122c4-bf19-499f-b507-087a028d1769#fa035681-15ce-488e-859e-200bb2ca90ac"
+                                                                }
+                                                            ]
+                                                        }
+                                                    },
+                                                    {
+                                                        "type": "matcher",
+                                                        "definition": {
+                                                            "key": "~timestampu",
+                                                            "matcher": "lt",
+                                                            "values": [
+                                                                2019715200
+                                                            ]
+                                                        }
+                                                    },
+                                                    {
+                                                        "type": "group",
+                                                        "definition": {
+                                                            "logic": "and",
+                                                            "conditions": [
+                                                                {
+                                                                    "definition": {
+                                                                        "key": "~type",
+                                                                        "matcher": "eq",
+                                                                        "values": [
+                                                                            "com.adobe.eventType.places"
+                                                                        ]
+                                                                    },
+                                                                    "type": "matcher"
+                                                                },
+                                                                {
+                                                                    "definition": {
+                                                                        "key": "~source",
+                                                                        "matcher": "eq",
+                                                                        "values": [
+                                                                            "com.adobe.eventSource.requestContent"
+                                                                        ]
+                                                                    },
+                                                                    "type": "matcher"
+                                                                },
+                                                                {
+                                                                    "definition": {
+                                                                        "key": "regionEventType",
+                                                                        "matcher": "eq",
+                                                                        "values": [
+                                                                            "entered"
+                                                                        ]
+                                                                    },
+                                                                    "type": "matcher"
+                                                                }
+                                                            ]
+                                                        }
+                                                    },
+                                                    {
+                                                        "type": "historical",
+                                                        "definition": {
+                                                            "searchType": "mostRecent",
+                                                            "value": 1,
+                                                            "matcher": "ne",
+                                                            "events": [
+                                                                {
+                                                                    "iam.eventType": "unqualify",
+                                                                    "iam.id": "a43122c4-bf19-499f-b507-087a028d1769#fa035681-15ce-488e-859e-200bb2ca90ac"
+                                                                },
+                                                                {
+                                                                    "iam.eventType": "qualify",
+                                                                    "iam.id": "a43122c4-bf19-499f-b507-087a028d1769#fa035681-15ce-488e-859e-200bb2ca90ac"
+                                                                }
+                                                            ]
+                                                        }
+                                                    }
+                                                ]
+                                            }
+                                        },
+                                        "consequences": [
+                                            {
+                                                "id": "48181acd-22b3-edae-bc8a-447868a7df7c",
+                                                "type": "schema",
+                                                "detail": {
+                                                    "id": "48181acd-22b3-edae-bc8a-447868a7df7c",
+                                                    "schema": "https://ns.adobe.com/personalization/eventHistoryOperation",
+                                                    "data": {
+                                                        "operation": "insert",
+                                                        "content": {
+                                                            "iam.eventType": "qualify",
+                                                            "iam.id": "a43122c4-bf19-499f-b507-087a028d1769#fa035681-15ce-488e-859e-200bb2ca90ac"
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "condition": {
+                                            "type": "group",
+                                            "definition": {
+                                                "logic": "and",
+                                                "conditions": [
+                                                    {
+                                                        "type": "historical",
+                                                        "definition": {
+                                                            "value": 0,
+                                                            "matcher": "eq",
+                                                            "events": [
+                                                                {
+                                                                    "iam.eventType": "disqualify",
+                                                                    "iam.id": "a43122c4-bf19-499f-b507-087a028d1769#fa035681-15ce-488e-859e-200bb2ca90ac"
+                                                                }
+                                                            ]
+                                                        }
+                                                    },
+                                                    {
+                                                        "type": "group",
+                                                        "definition": {
+                                                            "logic": "and",
+                                                            "conditions": [
+                                                                {
+                                                                    "definition": {
+                                                                        "key": "~type",
+                                                                        "matcher": "eq",
+                                                                        "values": [
+                                                                            "com.adobe.eventType.places"
+                                                                        ]
+                                                                    },
+                                                                    "type": "matcher"
+                                                                },
+                                                                {
+                                                                    "definition": {
+                                                                        "key": "~source",
+                                                                        "matcher": "eq",
+                                                                        "values": [
+                                                                            "com.adobe.eventSource.requestContent"
+                                                                        ]
+                                                                    },
+                                                                    "type": "matcher"
+                                                                },
+                                                                {
+                                                                    "definition": {
+                                                                        "key": "regionEventType",
+                                                                        "matcher": "eq",
+                                                                        "values": [
+                                                                            "exited"
+                                                                        ]
+                                                                    },
+                                                                    "type": "matcher"
+                                                                }
+                                                            ]
+                                                        }
+                                                    },
+                                                    {
+                                                        "type": "historical",
+                                                        "definition": {
+                                                            "searchType": "mostRecent",
+                                                            "value": 0,
+                                                            "matcher": "ne",
+                                                            "events": [
+                                                                {
+                                                                    "iam.eventType": "unqualify",
+                                                                    "iam.id": "a43122c4-bf19-499f-b507-087a028d1769#fa035681-15ce-488e-859e-200bb2ca90ac"
+                                                                },
+                                                                {
+                                                                    "iam.eventType": "qualify",
+                                                                    "iam.id": "a43122c4-bf19-499f-b507-087a028d1769#fa035681-15ce-488e-859e-200bb2ca90ac"
+                                                                }
+                                                            ]
+                                                        }
+                                                    }
+                                                ]
+                                            }
+                                        },
+                                        "consequences": [
+                                            {
+                                                "id": "48181acd-22b3-edae-bc8a-447868a7df7c",
+                                                "type": "schema",
+                                                "detail": {
+                                                    "id": "48181acd-22b3-edae-bc8a-447868a7df7c",
+                                                    "schema": "https://ns.adobe.com/personalization/eventHistoryOperation",
+                                                    "data": {
+                                                        "operation": "insert",
+                                                        "content": {
+                                                            "iam.eventType": "unqualify",
+                                                            "iam.id": "a43122c4-bf19-499f-b507-087a028d1769#fa035681-15ce-488e-859e-200bb2ca90ac"
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "condition": {
+                                            "type": "group",
+                                            "definition": {
+                                                "logic": "and",
+                                                "conditions": [
+                                                    {
+                                                        "type": "group",
+                                                        "definition": {
+                                                            "logic": "and",
+                                                            "conditions": [
+                                                                {
+                                                                    "definition": {
+                                                                        "key": "~type",
+                                                                        "matcher": "eq",
+                                                                        "values": [
+                                                                            "com.adobe.eventType.edge"
+                                                                        ]
+                                                                    },
+                                                                    "type": "matcher"
+                                                                },
+                                                                {
+                                                                    "definition": {
+                                                                        "key": "~source",
+                                                                        "matcher": "eq",
+                                                                        "values": [
+                                                                            "com.adobe.eventSource.requestContent"
+                                                                        ]
+                                                                    },
+                                                                    "type": "matcher"
+                                                                },
+                                                                {
+                                                                    "definition": {
+                                                                        "key": "xdm.eventType",
+                                                                        "matcher": "eq",
+                                                                        "values": [
+                                                                            "decisioning.propositionDismiss"
+                                                                        ]
+                                                                    },
+                                                                    "type": "matcher"
+                                                                },
+                                                                {
+                                                                    "definition": {
+                                                                        "key": "xdm._experience.decisioning.propositions.0.scopeDetails.activity.id",
+                                                                        "matcher": "eq",
+                                                                        "values": [
+                                                                            "a43122c4-bf19-499f-b507-087a028d1769#fa035681-15ce-488e-859e-200bb2ca90ac"
+                                                                        ]
+                                                                    },
+                                                                    "type": "matcher"
+                                                                }
+                                                            ]
+                                                        }
+                                                    },
+                                                    {
+                                                        "type": "matcher",
+                                                        "definition": {
+                                                            "key": "~timestampu",
+                                                            "matcher": "lt",
+                                                            "values": [
+                                                                2019715200
+                                                            ]
+                                                        }
+                                                    }
+                                                ]
+                                            }
+                                        },
+                                        "consequences": [
+                                            {
+                                                "id": "48181acd-22b3-edae-bc8a-447868a7df7c",
+                                                "type": "schema",
+                                                "detail": {
+                                                    "id": "48181acd-22b3-edae-bc8a-447868a7df7c",
+                                                    "schema": "https://ns.adobe.com/personalization/eventHistoryOperation",
+                                                    "data": {
+                                                        "operation": "insertIfNotExists",
+                                                        "content": {
+                                                            "iam.eventType": "disqualify",
+                                                            "iam.id": "a43122c4-bf19-499f-b507-087a028d1769#fa035681-15ce-488e-859e-200bb2ca90ac"
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "id": "c2aa4a73-a534-44c2-baa4-a12980e5bb9f",
+                    "scope": "mobileapp://com.adobe.marketing.mobile.messaging.test/promos/feed1",
+                    "scopeDetails": {
+                        "decisionProvider": "AJO",
+                        "correlationID": "b5095046-7fd7-4961-871f-9d68f2dc335f",
+                        "characteristics": {
+                            "eventToken": "eyJtZXNzYWdlRXhlY3V0aW9uIjp7Im1lc3NhZ2VFeGVjdXRpb25JRCI6Ik5BIiwibWVzc2FnZUlEIjoiYjUwOTUwNDYtN2ZkNy00OTYxLTg3MWYtOWQ2OGYyZGMzMzVmIiwibWVzc2FnZVB1YmxpY2F0aW9uSUQiOiJiNzFlNDhiYS1mNzY3LTQ5NWItOWQxMS01YzA3MTg4NWNkODkiLCJtZXNzYWdlVHlwZSI6Im1hcmtldGluZyIsImNhbXBhaWduSUQiOiI5YzhlYzAzNS02YjNiLTQ3MGUtOGFlNS1lNTM5YzcxMjM4MDkiLCJjYW1wYWlnblZlcnNpb25JRCI6IjdkZGEyZGM2LTE5MjMtNGU2My1iZWFjLTU0ZGM3ODczNjFlYiIsImNhbXBhaWduQWN0aW9uSUQiOiJjN2MxNDk3ZS1lNWEzLTQ0MjMtYWUzNy1iYTc2ZTFlNDQzNDIifSwibWVzc2FnZVByb2ZpbGUiOnsibWVzc2FnZVByb2ZpbGVJRCI6IjQ0YWQ1NTA3LTZlODItNGY2MS05N2U1LTUzMmNhNmZkMDhhOCIsImNoYW5uZWwiOnsiX2lkIjoiaHR0cHM6Ly9ucy5hZG9iZS5jb20veGRtL2NoYW5uZWxzL3dlYiIsIl90eXBlIjoiaHR0cHM6Ly9ucy5hZG9iZS5jb20veGRtL2NoYW5uZWwtdHlwZXMvd2ViIn19fQ=="
+                        },
+                        "activity": {
+                            "id": "a43122c4-bf19-499f-b507-087a028d1769#fa035681-15ce-488e-859e-200bb2ca90af"
+                        }
+                    },
+                    "items": [
+                        {
+                            "id": "9d6eff2c-39a7-4aa1-9657-d642e26c517f",
+                            "schema": "https://ns.adobe.com/personalization/ruleset-item",
+                            "data": {
+                                "version": 1,
+                                "rules": [
+                                    {
+                                        "condition": {
+                                            "type": "group",
+                                            "definition": {
+                                                "logic": "and",
+                                                "conditions": [
+                                                    {
+                                                        "type": "historical",
+                                                        "definition": {
+                                                            "value": 0,
+                                                            "matcher": "eq",
+                                                            "events": [
+                                                                {
+                                                                    "iam.eventType": "disqualify",
+                                                                    "iam.id": "a43122c4-bf19-499f-b507-087a028d1769#fa035681-15ce-488e-859e-200bb2ca90af"
+                                                                }
+                                                            ]
+                                                        }
+                                                    },
+                                                    {
+                                                        "type": "matcher",
+                                                        "definition": {
+                                                            "key": "~timestampu",
+                                                            "matcher": "lt",
+                                                            "values": [
+                                                                2019715200
+                                                            ]
+                                                        }
+                                                    },
+                                                    {
+                                                        "type": "group",
+                                                        "definition": {
+                                                            "logic": "or",
+                                                            "conditions": [
+                                                                {
+                                                                    "type": "group",
+                                                                    "definition": {
+                                                                        "logic": "and",
+                                                                        "conditions": [
+                                                                            {
+                                                                                "definition": {
+                                                                                    "key": "~type",
+                                                                                    "matcher": "eq",
+                                                                                    "values": [
+                                                                                        "com.adobe.eventType.places"
+                                                                                    ]
+                                                                                },
+                                                                                "type": "matcher"
+                                                                            },
+                                                                            {
+                                                                                "definition": {
+                                                                                    "key": "~source",
+                                                                                    "matcher": "eq",
+                                                                                    "values": [
+                                                                                        "com.adobe.eventSource.requestContent"
+                                                                                    ]
+                                                                                },
+                                                                                "type": "matcher"
+                                                                            },
+                                                                            {
+                                                                                "definition": {
+                                                                                    "key": "regionEventType",
+                                                                                    "matcher": "eq",
+                                                                                    "values": [
+                                                                                        "entered"
+                                                                                    ]
+                                                                                },
+                                                                                "type": "matcher"
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                },
+                                                                {
+                                                                    "type": "historical",
+                                                                    "definition": {
+                                                                        "searchType": "mostRecent",
+                                                                        "value": 1,
+                                                                        "matcher": "ge",
+                                                                        "events": [
+                                                                            {
+                                                                                "iam.eventType": "unqualify",
+                                                                                "iam.id": "a43122c4-bf19-499f-b507-087a028d1769#fa035681-15ce-488e-859e-200bb2ca90af"
+                                                                            },
+                                                                            {
+                                                                                "iam.eventType": "trigger",
+                                                                                "iam.id": "a43122c4-bf19-499f-b507-087a028d1769#fa035681-15ce-488e-859e-200bb2ca90af"
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                },
+                                                                {
+                                                                    "type": "historical",
+                                                                    "definition": {
+                                                                        "searchType": "mostRecent",
+                                                                        "value": 1,
+                                                                        "matcher": "eq",
+                                                                        "events": [
+                                                                            {
+                                                                                "iam.eventType": "unqualify",
+                                                                                "iam.id": "a43122c4-bf19-499f-b507-087a028d1769#fa035681-15ce-488e-859e-200bb2ca90af"
+                                                                            },
+                                                                            {
+                                                                                "iam.eventType": "qualify",
+                                                                                "iam.id": "a43122c4-bf19-499f-b507-087a028d1769#fa035681-15ce-488e-859e-200bb2ca90af"
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                }
+                                                            ]
+                                                        }
+                                                    }
+                                                ]
+                                            }
+                                        },
+                                        "consequences": [
+                                            {
+                                                "id": "183639c4-cb37-458e-a8ef-4e130d767ebg",
+                                                "type": "schema",
+                                                "detail": {
+                                                    "id": "183639c4-cb37-458e-a8ef-4e130d767ebg",
+                                                    "schema": "https://ns.adobe.com/personalization/message/content-card",
+                                                    "data": {
+                                                        "expiryDate": 1723163897,
+                                                        "meta": {
+                                                            "feedName": "testFeed",
+                                                            "campaignName": "testCampaign",
+                                                            "surface": "mobileapp://com.adobe.marketing.mobile.messaging.test/promos/feed1"
+                                                        },
+                                                        "content": {
+                                                            "title": "Guacamole!",
+                                                            "body": "I'm the queen of Nacho Picchu and I'm really glad to meet you. To spice up this big tortilla chip, I command you to find a big dip.",
+                                                            "imageUrl": "https://d14dq8eoa1si34.cloudfront.net/2a6ef2f0-1167-11eb-88c6-b512a5ef09a7/urn:aaid:aem:d4b77a01-610a-4c3f-9be6-5ebe1bd13da3/oak:1.0::ci:fa54b394b6f987d974d8619833083519/8933c829-3ab2-38e8-a1ee-00d4f562fff8",
+                                                            "actionUrl": "https://luma.com/guacamolethemusical",
+                                                            "actionTitle": "guacamole!"
+                                                        },
+                                                        "contentType": "application/json",
+                                                        "publishedDate": 1691541497
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "condition": {
+                                            "type": "group",
+                                            "definition": {
+                                                "logic": "and",
+                                                "conditions": [
+                                                    {
+                                                        "type": "historical",
+                                                        "definition": {
+                                                            "value": 0,
+                                                            "matcher": "eq",
+                                                            "events": [
+                                                                {
+                                                                    "iam.eventType": "disqualify",
+                                                                    "iam.id": "a43122c4-bf19-499f-b507-087a028d1769#fa035681-15ce-488e-859e-200bb2ca90af"
+                                                                }
+                                                            ]
+                                                        }
+                                                    },
+                                                    {
+                                                        "type": "matcher",
+                                                        "definition": {
+                                                            "key": "~timestampu",
+                                                            "matcher": "lt",
+                                                            "values": [
+                                                                2019715200
+                                                            ]
+                                                        }
+                                                    },
+                                                    {
+                                                        "type": "group",
+                                                        "definition": {
+                                                            "logic": "and",
+                                                            "conditions": [
+                                                                {
+                                                                    "definition": {
+                                                                        "key": "~type",
+                                                                        "matcher": "eq",
+                                                                        "values": [
+                                                                            "com.adobe.eventType.places"
+                                                                        ]
+                                                                    },
+                                                                    "type": "matcher"
+                                                                },
+                                                                {
+                                                                    "definition": {
+                                                                        "key": "~source",
+                                                                        "matcher": "eq",
+                                                                        "values": [
+                                                                            "com.adobe.eventSource.requestContent"
+                                                                        ]
+                                                                    },
+                                                                    "type": "matcher"
+                                                                },
+                                                                {
+                                                                    "definition": {
+                                                                        "key": "regionEventType",
+                                                                        "matcher": "eq",
+                                                                        "values": [
+                                                                            "entered"
+                                                                        ]
+                                                                    },
+                                                                    "type": "matcher"
+                                                                }
+                                                            ]
+                                                        }
+                                                    },
+                                                    {
+                                                        "type": "historical",
+                                                        "definition": {
+                                                            "searchType": "mostRecent",
+                                                            "value": 1,
+                                                            "matcher": "ne",
+                                                            "events": [
+                                                                {
+                                                                    "iam.eventType": "unqualify",
+                                                                    "iam.id": "a43122c4-bf19-499f-b507-087a028d1769#fa035681-15ce-488e-859e-200bb2ca90af"
+                                                                },
+                                                                {
+                                                                    "iam.eventType": "qualify",
+                                                                    "iam.id": "a43122c4-bf19-499f-b507-087a028d1769#fa035681-15ce-488e-859e-200bb2ca90af"
+                                                                }
+                                                            ]
+                                                        }
+                                                    }
+                                                ]
+                                            }
+                                        },
+                                        "consequences": [
+                                            {
+                                                "id": "48181acd-22b3-edae-bc8a-447868a7df7f",
+                                                "type": "schema",
+                                                "detail": {
+                                                    "id": "48181acd-22b3-edae-bc8a-447868a7df7f",
+                                                    "schema": "https://ns.adobe.com/personalization/eventHistoryOperation",
+                                                    "data": {
+                                                        "operation": "insert",
+                                                        "content": {
+                                                            "iam.eventType": "qualify",
+                                                            "iam.id": "a43122c4-bf19-499f-b507-087a028d1769#fa035681-15ce-488e-859e-200bb2ca90af"
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "condition": {
+                                            "type": "group",
+                                            "definition": {
+                                                "logic": "and",
+                                                "conditions": [
+                                                    {
+                                                        "type": "historical",
+                                                        "definition": {
+                                                            "value": 0,
+                                                            "matcher": "eq",
+                                                            "events": [
+                                                                {
+                                                                    "iam.eventType": "disqualify",
+                                                                    "iam.id": "a43122c4-bf19-499f-b507-087a028d1769#fa035681-15ce-488e-859e-200bb2ca90af"
+                                                                }
+                                                            ]
+                                                        }
+                                                    },
+                                                    {
+                                                        "type": "group",
+                                                        "definition": {
+                                                            "logic": "and",
+                                                            "conditions": [
+                                                                {
+                                                                    "definition": {
+                                                                        "key": "~type",
+                                                                        "matcher": "eq",
+                                                                        "values": [
+                                                                            "com.adobe.eventType.places"
+                                                                        ]
+                                                                    },
+                                                                    "type": "matcher"
+                                                                },
+                                                                {
+                                                                    "definition": {
+                                                                        "key": "~source",
+                                                                        "matcher": "eq",
+                                                                        "values": [
+                                                                            "com.adobe.eventSource.requestContent"
+                                                                        ]
+                                                                    },
+                                                                    "type": "matcher"
+                                                                },
+                                                                {
+                                                                    "definition": {
+                                                                        "key": "regionEventType",
+                                                                        "matcher": "eq",
+                                                                        "values": [
+                                                                            "exited"
+                                                                        ]
+                                                                    },
+                                                                    "type": "matcher"
+                                                                }
+                                                            ]
+                                                        }
+                                                    },
+                                                    {
+                                                        "type": "historical",
+                                                        "definition": {
+                                                            "searchType": "mostRecent",
+                                                            "value": 0,
+                                                            "matcher": "ne",
+                                                            "events": [
+                                                                {
+                                                                    "iam.eventType": "unqualify",
+                                                                    "iam.id": "a43122c4-bf19-499f-b507-087a028d1769#fa035681-15ce-488e-859e-200bb2ca90af"
+                                                                },
+                                                                {
+                                                                    "iam.eventType": "qualify",
+                                                                    "iam.id": "a43122c4-bf19-499f-b507-087a028d1769#fa035681-15ce-488e-859e-200bb2ca90af"
+                                                                }
+                                                            ]
+                                                        }
+                                                    }
+                                                ]
+                                            }
+                                        },
+                                        "consequences": [
+                                            {
+                                                "id": "48181acd-22b3-edae-bc8a-447868a7df7f",
+                                                "type": "schema",
+                                                "detail": {
+                                                    "id": "48181acd-22b3-edae-bc8a-447868a7df7f",
+                                                    "schema": "https://ns.adobe.com/personalization/eventHistoryOperation",
+                                                    "data": {
+                                                        "operation": "insert",
+                                                        "content": {
+                                                            "iam.eventType": "unqualify",
+                                                            "iam.id": "a43122c4-bf19-499f-b507-087a028d1769#fa035681-15ce-488e-859e-200bb2ca90af"
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "condition": {
+                                            "type": "group",
+                                            "definition": {
+                                                "logic": "and",
+                                                "conditions": [
+                                                    {
+                                                        "type": "group",
+                                                        "definition": {
+                                                            "logic": "and",
+                                                            "conditions": [
+                                                                {
+                                                                    "definition": {
+                                                                        "key": "~type",
+                                                                        "matcher": "eq",
+                                                                        "values": [
+                                                                            "com.adobe.eventType.edge"
+                                                                        ]
+                                                                    },
+                                                                    "type": "matcher"
+                                                                },
+                                                                {
+                                                                    "definition": {
+                                                                        "key": "~source",
+                                                                        "matcher": "eq",
+                                                                        "values": [
+                                                                            "com.adobe.eventSource.requestContent"
+                                                                        ]
+                                                                    },
+                                                                    "type": "matcher"
+                                                                },
+                                                                {
+                                                                    "definition": {
+                                                                        "key": "xdm.eventType",
+                                                                        "matcher": "eq",
+                                                                        "values": [
+                                                                            "decisioning.propositionDismiss"
+                                                                        ]
+                                                                    },
+                                                                    "type": "matcher"
+                                                                },
+                                                                {
+                                                                    "definition": {
+                                                                        "key": "xdm._experience.decisioning.propositions.0.scopeDetails.activity.id",
+                                                                        "matcher": "eq",
+                                                                        "values": [
+                                                                            "a43122c4-bf19-499f-b507-087a028d1769#fa035681-15ce-488e-859e-200bb2ca90af"
+                                                                        ]
+                                                                    },
+                                                                    "type": "matcher"
+                                                                }
+                                                            ]
+                                                        }
+                                                    },
+                                                    {
+                                                        "type": "matcher",
+                                                        "definition": {
+                                                            "key": "~timestampu",
+                                                            "matcher": "lt",
+                                                            "values": [
+                                                                2019715200
+                                                            ]
+                                                        }
+                                                    }
+                                                ]
+                                            }
+                                        },
+                                        "consequences": [
+                                            {
+                                                "id": "48181acd-22b3-edae-bc8a-447868a7df7f",
+                                                "type": "schema",
+                                                "detail": {
+                                                    "id": "48181acd-22b3-edae-bc8a-447868a7df7f",
+                                                    "schema": "https://ns.adobe.com/personalization/eventHistoryOperation",
+                                                    "data": {
+                                                        "operation": "insertIfNotExists",
+                                                        "content": {
+                                                            "iam.eventType": "disqualify",
+                                                            "iam.id": "a43122c4-bf19-499f-b507-087a028d1769#fa035681-15ce-488e-859e-200bb2ca90af"
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                },
+                {
+                    "id": "c2aa4a73-a534-44c2-baa4-a12980e5bb9e",
+                    "scope": "mobileapp://com.adobe.marketing.mobile.messaging.test/promos/feed2",
+                    "scopeDetails": {
+                        "decisionProvider": "AJO",
+                        "correlationID": "b5095046-7fd7-4961-871f-9d68f2dc335e",
+                        "characteristics": {
+                            "eventToken": "eyJtZXNzYWdlRXhlY3V0aW9uIjp7Im1lc3NhZ2VFeGVjdXRpb25JRCI6Ik5BIiwibWVzc2FnZUlEIjoiYjUwOTUwNDYtN2ZkNy00OTYxLTg3MWYtOWQ2OGYyZGMzMzVmIiwibWVzc2FnZVB1YmxpY2F0aW9uSUQiOiJiNzFlNDhiYS1mNzY3LTQ5NWItOWQxMS01YzA3MTg4NWNkODkiLCJtZXNzYWdlVHlwZSI6Im1hcmtldGluZyIsImNhbXBhaWduSUQiOiI5YzhlYzAzNS02YjNiLTQ3MGUtOGFlNS1lNTM5YzcxMjM4MDkiLCJjYW1wYWlnblZlcnNpb25JRCI6IjdkZGEyZGM2LTE5MjMtNGU2My1iZWFjLTU0ZGM3ODczNjFlYiIsImNhbXBhaWduQWN0aW9uSUQiOiJjN2MxNDk3ZS1lNWEzLTQ0MjMtYWUzNy1iYTc2ZTFlNDQzNDIifSwibWVzc2FnZVByb2ZpbGUiOnsibWVzc2FnZVByb2ZpbGVJRCI6IjQ0YWQ1NTA3LTZlODItNGY2MS05N2U1LTUzMmNhNmZkMDhhOCIsImNoYW5uZWwiOnsiX2lkIjoiaHR0cHM6Ly9ucy5hZG9iZS5jb20veGRtL2NoYW5uZWxzL3dlYiIsIl90eXBlIjoiaHR0cHM6Ly9ucy5hZG9iZS5jb20veGRtL2NoYW5uZWwtdHlwZXMvd2ViIn19fQ=="
+                        },
+                        "activity": {
+                            "id": "a43122c4-bf19-499f-b507-087a028d1769#fa035681-15ce-488e-859e-200bb2ca90ae"
+                        }
+                    },
+                    "items": [
+                        {
+                            "id": "9d6eff2c-39a7-4aa1-9657-d642e26c517e",
+                            "schema": "https://ns.adobe.com/personalization/ruleset-item",
+                            "data": {
+                                "version": 1,
+                                "rules": [
+                                    {
+                                        "condition": {
+                                            "type": "group",
+                                            "definition": {
+                                                "logic": "and",
+                                                "conditions": [
+                                                    {
+                                                        "type": "historical",
+                                                        "definition": {
+                                                            "value": 0,
+                                                            "matcher": "eq",
+                                                            "events": [
+                                                                {
+                                                                    "iam.eventType": "disqualify",
+                                                                    "iam.id": "a43122c4-bf19-499f-b507-087a028d1769#fa035681-15ce-488e-859e-200bb2ca90ae"
+                                                                }
+                                                            ]
+                                                        }
+                                                    },
+                                                    {
+                                                        "type": "matcher",
+                                                        "definition": {
+                                                            "key": "~timestampu",
+                                                            "matcher": "lt",
+                                                            "values": [
+                                                                2019715200
+                                                            ]
+                                                        }
+                                                    },
+                                                    {
+                                                        "type": "group",
+                                                        "definition": {
+                                                            "logic": "or",
+                                                            "conditions": [
+                                                                {
+                                                                    "type": "group",
+                                                                    "definition": {
+                                                                        "logic": "and",
+                                                                        "conditions": [
+                                                                            {
+                                                                                "definition": {
+                                                                                    "key": "~type",
+                                                                                    "matcher": "eq",
+                                                                                    "values": [
+                                                                                        "com.adobe.eventType.places"
+                                                                                    ]
+                                                                                },
+                                                                                "type": "matcher"
+                                                                            },
+                                                                            {
+                                                                                "definition": {
+                                                                                    "key": "~source",
+                                                                                    "matcher": "eq",
+                                                                                    "values": [
+                                                                                        "com.adobe.eventSource.requestContent"
+                                                                                    ]
+                                                                                },
+                                                                                "type": "matcher"
+                                                                            },
+                                                                            {
+                                                                                "definition": {
+                                                                                    "key": "regionEventType",
+                                                                                    "matcher": "eq",
+                                                                                    "values": [
+                                                                                        "entered"
+                                                                                    ]
+                                                                                },
+                                                                                "type": "matcher"
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                },
+                                                                {
+                                                                    "type": "historical",
+                                                                    "definition": {
+                                                                        "searchType": "mostRecent",
+                                                                        "value": 1,
+                                                                        "matcher": "ge",
+                                                                        "events": [
+                                                                            {
+                                                                                "iam.eventType": "unqualify",
+                                                                                "iam.id": "a43122c4-bf19-499f-b507-087a028d1769#fa035681-15ce-488e-859e-200bb2ca90ae"
+                                                                            },
+                                                                            {
+                                                                                "iam.eventType": "trigger",
+                                                                                "iam.id": "a43122c4-bf19-499f-b507-087a028d1769#fa035681-15ce-488e-859e-200bb2ca90ae"
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                },
+                                                                {
+                                                                    "type": "historical",
+                                                                    "definition": {
+                                                                        "searchType": "mostRecent",
+                                                                        "value": 1,
+                                                                        "matcher": "eq",
+                                                                        "events": [
+                                                                            {
+                                                                                "iam.eventType": "unqualify",
+                                                                                "iam.id": "a43122c4-bf19-499f-b507-087a028d1769#fa035681-15ce-488e-859e-200bb2ca90ae"
+                                                                            },
+                                                                            {
+                                                                                "iam.eventType": "qualify",
+                                                                                "iam.id": "a43122c4-bf19-499f-b507-087a028d1769#fa035681-15ce-488e-859e-200bb2ca90ae"
+                                                                            }
+                                                                        ]
+                                                                    }
+                                                                }
+                                                            ]
+                                                        }
+                                                    }
+                                                ]
+                                            }
+                                        },
+                                        "consequences": [
+                                            {
+                                                "id": "183639c4-cb37-458e-a8ef-4e130d767ebe",
+                                                "type": "schema",
+                                                "detail": {
+                                                    "id": "183639c4-cb37-458e-a8ef-4e130d767ebe",
+                                                    "schema": "https://ns.adobe.com/personalization/message/content-card",
+                                                    "data": {
+                                                        "expiryDate": 1723163897,
+                                                        "meta": {
+                                                            "feedName": "testFeed",
+                                                            "campaignName": "testCampaign",
+                                                            "surface": "mobileapp://com.adobe.marketing.mobile.messaging.test/promos/feed2"
+                                                        },
+                                                        "content": {
+                                                            "title": "Guacamole!",
+                                                            "body": "I'm the queen of Nacho Picchu and I'm really glad to meet you. To spice up this big tortilla chip, I command you to find a big dip.",
+                                                            "imageUrl": "https://d14dq8eoa1si34.cloudfront.net/2a6ef2f0-1167-11eb-88c6-b512a5ef09a7/urn:aaid:aem:d4b77a01-610a-4c3f-9be6-5ebe1bd13da3/oak:1.0::ci:fa54b394b6f987d974d8619833083519/8933c829-3ab2-38e8-a1ee-00d4f562fff8",
+                                                            "actionUrl": "https://luma.com/guacamolethemusical",
+                                                            "actionTitle": "guacamole!"
+                                                        },
+                                                        "contentType": "application/json",
+                                                        "publishedDate": 1691541497
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "condition": {
+                                            "type": "group",
+                                            "definition": {
+                                                "logic": "and",
+                                                "conditions": [
+                                                    {
+                                                        "type": "historical",
+                                                        "definition": {
+                                                            "value": 0,
+                                                            "matcher": "eq",
+                                                            "events": [
+                                                                {
+                                                                    "iam.eventType": "disqualify",
+                                                                    "iam.id": "a43122c4-bf19-499f-b507-087a028d1769#fa035681-15ce-488e-859e-200bb2ca90aee"
+                                                                }
+                                                            ]
+                                                        }
+                                                    },
+                                                    {
+                                                        "type": "matcher",
+                                                        "definition": {
+                                                            "key": "~timestampu",
+                                                            "matcher": "lt",
+                                                            "values": [
+                                                                2019715200
+                                                            ]
+                                                        }
+                                                    },
+                                                    {
+                                                        "type": "group",
+                                                        "definition": {
+                                                            "logic": "and",
+                                                            "conditions": [
+                                                                {
+                                                                    "definition": {
+                                                                        "key": "~type",
+                                                                        "matcher": "eq",
+                                                                        "values": [
+                                                                            "com.adobe.eventType.places"
+                                                                        ]
+                                                                    },
+                                                                    "type": "matcher"
+                                                                },
+                                                                {
+                                                                    "definition": {
+                                                                        "key": "~source",
+                                                                        "matcher": "eq",
+                                                                        "values": [
+                                                                            "com.adobe.eventSource.requestContent"
+                                                                        ]
+                                                                    },
+                                                                    "type": "matcher"
+                                                                },
+                                                                {
+                                                                    "definition": {
+                                                                        "key": "regionEventType",
+                                                                        "matcher": "eq",
+                                                                        "values": [
+                                                                            "entered"
+                                                                        ]
+                                                                    },
+                                                                    "type": "matcher"
+                                                                }
+                                                            ]
+                                                        }
+                                                    },
+                                                    {
+                                                        "type": "historical",
+                                                        "definition": {
+                                                            "searchType": "mostRecent",
+                                                            "value": 1,
+                                                            "matcher": "ne",
+                                                            "events": [
+                                                                {
+                                                                    "iam.eventType": "unqualify",
+                                                                    "iam.id": "a43122c4-bf19-499f-b507-087a028d1769#fa035681-15ce-488e-859e-200bb2ca90ae"
+                                                                },
+                                                                {
+                                                                    "iam.eventType": "qualify",
+                                                                    "iam.id": "a43122c4-bf19-499f-b507-087a028d1769#fa035681-15ce-488e-859e-200bb2ca90ae"
+                                                                }
+                                                            ]
+                                                        }
+                                                    }
+                                                ]
+                                            }
+                                        },
+                                        "consequences": [
+                                            {
+                                                "id": "48181acd-22b3-edae-bc8a-447868a7df7e",
+                                                "type": "schema",
+                                                "detail": {
+                                                    "id": "48181acd-22b3-edae-bc8a-447868a7df7e",
+                                                    "schema": "https://ns.adobe.com/personalization/eventHistoryOperation",
+                                                    "data": {
+                                                        "operation": "insert",
+                                                        "content": {
+                                                            "iam.eventType": "qualify",
+                                                            "iam.id": "a43122c4-bf19-499f-b507-087a028d1769#fa035681-15ce-488e-859e-200bb2ca90ae"
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "condition": {
+                                            "type": "group",
+                                            "definition": {
+                                                "logic": "and",
+                                                "conditions": [
+                                                    {
+                                                        "type": "historical",
+                                                        "definition": {
+                                                            "value": 0,
+                                                            "matcher": "eq",
+                                                            "events": [
+                                                                {
+                                                                    "iam.eventType": "disqualify",
+                                                                    "iam.id": "a43122c4-bf19-499f-b507-087a028d1769#fa035681-15ce-488e-859e-200bb2ca90ae"
+                                                                }
+                                                            ]
+                                                        }
+                                                    },
+                                                    {
+                                                        "type": "group",
+                                                        "definition": {
+                                                            "logic": "and",
+                                                            "conditions": [
+                                                                {
+                                                                    "definition": {
+                                                                        "key": "~type",
+                                                                        "matcher": "eq",
+                                                                        "values": [
+                                                                            "com.adobe.eventType.places"
+                                                                        ]
+                                                                    },
+                                                                    "type": "matcher"
+                                                                },
+                                                                {
+                                                                    "definition": {
+                                                                        "key": "~source",
+                                                                        "matcher": "eq",
+                                                                        "values": [
+                                                                            "com.adobe.eventSource.requestContent"
+                                                                        ]
+                                                                    },
+                                                                    "type": "matcher"
+                                                                },
+                                                                {
+                                                                    "definition": {
+                                                                        "key": "regionEventType",
+                                                                        "matcher": "eq",
+                                                                        "values": [
+                                                                            "exited"
+                                                                        ]
+                                                                    },
+                                                                    "type": "matcher"
+                                                                }
+                                                            ]
+                                                        }
+                                                    },
+                                                    {
+                                                        "type": "historical",
+                                                        "definition": {
+                                                            "searchType": "mostRecent",
+                                                            "value": 0,
+                                                            "matcher": "ne",
+                                                            "events": [
+                                                                {
+                                                                    "iam.eventType": "unqualify",
+                                                                    "iam.id": "a43122c4-bf19-499f-b507-087a028d1769#fa035681-15ce-488e-859e-200bb2ca90ae"
+                                                                },
+                                                                {
+                                                                    "iam.eventType": "qualify",
+                                                                    "iam.id": "a43122c4-bf19-499f-b507-087a028d1769#fa035681-15ce-488e-859e-200bb2ca90ae"
+                                                                }
+                                                            ]
+                                                        }
+                                                    }
+                                                ]
+                                            }
+                                        },
+                                        "consequences": [
+                                            {
+                                                "id": "48181acd-22b3-edae-bc8a-447868a7df7e",
+                                                "type": "schema",
+                                                "detail": {
+                                                    "id": "48181acd-22b3-edae-bc8a-447868a7df7e",
+                                                    "schema": "https://ns.adobe.com/personalization/eventHistoryOperation",
+                                                    "data": {
+                                                        "operation": "insert",
+                                                        "content": {
+                                                            "iam.eventType": "unqualify",
+                                                            "iam.id": "a43122c4-bf19-499f-b507-087a028d1769#fa035681-15ce-488e-859e-200bb2ca90ae"
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    },
+                                    {
+                                        "condition": {
+                                            "type": "group",
+                                            "definition": {
+                                                "logic": "and",
+                                                "conditions": [
+                                                    {
+                                                        "type": "group",
+                                                        "definition": {
+                                                            "logic": "and",
+                                                            "conditions": [
+                                                                {
+                                                                    "definition": {
+                                                                        "key": "~type",
+                                                                        "matcher": "eq",
+                                                                        "values": [
+                                                                            "com.adobe.eventType.edge"
+                                                                        ]
+                                                                    },
+                                                                    "type": "matcher"
+                                                                },
+                                                                {
+                                                                    "definition": {
+                                                                        "key": "~source",
+                                                                        "matcher": "eq",
+                                                                        "values": [
+                                                                            "com.adobe.eventSource.requestContent"
+                                                                        ]
+                                                                    },
+                                                                    "type": "matcher"
+                                                                },
+                                                                {
+                                                                    "definition": {
+                                                                        "key": "xdm.eventType",
+                                                                        "matcher": "eq",
+                                                                        "values": [
+                                                                            "decisioning.propositionDismiss"
+                                                                        ]
+                                                                    },
+                                                                    "type": "matcher"
+                                                                },
+                                                                {
+                                                                    "definition": {
+                                                                        "key": "xdm._experience.decisioning.propositions.0.scopeDetails.activity.id",
+                                                                        "matcher": "eq",
+                                                                        "values": [
+                                                                            "a43122c4-bf19-499f-b507-087a028d1769#fa035681-15ce-488e-859e-200bb2ca90ae"
+                                                                        ]
+                                                                    },
+                                                                    "type": "matcher"
+                                                                }
+                                                            ]
+                                                        }
+                                                    },
+                                                    {
+                                                        "type": "matcher",
+                                                        "definition": {
+                                                            "key": "~timestampu",
+                                                            "matcher": "lt",
+                                                            "values": [
+                                                                2019715200
+                                                            ]
+                                                        }
+                                                    }
+                                                ]
+                                            }
+                                        },
+                                        "consequences": [
+                                            {
+                                                "id": "48181acd-22b3-edae-bc8a-447868a7df7e",
+                                                "type": "schema",
+                                                "detail": {
+                                                    "id": "48181acd-22b3-edae-bc8a-447868a7df7c",
+                                                    "schema": "https://ns.adobe.com/personalization/eventHistoryOperation",
+                                                    "data": {
+                                                        "operation": "insertIfNotExists",
+                                                        "content": {
+                                                            "iam.eventType": "disqualify",
+                                                            "iam.id": "a43122c4-bf19-499f-b507-087a028d1769#fa035681-15ce-488e-859e-200bb2ca90ae"
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        }
+                    ]
+                }
+            ],
+            "type": "personalization:decisions"
+        }
+    ]
+}

--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/ContentCardMapper.kt
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/ContentCardMapper.kt
@@ -62,6 +62,7 @@ class ContentCardMapper private constructor() {
         contentCardSchemaDataMap.remove(propositionId)
     }
 
+    @JvmName("clear")
     @VisibleForTesting
     internal fun clear() {
         contentCardSchemaDataMap.clear()

--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/EdgePersonalizationResponseHandler.java
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/EdgePersonalizationResponseHandler.java
@@ -822,41 +822,12 @@ class EdgePersonalizationResponseHandler {
                     }
                 }
                 existingPropositionsArray.add(proposition);
-
-                // Store qualified content cards as schema data in the ContentCardMapper for later
-                // use by the UI layer
-                final ContentCardSchemaData propositionAsContentCard =
-                        proposition.getItems().get(0).getContentCardSchemaData();
-                ContentCardMapper.getInstance()
-                        .storeContentCardSchemaData(propositionAsContentCard);
+                storeContentCardInMapper(proposition);
             }
 
             contentCardsBySurface.put(surface, existingPropositionsArray);
-
-            // Send batched trigger events for new proposition items only
-            if (!newPropositionItems.isEmpty()) {
-                sendBatchedPropositionInteraction(
-                        newPropositionItems, null, MessagingEdgeEventType.TRIGGER);
-            }
-
-            int newCount = existingPropositionsArray.size();
-            if (startingCount != newCount) {
-                final Locale locale =
-                        ServiceProvider.getInstance().getDeviceInfoService().getActiveLocale();
-                String message =
-                        newCount > 0
-                                ? String.format(
-                                        locale,
-                                        "User has qualified for %d content card(s) for surface %s",
-                                        newCount,
-                                        surface.getUri())
-                                : String.format(
-                                        locale,
-                                        "User has not qualified for any content card(s) for surface"
-                                                + " %s",
-                                        surface.getUri());
-                Log.trace(MessagingConstants.LOG_TAG, SELF_TAG, message);
-            }
+            sendTriggersForNewPropositions(newPropositionItems);
+            logContentCardCountChange(surface, startingCount, existingPropositionsArray.size());
         }
     }
 
@@ -894,7 +865,7 @@ class EdgePersonalizationResponseHandler {
                 if (evictedPropositions != null) {
                     for (final Proposition proposition : evictedPropositions) {
                         ContentCardMapper.getInstance()
-                                .removeContentCardSchemaData(proposition.getUniqueId());
+                                .removeContentCardSchemaData(proposition.getActivityId());
                     }
                 }
             }
@@ -925,49 +896,74 @@ class EdgePersonalizationResponseHandler {
                     }
                 }
                 newPropositionsArray.add(proposition);
-
-                // Store qualified content cards as schema data in the ContentCardMapper for later
-                // use by the UI layer
-                final ContentCardSchemaData propositionAsContentCard =
-                        proposition.getItems().get(0).getContentCardSchemaData();
-                ContentCardMapper.getInstance()
-                        .storeContentCardSchemaData(propositionAsContentCard);
+                storeContentCardInMapper(proposition);
             }
 
             // Remove ContentCardMapper entries for old propositions no longer in the fresh response
             for (final Proposition oldProposition : existingPropositionsArray) {
                 if (!newPropositionsArray.contains(oldProposition)) {
                     ContentCardMapper.getInstance()
-                            .removeContentCardSchemaData(oldProposition.getUniqueId());
+                            .removeContentCardSchemaData(oldProposition.getActivityId());
                 }
             }
-            // Replace the cached list entirely with the fresh response data
+
             contentCardsBySurface.put(surface, newPropositionsArray);
+            sendTriggersForNewPropositions(newPropositionItems);
+            logContentCardCountChange(surface, startingCount, newPropositionsArray.size());
+        }
+    }
 
-            // Send batched trigger events for new proposition items only
-            if (!newPropositionItems.isEmpty()) {
-                sendBatchedPropositionInteraction(
-                        newPropositionItems, null, MessagingEdgeEventType.TRIGGER);
-            }
+    /**
+     * Stores the first {@link PropositionItem}'s {@link ContentCardSchemaData} in the {@link
+     * ContentCardMapper} for later use by the UI layer. No-op if the proposition has no items.
+     *
+     * @param proposition the {@link Proposition} whose first item should be stored.
+     */
+    private void storeContentCardInMapper(final Proposition proposition) {
+        final List<PropositionItem> items = proposition.getItems();
+        if (!items.isEmpty()) {
+            final ContentCardSchemaData schemaData = items.get(0).getContentCardSchemaData();
+            ContentCardMapper.getInstance().storeContentCardSchemaData(schemaData);
+        }
+    }
 
-            int newCount = newPropositionsArray.size();
-            if (startingCount != newCount) {
-                final Locale locale =
-                        ServiceProvider.getInstance().getDeviceInfoService().getActiveLocale();
-                String message =
-                        newCount > 0
-                                ? String.format(
-                                        locale,
-                                        "User has qualified for %d content card(s) for surface %s",
-                                        newCount,
-                                        surface.getUri())
-                                : String.format(
-                                        locale,
-                                        "User has not qualified for any content card(s) for surface"
-                                                + " %s",
-                                        surface.getUri());
-                Log.trace(MessagingConstants.LOG_TAG, SELF_TAG, message);
-            }
+    /**
+     * Sends batched {@code TRIGGER} events for the given proposition items. No-op if the list is
+     * empty.
+     *
+     * @param newPropositionItems {@link List} of newly qualified {@link PropositionItem}s.
+     */
+    private void sendTriggersForNewPropositions(final List<PropositionItem> newPropositionItems) {
+        if (!newPropositionItems.isEmpty()) {
+            sendBatchedPropositionInteraction(
+                    newPropositionItems, null, MessagingEdgeEventType.TRIGGER);
+        }
+    }
+
+    /**
+     * Logs a trace message when the number of qualified content cards for a surface changes.
+     *
+     * @param surface the {@link Surface} whose count changed.
+     * @param oldCount the previous number of qualified propositions.
+     * @param newCount the current number of qualified propositions.
+     */
+    private void logContentCardCountChange(
+            final Surface surface, final int oldCount, final int newCount) {
+        if (oldCount != newCount) {
+            final Locale locale =
+                    ServiceProvider.getInstance().getDeviceInfoService().getActiveLocale();
+            String message =
+                    newCount > 0
+                            ? String.format(
+                                    locale,
+                                    "User has qualified for %d content card(s) for surface %s",
+                                    newCount,
+                                    surface.getUri())
+                            : String.format(
+                                    locale,
+                                    "User has not qualified for any content card(s) for surface %s",
+                                    surface.getUri());
+            Log.trace(MessagingConstants.LOG_TAG, SELF_TAG, message);
         }
     }
 

--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/EdgePersonalizationResponseHandler.java
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/EdgePersonalizationResponseHandler.java
@@ -678,46 +678,41 @@ class EdgePersonalizationResponseHandler {
                 requestedSurfaces,
                 eventHistoryRulesBySurface);
 
-        // collect and update content card rules engine
-        if (surfaceRulesBySchemaType.get(SchemaType.CONTENT_CARD) != null) {
-            final List<LaunchRule> collectedContentCardRules =
-                    collectRulesFrom(contentCardRulesBySurface);
-            contentCardRulesEngine.replaceRules(collectedContentCardRules);
+        // Always sync the content card rules engine and refresh the qualified cache.
+        // processRulesForSchemaType clears contentCardRulesBySurface for requested surfaces
+        // when CONTENT_CARD is absent from the response (e.g. all campaigns removed
+        // server-side); we must still replaceRules and call removeOrReplaceContentCards in
+        // that case — not only when the key is present.
+        final List<LaunchRule> collectedContentCardRules =
+                collectRulesFrom(contentCardRulesBySurface);
+        contentCardRulesEngine.replaceRules(collectedContentCardRules);
 
-            // process a generic event to see if there are any content cards with:
-            // 1. no client-side qualification requirements, or
-            // 2. prior qualification by this device
-            final Event event =
-                    new Event.Builder(
-                                    "Seed content cards",
-                                    EventType.MESSAGING,
-                                    EventSource.REQUEST_CONTENT)
-                            .build();
-            removeOrReplaceContentCards(event, requestedSurfaces);
-        }
+        final Event contentCardSeedEvent =
+                new Event.Builder(
+                                "Seed content cards",
+                                EventType.MESSAGING,
+                                EventSource.REQUEST_CONTENT)
+                        .build();
+        removeOrReplaceContentCards(contentCardSeedEvent, requestedSurfaces);
 
-        // collect and update launch rules engine for in-app and event history
-        if (surfaceRulesBySchemaType.get(SchemaType.INAPP) != null
-                || surfaceRulesBySchemaType.get(SchemaType.EVENT_HISTORY_OPERATION) != null) {
+        // Always sync the in-app + event history rules engine, for the same reason as
+        // content cards above: processRulesForSchemaType already cleared stale entries from
+        // inAppRulesBySurface / eventHistoryRulesBySurface, and the engine must reflect that.
+        final List<LaunchRule> collectedInAppRules = collectRulesFrom(inAppRulesBySurface);
 
-            // pre-fetch the assets for in-app message if any in-app rules were returned
-            final List<LaunchRule> collectedInAppRules = collectRulesFrom(inAppRulesBySurface);
-            if (surfaceRulesBySchemaType.get(SchemaType.INAPP) != null) {
-                final List<RuleConsequence> collectedInAppConsequences = new ArrayList<>();
-                for (final LaunchRule rule : collectedInAppRules) {
-                    collectedInAppConsequences.addAll(rule.getConsequenceList());
-                }
-                cacheImageAssetsFromPayload(collectedInAppConsequences);
+        // Pre-fetch assets only when the response actually contained new in-app rules
+        if (surfaceRulesBySchemaType.get(SchemaType.INAPP) != null) {
+            final List<RuleConsequence> collectedInAppConsequences = new ArrayList<>();
+            for (final LaunchRule rule : collectedInAppRules) {
+                collectedInAppConsequences.addAll(rule.getConsequenceList());
             }
-
-            // collect rules for in-app message and event history
-            final List<LaunchRule> collectedInAppAndEventHistoryRules =
-                    new ArrayList<>(collectedInAppRules);
-            collectedInAppAndEventHistoryRules.addAll(collectRulesFrom(eventHistoryRulesBySurface));
-
-            // update rules in launch rules engine
-            launchRulesEngine.replaceRules(collectedInAppAndEventHistoryRules);
+            cacheImageAssetsFromPayload(collectedInAppConsequences);
         }
+
+        final List<LaunchRule> collectedInAppAndEventHistoryRules =
+                new ArrayList<>(collectedInAppRules);
+        collectedInAppAndEventHistoryRules.addAll(collectRulesFrom(eventHistoryRulesBySurface));
+        launchRulesEngine.replaceRules(collectedInAppAndEventHistoryRules);
     }
 
     private void processRulesForSchemaType(

--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/EdgePersonalizationResponseHandler.java
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/EdgePersonalizationResponseHandler.java
@@ -304,9 +304,6 @@ class EdgePersonalizationResponseHandler {
                                 "Unable to run completion logic for a personalization request event"
                                         + " - error occurred: %s",
                                 adobeError.getErrorName());
-                        if (handler != null) {
-                            handler.handle.call(false);
-                        }
                     }
 
                     // the callback is called by Edge extension when a request's stream has been
@@ -892,7 +889,14 @@ class EdgePersonalizationResponseHandler {
         // This ensures cards removed server-side are also evicted from the local cache.
         for (final Surface surface : requestedSurfaces) {
             if (!qualifiedContentCardsBySurface.containsKey(surface)) {
-                contentCardsBySurface.remove(surface);
+                final List<Proposition> evictedPropositions =
+                        contentCardsBySurface.remove(surface);
+                if (evictedPropositions != null) {
+                    for (final Proposition proposition : evictedPropositions) {
+                        ContentCardMapper.getInstance()
+                                .removeContentCardSchemaData(proposition.getUniqueId());
+                    }
+                }
             }
         }
 
@@ -930,6 +934,13 @@ class EdgePersonalizationResponseHandler {
                         .storeContentCardSchemaData(propositionAsContentCard);
             }
 
+            // Remove ContentCardMapper entries for old propositions no longer in the fresh response
+            for (final Proposition oldProposition : existingPropositionsArray) {
+                if (!newPropositionsArray.contains(oldProposition)) {
+                    ContentCardMapper.getInstance()
+                            .removeContentCardSchemaData(oldProposition.getUniqueId());
+                }
+            }
             // Replace the cached list entirely with the fresh response data
             contentCardsBySurface.put(surface, newPropositionsArray);
 
@@ -939,7 +950,7 @@ class EdgePersonalizationResponseHandler {
                         newPropositionItems, null, MessagingEdgeEventType.TRIGGER);
             }
 
-            int newCount = existingPropositionsArray.size();
+            int newCount = newPropositionsArray.size();
             if (startingCount != newCount) {
                 final Locale locale =
                         ServiceProvider.getInstance().getDeviceInfoService().getActiveLocale();

--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/EdgePersonalizationResponseHandler.java
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/EdgePersonalizationResponseHandler.java
@@ -860,8 +860,7 @@ class EdgePersonalizationResponseHandler {
         // This ensures cards removed server-side are also evicted from the local cache.
         for (final Surface surface : requestedSurfaces) {
             if (!qualifiedContentCardsBySurface.containsKey(surface)) {
-                final List<Proposition> evictedPropositions =
-                        contentCardsBySurface.remove(surface);
+                final List<Proposition> evictedPropositions = contentCardsBySurface.remove(surface);
                 if (evictedPropositions != null) {
                     for (final Proposition proposition : evictedPropositions) {
                         ContentCardMapper.getInstance()

--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/EdgePersonalizationResponseHandler.java
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/EdgePersonalizationResponseHandler.java
@@ -1108,7 +1108,7 @@ class EdgePersonalizationResponseHandler {
         for (final Surface surface : surfaces) {
             final List<Proposition> propositionsList = inMemoryPropositions.get(surface);
             if (!MessagingUtils.isNullOrEmpty(propositionsList)) {
-                propositionMap.put(surface, propositionsList);
+                propositionMap.put(surface, new ArrayList<>(propositionsList));
             }
         }
         return propositionMap;

--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/EdgePersonalizationResponseHandler.java
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/EdgePersonalizationResponseHandler.java
@@ -304,6 +304,9 @@ class EdgePersonalizationResponseHandler {
                                 "Unable to run completion logic for a personalization request event"
                                         + " - error occurred: %s",
                                 adobeError.getErrorName());
+                        if (handler != null) {
+                            handler.handle.call(false);
+                        }
                     }
 
                     // the callback is called by Edge extension when a request's stream has been
@@ -693,7 +696,7 @@ class EdgePersonalizationResponseHandler {
                                     EventType.MESSAGING,
                                     EventSource.REQUEST_CONTENT)
                             .build();
-            updateQualifiedContentCardsForEvent(event);
+            removeOrReplaceContentCards(event, requestedSurfaces);
         }
 
         // collect and update launch rules engine for in-app and event history
@@ -775,81 +778,185 @@ class EdgePersonalizationResponseHandler {
     }
 
     /**
-     * Checks to see if the user has qualified for any content cards based on provided {@link
-     * Event}.
+     * Incrementally updates the content card cache for surfaces qualified by the rules engine.
      *
-     * @param event may result in content card qualification.
+     * <p>Called during rules engine processing (e.g. lifecycle or generic events). For each surface
+     * qualified by the provided {@link Event}:
+     *
+     * <ul>
+     *   <li>If a proposition already exists in the cache, it is removed and re-added (replaced) so
+     *       the latest data is reflected without duplicates.
+     *   <li>If a proposition is new (not previously in the cache), a {@code TRIGGER} event is sent
+     *       to Edge Network and the proposition is added to the cache.
+     * </ul>
+     *
+     * <p>This method is additive — it does not remove surfaces that return no results. Use {@link
+     * #removeOrReplaceContentCards(Event, List)} for authoritative refreshes that should clear
+     * stale surfaces.
+     *
+     * @param event the rules engine {@link Event} that may result in content card qualification.
      */
-    void updateQualifiedContentCardsForEvent(final Event event) {
+    @SuppressWarnings("NestedIfDepth")
+    void addOrReplaceContentCards(final Event event) {
         final Map<Surface, List<Proposition>> qualifiedContentCardsBySurface =
                 getPropositionsFromContentCardRulesEngine(event);
         for (final Map.Entry<Surface, List<Proposition>> entry :
                 qualifiedContentCardsBySurface.entrySet()) {
-            addOrReplaceContentCards(entry.getValue(), entry.getKey());
+            final List<Proposition> propositions = entry.getValue();
+            final Surface surface = entry.getKey();
+            List<Proposition> existingPropositionsArray = contentCardsBySurface.get(surface);
+            if (existingPropositionsArray == null) {
+                existingPropositionsArray = new ArrayList<>();
+            }
+
+            int startingCount = existingPropositionsArray.size();
+            // Track proposition items that are new so we can fire TRIGGER events for them
+            List<PropositionItem> newPropositionItems = new ArrayList<>();
+
+            for (final Proposition proposition : propositions) {
+                if (existingPropositionsArray.contains(proposition)) {
+                    // Remove the stale entry so the updated proposition is added at the end
+                    existingPropositionsArray.remove(proposition);
+                } else {
+                    // Proposition is new — collect its first item for a batched TRIGGER event
+                    final List<PropositionItem> propItems = proposition.getItems();
+                    if (!propItems.isEmpty()) {
+                        newPropositionItems.add(propItems.get(0));
+                    }
+                }
+                existingPropositionsArray.add(proposition);
+
+                // Store qualified content cards as schema data in the ContentCardMapper for later
+                // use by the UI layer
+                final ContentCardSchemaData propositionAsContentCard =
+                        proposition.getItems().get(0).getContentCardSchemaData();
+                ContentCardMapper.getInstance()
+                        .storeContentCardSchemaData(propositionAsContentCard);
+            }
+
+            contentCardsBySurface.put(surface, existingPropositionsArray);
+
+            // Send batched trigger events for new proposition items only
+            if (!newPropositionItems.isEmpty()) {
+                sendBatchedPropositionInteraction(
+                        newPropositionItems, null, MessagingEdgeEventType.TRIGGER);
+            }
+
+            int newCount = existingPropositionsArray.size();
+            if (startingCount != newCount) {
+                final Locale locale =
+                        ServiceProvider.getInstance().getDeviceInfoService().getActiveLocale();
+                String message =
+                        newCount > 0
+                                ? String.format(
+                                        locale,
+                                        "User has qualified for %d content card(s) for surface %s",
+                                        newCount,
+                                        surface.getUri())
+                                : String.format(
+                                        locale,
+                                        "User has not qualified for any content card(s) for surface"
+                                                + " %s",
+                                        surface.getUri());
+                Log.trace(MessagingConstants.LOG_TAG, SELF_TAG, message);
+            }
         }
     }
 
     /**
-     * Manages qualified content cards by surface. Prevents multiple entries for the same
-     * proposition in {@code contentCardsBySurface}. If an existing entry for a proposition is
-     * found, it is replaced with the value in propositions. If no prior entry exists for a
-     * proposition, a `trigger` event will be sent and written to event history).
+     * Authoritatively refreshes the content card cache using the response from a personalization
+     * network request.
      *
-     * @param propositions list of qualified {@link Proposition}s for the given surface.
-     * @param surface {@link Surface} to which qualified propositions belong.
+     * <p>Called after a personalization response stream completes. Treats the response as the
+     * source of truth for the requested surfaces:
+     *
+     * <ul>
+     *   <li>Any requested surface that returned no qualified propositions is removed from the
+     *       cache, preventing stale cards from persisting after a server-side change.
+     *   <li>For surfaces that did return propositions, the cached list is fully replaced (not
+     *       merged) with the new results.
+     *   <li>Propositions that are new (not previously in the cache) generate a {@code TRIGGER}
+     *       event sent to Edge Network.
+     * </ul>
+     *
+     * @param event the personalization response {@link Event} used to query the rules engine.
+     * @param requestedSurfaces the list of {@link Surface}s that were included in the originating
+     *     personalization request; used to identify surfaces that should be cleared if absent from
+     *     the response.
      */
-    @SuppressWarnings("NestedIfDepth")
-    private void addOrReplaceContentCards(
-            final List<Proposition> propositions, final Surface surface) {
-        List<Proposition> existingPropositionsArray = contentCardsBySurface.get(surface);
-        if (existingPropositionsArray == null) {
-            existingPropositionsArray = new ArrayList<>();
-        }
+    void removeOrReplaceContentCards(final Event event, final List<Surface> requestedSurfaces) {
+        final Map<Surface, List<Proposition>> qualifiedContentCardsBySurface =
+                getPropositionsFromContentCardRulesEngine(event);
 
-        int startingCount = existingPropositionsArray.size();
-        List<PropositionItem> newPropositionItems = new ArrayList<>();
-
-        for (final Proposition proposition : propositions) {
-            if (existingPropositionsArray.contains(proposition)) {
-                existingPropositionsArray.remove(proposition);
-            } else {
-                final List<PropositionItem> propItems = proposition.getItems();
-                if (!propItems.isEmpty()) {
-                    newPropositionItems.add(propItems.get(0));
-                }
+        // Clear any requested surface that returned no qualified propositions in this response.
+        // This ensures cards removed server-side are also evicted from the local cache.
+        for (final Surface surface : requestedSurfaces) {
+            if (!qualifiedContentCardsBySurface.containsKey(surface)) {
+                contentCardsBySurface.remove(surface);
             }
-            existingPropositionsArray.add(proposition);
-
-            // store qualified content cards as schema data in the ContentCardMapper for later use
-            final ContentCardSchemaData propositionAsContentCard =
-                    proposition.getItems().get(0).getContentCardSchemaData();
-            ContentCardMapper.getInstance().storeContentCardSchemaData(propositionAsContentCard);
         }
 
-        contentCardsBySurface.put(surface, existingPropositionsArray);
+        // Fully replace cached propositions for surfaces that have qualified content cards
+        for (final Map.Entry<Surface, List<Proposition>> entry :
+                qualifiedContentCardsBySurface.entrySet()) {
+            final List<Proposition> propositions = entry.getValue();
+            final Surface surface = entry.getKey();
+            List<Proposition> existingPropositionsArray = contentCardsBySurface.get(surface);
+            if (existingPropositionsArray == null) {
+                existingPropositionsArray = new ArrayList<>();
+            }
 
-        // Send batched trigger events for new proposition items
-        if (!newPropositionItems.isEmpty()) {
-            sendBatchedPropositionInteraction(
-                    newPropositionItems, null, MessagingEdgeEventType.TRIGGER);
-        }
+            int startingCount = existingPropositionsArray.size();
+            // Build a fresh list from the response rather than mutating the existing one
+            List<Proposition> newPropositionsArray = new ArrayList<>();
+            // Track proposition items that are genuinely new so we can fire TRIGGER events
+            List<PropositionItem> newPropositionItems = new ArrayList<>();
 
-        int newCount = existingPropositionsArray.size();
-        if (startingCount != newCount) {
-            final Locale locale =
-                    ServiceProvider.getInstance().getDeviceInfoService().getActiveLocale();
-            String message =
-                    newCount > 0
-                            ? String.format(
-                                    locale,
-                                    "User has qualified for %d content card(s) for surface %s",
-                                    newCount,
-                                    surface.getUri())
-                            : String.format(
-                                    locale,
-                                    "User has not qualified for any content card(s) for surface %s",
-                                    surface.getUri());
-            Log.trace(MessagingConstants.LOG_TAG, SELF_TAG, message);
+            for (final Proposition proposition : propositions) {
+                if (!existingPropositionsArray.contains(proposition)) {
+                    // Proposition is new — collect its first item for a batched TRIGGER event
+                    final List<PropositionItem> propItems = proposition.getItems();
+                    if (!propItems.isEmpty()) {
+                        newPropositionItems.add(propItems.get(0));
+                    }
+                }
+                newPropositionsArray.add(proposition);
+
+                // Store qualified content cards as schema data in the ContentCardMapper for later
+                // use by the UI layer
+                final ContentCardSchemaData propositionAsContentCard =
+                        proposition.getItems().get(0).getContentCardSchemaData();
+                ContentCardMapper.getInstance()
+                        .storeContentCardSchemaData(propositionAsContentCard);
+            }
+
+            // Replace the cached list entirely with the fresh response data
+            contentCardsBySurface.put(surface, newPropositionsArray);
+
+            // Send batched trigger events for new proposition items only
+            if (!newPropositionItems.isEmpty()) {
+                sendBatchedPropositionInteraction(
+                        newPropositionItems, null, MessagingEdgeEventType.TRIGGER);
+            }
+
+            int newCount = existingPropositionsArray.size();
+            if (startingCount != newCount) {
+                final Locale locale =
+                        ServiceProvider.getInstance().getDeviceInfoService().getActiveLocale();
+                String message =
+                        newCount > 0
+                                ? String.format(
+                                        locale,
+                                        "User has qualified for %d content card(s) for surface %s",
+                                        newCount,
+                                        surface.getUri())
+                                : String.format(
+                                        locale,
+                                        "User has not qualified for any content card(s) for surface"
+                                                + " %s",
+                                        surface.getUri());
+                Log.trace(MessagingConstants.LOG_TAG, SELF_TAG, message);
+            }
         }
     }
 

--- a/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/MessagingExtension.java
+++ b/code/messaging/src/main/java/com/adobe/marketing/mobile/messaging/MessagingExtension.java
@@ -299,7 +299,7 @@ public final class MessagingExtension extends Extension {
             return;
         }
         messagingRulesEngine.processEvent(event);
-        edgePersonalizationResponseHandler.updateQualifiedContentCardsForEvent(event);
+        edgePersonalizationResponseHandler.addOrReplaceContentCards(event);
     }
 
     /**

--- a/code/messaging/src/test/java/com/adobe/marketing/mobile/messaging/EdgePersonalizationResponseHandlerTests.java
+++ b/code/messaging/src/test/java/com/adobe/marketing/mobile/messaging/EdgePersonalizationResponseHandlerTests.java
@@ -56,6 +56,7 @@ import com.adobe.marketing.mobile.util.DataReader;
 import com.adobe.marketing.mobile.util.JSONUtils;
 import com.adobe.marketing.mobile.util.SerialWorkDispatcher;
 import java.io.File;
+import java.lang.ref.SoftReference;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -143,10 +144,26 @@ public class EdgePersonalizationResponseHandlerTests {
         reset(mockPresentableMessageMapper);
         reset(mockInternalMessage);
         reset(mockAdobeCallback);
+        ContentCardMapper.getInstance().clear();
 
         if (cacheDir.exists()) {
             cacheDir.delete();
         }
+    }
+
+    /**
+     * Pre-populates ContentCardMapper with a mock ContentCardSchemaData entry keyed by the given
+     * proposition ID, so tests can verify removal behaviour.
+     */
+    private void seedContentCardMapper(String propositionId) {
+        ContentCardSchemaData schemaData = mock(ContentCardSchemaData.class);
+        PropositionItem propItem = mock(PropositionItem.class);
+        Proposition prop = mock(Proposition.class);
+        schemaData.parent = propItem;
+        propItem.propositionReference = new SoftReference<>(prop);
+        when(propItem.getProposition()).thenReturn(prop);
+        when(prop.getUniqueId()).thenReturn(propositionId);
+        ContentCardMapper.getInstance().storeContentCardSchemaData(schemaData);
     }
 
     void runUsingMockedServiceProvider(final Runnable runnable) {
@@ -2697,6 +2714,439 @@ public class EdgePersonalizationResponseHandlerTests {
                                 qualifiedContentCardsBySurface.get(feedSurface);
                         assertEquals(propositions, qualifiedContentCardsList);
                     }
+                });
+    }
+
+    // ========================================================================================
+    // removeOrReplaceContentCards
+    // ========================================================================================
+    @Test
+    public void
+            test_removeOrReplaceContentCards_EvictsAllRequestedSurfaces_WhenNoQualifiedCards() {
+        runUsingMockedServiceProvider(
+                () -> {
+                    // setup: pre-populate contentCardsBySurface with two surfaces
+                    Surface surfaceA = new Surface("feed1");
+                    Surface surfaceB = new Surface("feed2");
+
+                    MessageTestConfig configA = new MessageTestConfig();
+                    configA.count = 2;
+                    List<Proposition> propositionsA =
+                            MessagingTestUtils.generateQualifiedContentCards(configA);
+                    MessageTestConfig configB = new MessageTestConfig();
+                    configB.count = 1;
+                    List<Proposition> propositionsB =
+                            MessagingTestUtils.generateQualifiedContentCards(configB);
+
+                    Map<Surface, List<Proposition>> contentCards = new HashMap<>();
+                    contentCards.put(surfaceA, propositionsA);
+                    contentCards.put(surfaceB, propositionsB);
+                    edgePersonalizationResponseHandler.setQualifiedContentCardsBySurface(
+                            contentCards);
+                    assertEquals(
+                            2,
+                            edgePersonalizationResponseHandler
+                                    .getQualifiedContentCardsBySurface()
+                                    .size());
+
+                    // mock evaluate to return null (no qualified content cards)
+                    when(mockContentCardRulesEngine.evaluate(any(Event.class))).thenReturn(null);
+
+                    Event testEvent = mock(Event.class);
+                    List<Surface> requestedSurfaces = new ArrayList<>();
+                    requestedSurfaces.add(surfaceA);
+                    requestedSurfaces.add(surfaceB);
+
+                    // test
+                    edgePersonalizationResponseHandler.removeOrReplaceContentCards(
+                            testEvent, requestedSurfaces);
+
+                    // verify all requested surfaces are evicted
+                    Map<Surface, List<Proposition>> result =
+                            edgePersonalizationResponseHandler.getQualifiedContentCardsBySurface();
+                    assertEquals(0, result.size());
+                });
+    }
+
+    @Test
+    public void
+            test_removeOrReplaceContentCards_OnlyEvictsRequestedSurfaces_PreservesUnrequested() {
+        runUsingMockedServiceProvider(
+                () -> {
+                    // setup: pre-populate contentCardsBySurface with three surfaces
+                    Surface surfaceA = new Surface("feed1");
+                    Surface surfaceB = new Surface("feed2");
+                    Surface surfaceC = new Surface("feed3");
+
+                    MessageTestConfig config = new MessageTestConfig();
+                    config.count = 1;
+                    List<Proposition> propositionsA =
+                            MessagingTestUtils.generateQualifiedContentCards(config);
+                    List<Proposition> propositionsB =
+                            MessagingTestUtils.generateQualifiedContentCards(config);
+                    List<Proposition> propositionsC =
+                            MessagingTestUtils.generateQualifiedContentCards(config);
+
+                    Map<Surface, List<Proposition>> contentCards = new HashMap<>();
+                    contentCards.put(surfaceA, propositionsA);
+                    contentCards.put(surfaceB, propositionsB);
+                    contentCards.put(surfaceC, propositionsC);
+                    edgePersonalizationResponseHandler.setQualifiedContentCardsBySurface(
+                            contentCards);
+                    assertEquals(
+                            3,
+                            edgePersonalizationResponseHandler
+                                    .getQualifiedContentCardsBySurface()
+                                    .size());
+
+                    // mock evaluate to return null (no qualified content cards)
+                    when(mockContentCardRulesEngine.evaluate(any(Event.class))).thenReturn(null);
+
+                    Event testEvent = mock(Event.class);
+                    // request only A and B — not C
+                    List<Surface> requestedSurfaces = new ArrayList<>();
+                    requestedSurfaces.add(surfaceA);
+                    requestedSurfaces.add(surfaceB);
+
+                    // test
+                    edgePersonalizationResponseHandler.removeOrReplaceContentCards(
+                            testEvent, requestedSurfaces);
+
+                    // verify A and B are evicted, C is preserved
+                    Map<Surface, List<Proposition>> result =
+                            edgePersonalizationResponseHandler.getQualifiedContentCardsBySurface();
+                    assertEquals(1, result.size());
+                    assertNotNull(result.get(surfaceC));
+                    assertNull(result.get(surfaceA));
+                    assertNull(result.get(surfaceB));
+                });
+    }
+
+    @Test
+    public void
+            test_removeOrReplaceContentCards_ReplacesPropositionsForQualifiedSurface_AndEvictsAbsentSurface() {
+        runUsingMockedServiceProvider(
+                () -> {
+                    // setup: pre-populate contentCardsBySurface with two surfaces
+                    Surface surfaceA = new Surface("feed1");
+                    Surface surfaceB = new Surface("feed2");
+
+                    MessageTestConfig configA = new MessageTestConfig();
+                    configA.count = 2;
+                    List<Proposition> oldPropositionsA =
+                            MessagingTestUtils.generateQualifiedContentCards(configA);
+                    MessageTestConfig configB = new MessageTestConfig();
+                    configB.count = 1;
+                    List<Proposition> oldPropositionsB =
+                            MessagingTestUtils.generateQualifiedContentCards(configB);
+
+                    Map<Surface, List<Proposition>> contentCards = new HashMap<>();
+                    contentCards.put(surfaceA, oldPropositionsA);
+                    contentCards.put(surfaceB, oldPropositionsB);
+                    edgePersonalizationResponseHandler.setQualifiedContentCardsBySurface(
+                            contentCards);
+                    assertEquals(2, oldPropositionsA.size());
+                    assertEquals(1, oldPropositionsB.size());
+
+                    // populate propositionInfo via reflection so
+                    // getPropositionsFromContentCardRulesEngine
+                    // can reconstruct propositions for items returned by evaluate()
+                    try {
+                        Map<String, Object> activity = new HashMap<>();
+                        activity.put("id", "newActivityId");
+                        Map<String, Object> scopeDetails = new HashMap<>();
+                        scopeDetails.put("activity", activity);
+                        scopeDetails.put("correlationID", "testCorrelationId");
+
+                        Map<String, Object> infoMap = new HashMap<>();
+                        infoMap.put("id", "newPropositionId");
+                        infoMap.put("scope", surfaceA.getUri());
+                        infoMap.put("scopeDetails", scopeDetails);
+                        PropositionInfo info = PropositionInfo.create(infoMap);
+
+                        java.lang.reflect.Field propositionInfoField =
+                                EdgePersonalizationResponseHandler.class.getDeclaredField(
+                                        "propositionInfo");
+                        propositionInfoField.setAccessible(true);
+                        @SuppressWarnings("unchecked")
+                        Map<String, PropositionInfo> propositionInfoMap =
+                                (Map<String, PropositionInfo>)
+                                        propositionInfoField.get(
+                                                edgePersonalizationResponseHandler);
+                        propositionInfoMap.put(
+                                "183639c4-cb37-458e-a8ef-4e130d767ebf", info);
+                    } catch (Exception e) {
+                        fail("Failed to set propositionInfo via reflection: " + e.getMessage());
+                    }
+
+                    // mock evaluate to return 1 qualified item for surfaceA only
+                    Map<Surface, List<PropositionItem>> evaluateResult = new HashMap<>();
+                    evaluateResult.put(
+                            surfaceA,
+                            MessagingTestUtils.createMessagingPropositionItemList(1));
+                    when(mockContentCardRulesEngine.evaluate(any(Event.class)))
+                            .thenReturn(evaluateResult);
+
+                    Event testEvent = mock(Event.class);
+                    List<Surface> requestedSurfaces = new ArrayList<>();
+                    requestedSurfaces.add(surfaceA);
+                    requestedSurfaces.add(surfaceB);
+
+                    // test
+                    edgePersonalizationResponseHandler.removeOrReplaceContentCards(
+                            testEvent, requestedSurfaces);
+
+                    // verify surfaceA has new proposition (replaced, not merged)
+                    Map<Surface, List<Proposition>> result =
+                            edgePersonalizationResponseHandler.getQualifiedContentCardsBySurface();
+                    assertEquals(1, result.size());
+
+                    List<Proposition> resultA = result.get(surfaceA);
+                    assertNotNull(resultA);
+                    assertEquals(1, resultA.size());
+                    assertEquals("newPropositionId", resultA.get(0).getUniqueId());
+
+                    // verify surfaceB is evicted
+                    assertNull(result.get(surfaceB));
+                });
+    }
+
+    // ========================================================================================
+    // addOrReplaceContentCards (incremental — should NOT evict)
+    // ========================================================================================
+    @Test
+    public void test_addOrReplaceContentCards_DoesNotEvictSurfaces_WhenNoQualifiedCards() {
+        runUsingMockedServiceProvider(
+                () -> {
+                    // setup: pre-populate contentCardsBySurface with two surfaces
+                    Surface surfaceA = new Surface("feed1");
+                    Surface surfaceB = new Surface("feed2");
+
+                    MessageTestConfig configA = new MessageTestConfig();
+                    configA.count = 2;
+                    List<Proposition> propositionsA =
+                            MessagingTestUtils.generateQualifiedContentCards(configA);
+                    MessageTestConfig configB = new MessageTestConfig();
+                    configB.count = 1;
+                    List<Proposition> propositionsB =
+                            MessagingTestUtils.generateQualifiedContentCards(configB);
+
+                    Map<Surface, List<Proposition>> contentCards = new HashMap<>();
+                    contentCards.put(surfaceA, propositionsA);
+                    contentCards.put(surfaceB, propositionsB);
+                    edgePersonalizationResponseHandler.setQualifiedContentCardsBySurface(
+                            contentCards);
+                    assertEquals(
+                            2,
+                            edgePersonalizationResponseHandler
+                                    .getQualifiedContentCardsBySurface()
+                                    .size());
+
+                    // mock evaluate to return null (no qualified content cards)
+                    when(mockContentCardRulesEngine.evaluate(any(Event.class))).thenReturn(null);
+
+                    Event testEvent = mock(Event.class);
+
+                    // test
+                    edgePersonalizationResponseHandler.addOrReplaceContentCards(testEvent);
+
+                    // verify all surfaces are preserved (additive behavior does not evict)
+                    Map<Surface, List<Proposition>> result =
+                            edgePersonalizationResponseHandler.getQualifiedContentCardsBySurface();
+                    assertEquals(2, result.size());
+                    assertEquals(propositionsA, result.get(surfaceA));
+                    assertEquals(propositionsB, result.get(surfaceB));
+                });
+    }
+
+    // ========================================================================================
+    // removeOrReplaceContentCards — ContentCardMapper cleanup
+    // ========================================================================================
+    @Test
+    public void
+            test_removeOrReplaceContentCards_ClearsContentCardMapperEntries_WhenSurfaceEvicted() {
+        runUsingMockedServiceProvider(
+                () -> {
+                    Surface surfaceA = new Surface("feed1");
+
+                    MessageTestConfig config = new MessageTestConfig();
+                    config.count = 1;
+                    List<Proposition> propositionsA =
+                            MessagingTestUtils.generateQualifiedContentCards(config);
+                    String propositionId = propositionsA.get(0).getUniqueId();
+
+                    Map<Surface, List<Proposition>> contentCards = new HashMap<>();
+                    contentCards.put(surfaceA, propositionsA);
+                    edgePersonalizationResponseHandler.setQualifiedContentCardsBySurface(
+                            contentCards);
+
+                    // pre-populate ContentCardMapper with an entry for the proposition
+                    seedContentCardMapper(propositionId);
+                    assertNotNull(
+                            ContentCardMapper.getInstance()
+                                    .getContentCardSchemaData(propositionId));
+
+                    when(mockContentCardRulesEngine.evaluate(any(Event.class))).thenReturn(null);
+
+                    Event testEvent = mock(Event.class);
+                    List<Surface> requestedSurfaces = new ArrayList<>();
+                    requestedSurfaces.add(surfaceA);
+
+                    // test
+                    edgePersonalizationResponseHandler.removeOrReplaceContentCards(
+                            testEvent, requestedSurfaces);
+
+                    // verify surface evicted from cache
+                    assertNull(
+                            edgePersonalizationResponseHandler
+                                    .getQualifiedContentCardsBySurface()
+                                    .get(surfaceA));
+                    // verify ContentCardMapper entry was removed
+                    assertNull(
+                            ContentCardMapper.getInstance()
+                                    .getContentCardSchemaData(propositionId));
+                });
+    }
+
+    @Test
+    public void
+            test_removeOrReplaceContentCards_RemovesOldAndStoresNewContentCardMapperEntries_OnReplacement() {
+        runUsingMockedServiceProvider(
+                () -> {
+                    Surface surfaceA = new Surface("feed1");
+
+                    MessageTestConfig configOld = new MessageTestConfig();
+                    configOld.count = 1;
+                    List<Proposition> oldPropositions =
+                            MessagingTestUtils.generateQualifiedContentCards(configOld);
+                    String oldPropositionId = oldPropositions.get(0).getUniqueId();
+
+                    Map<Surface, List<Proposition>> contentCards = new HashMap<>();
+                    contentCards.put(surfaceA, oldPropositions);
+                    edgePersonalizationResponseHandler.setQualifiedContentCardsBySurface(
+                            contentCards);
+
+                    // pre-populate ContentCardMapper with an entry for the old proposition
+                    seedContentCardMapper(oldPropositionId);
+                    assertNotNull(
+                            ContentCardMapper.getInstance()
+                                    .getContentCardSchemaData(oldPropositionId));
+
+                    // set up propositionInfo so getPropositionsFromContentCardRulesEngine can
+                    // reconstruct propositions from evaluate() results
+                    String newPropositionId = "newPropositionId";
+                    try {
+                        Map<String, Object> activity = new HashMap<>();
+                        activity.put("id", "newActivityId");
+                        Map<String, Object> scopeDetails = new HashMap<>();
+                        scopeDetails.put("activity", activity);
+                        scopeDetails.put("correlationID", "testCorrelationId");
+
+                        Map<String, Object> infoMap = new HashMap<>();
+                        infoMap.put("id", newPropositionId);
+                        infoMap.put("scope", surfaceA.getUri());
+                        infoMap.put("scopeDetails", scopeDetails);
+                        PropositionInfo info = PropositionInfo.create(infoMap);
+
+                        java.lang.reflect.Field propositionInfoField =
+                                EdgePersonalizationResponseHandler.class.getDeclaredField(
+                                        "propositionInfo");
+                        propositionInfoField.setAccessible(true);
+                        @SuppressWarnings("unchecked")
+                        Map<String, PropositionInfo> propositionInfoMap =
+                                (Map<String, PropositionInfo>)
+                                        propositionInfoField.get(
+                                                edgePersonalizationResponseHandler);
+                        propositionInfoMap.put(
+                                "183639c4-cb37-458e-a8ef-4e130d767ebf", info);
+                    } catch (Exception e) {
+                        fail("Failed to set propositionInfo via reflection: " + e.getMessage());
+                    }
+
+                    Map<Surface, List<PropositionItem>> evaluateResult = new HashMap<>();
+                    evaluateResult.put(
+                            surfaceA,
+                            MessagingTestUtils.createMessagingPropositionItemList(1));
+                    when(mockContentCardRulesEngine.evaluate(any(Event.class)))
+                            .thenReturn(evaluateResult);
+
+                    Event testEvent = mock(Event.class);
+                    List<Surface> requestedSurfaces = new ArrayList<>();
+                    requestedSurfaces.add(surfaceA);
+
+                    // test
+                    edgePersonalizationResponseHandler.removeOrReplaceContentCards(
+                            testEvent, requestedSurfaces);
+
+                    // verify old proposition's ContentCardMapper entry was removed
+                    assertNull(
+                            ContentCardMapper.getInstance()
+                                    .getContentCardSchemaData(oldPropositionId));
+                    // verify new proposition is stored in ContentCardMapper
+                    assertNotNull(
+                            ContentCardMapper.getInstance()
+                                    .getContentCardSchemaData(newPropositionId));
+                });
+    }
+
+    // ========================================================================================
+    // removeOrReplaceContentCards — edge cases
+    // ========================================================================================
+    @Test
+    public void
+            test_removeOrReplaceContentCards_NoOp_WhenRequestedSurfacesEmpty() {
+        runUsingMockedServiceProvider(
+                () -> {
+                    Surface surfaceA = new Surface("feed1");
+
+                    MessageTestConfig config = new MessageTestConfig();
+                    config.count = 1;
+                    List<Proposition> propositionsA =
+                            MessagingTestUtils.generateQualifiedContentCards(config);
+
+                    Map<Surface, List<Proposition>> contentCards = new HashMap<>();
+                    contentCards.put(surfaceA, propositionsA);
+                    edgePersonalizationResponseHandler.setQualifiedContentCardsBySurface(
+                            contentCards);
+
+                    when(mockContentCardRulesEngine.evaluate(any(Event.class))).thenReturn(null);
+
+                    Event testEvent = mock(Event.class);
+                    List<Surface> requestedSurfaces = new ArrayList<>();
+
+                    // test with empty requested surfaces
+                    edgePersonalizationResponseHandler.removeOrReplaceContentCards(
+                            testEvent, requestedSurfaces);
+
+                    // verify cache is unchanged
+                    Map<Surface, List<Proposition>> result =
+                            edgePersonalizationResponseHandler.getQualifiedContentCardsBySurface();
+                    assertEquals(1, result.size());
+                    assertNotNull(result.get(surfaceA));
+                });
+    }
+
+    @Test
+    public void
+            test_removeOrReplaceContentCards_NoError_WhenRequestedSurfaceNeverCached() {
+        runUsingMockedServiceProvider(
+                () -> {
+                    Surface surfaceA = new Surface("feed1");
+
+                    when(mockContentCardRulesEngine.evaluate(any(Event.class))).thenReturn(null);
+
+                    Event testEvent = mock(Event.class);
+                    List<Surface> requestedSurfaces = new ArrayList<>();
+                    requestedSurfaces.add(surfaceA);
+
+                    // test — surfaceA was never in the cache
+                    edgePersonalizationResponseHandler.removeOrReplaceContentCards(
+                            testEvent, requestedSurfaces);
+
+                    // verify cache remains empty, no exceptions thrown
+                    Map<Surface, List<Proposition>> result =
+                            edgePersonalizationResponseHandler.getQualifiedContentCardsBySurface();
+                    assertEquals(0, result.size());
                 });
     }
 }

--- a/code/messaging/src/test/java/com/adobe/marketing/mobile/messaging/EdgePersonalizationResponseHandlerTests.java
+++ b/code/messaging/src/test/java/com/adobe/marketing/mobile/messaging/EdgePersonalizationResponseHandlerTests.java
@@ -153,16 +153,18 @@ public class EdgePersonalizationResponseHandlerTests {
 
     /**
      * Pre-populates ContentCardMapper with a mock ContentCardSchemaData entry keyed by the given
-     * proposition ID, so tests can verify removal behaviour.
+     * activity ID, so tests can verify removal behaviour. Uses a separate unique ID to ensure the
+     * mapper is keyed by activityId, not uniqueId.
      */
-    private void seedContentCardMapper(String propositionId) {
+    private void seedContentCardMapper(String activityId) {
         ContentCardSchemaData schemaData = mock(ContentCardSchemaData.class);
         PropositionItem propItem = mock(PropositionItem.class);
         Proposition prop = mock(Proposition.class);
         schemaData.parent = propItem;
         propItem.propositionReference = new SoftReference<>(prop);
         when(propItem.getProposition()).thenReturn(prop);
-        when(prop.getUniqueId()).thenReturn(propositionId);
+        when(prop.getUniqueId()).thenReturn("uniqueId_" + activityId);
+        when(prop.getActivityId()).thenReturn(activityId);
         ContentCardMapper.getInstance().storeContentCardSchemaData(schemaData);
     }
 
@@ -3101,18 +3103,18 @@ public class EdgePersonalizationResponseHandlerTests {
                     config.count = 1;
                     List<Proposition> propositionsA =
                             MessagingTestUtils.generateQualifiedContentCards(config);
-                    String propositionId = propositionsA.get(0).getUniqueId();
+                    String activityId = propositionsA.get(0).getActivityId();
 
                     Map<Surface, List<Proposition>> contentCards = new HashMap<>();
                     contentCards.put(surfaceA, propositionsA);
                     edgePersonalizationResponseHandler.setQualifiedContentCardsBySurface(
                             contentCards);
 
-                    // pre-populate ContentCardMapper with an entry for the proposition
-                    seedContentCardMapper(propositionId);
+                    // pre-populate ContentCardMapper with an entry keyed by activityId
+                    seedContentCardMapper(activityId);
                     assertNotNull(
                             ContentCardMapper.getInstance()
-                                    .getContentCardSchemaData(propositionId));
+                                    .getContentCardSchemaData(activityId));
 
                     when(mockContentCardRulesEngine.evaluate(any(Event.class))).thenReturn(null);
 
@@ -3132,7 +3134,7 @@ public class EdgePersonalizationResponseHandlerTests {
                     // verify ContentCardMapper entry was removed
                     assertNull(
                             ContentCardMapper.getInstance()
-                                    .getContentCardSchemaData(propositionId));
+                                    .getContentCardSchemaData(activityId));
                 });
     }
 
@@ -3147,25 +3149,26 @@ public class EdgePersonalizationResponseHandlerTests {
                     configOld.count = 1;
                     List<Proposition> oldPropositions =
                             MessagingTestUtils.generateQualifiedContentCards(configOld);
-                    String oldPropositionId = oldPropositions.get(0).getUniqueId();
+                    String oldActivityId = oldPropositions.get(0).getActivityId();
 
                     Map<Surface, List<Proposition>> contentCards = new HashMap<>();
                     contentCards.put(surfaceA, oldPropositions);
                     edgePersonalizationResponseHandler.setQualifiedContentCardsBySurface(
                             contentCards);
 
-                    // pre-populate ContentCardMapper with an entry for the old proposition
-                    seedContentCardMapper(oldPropositionId);
+                    // pre-populate ContentCardMapper with an entry keyed by activityId
+                    seedContentCardMapper(oldActivityId);
                     assertNotNull(
                             ContentCardMapper.getInstance()
-                                    .getContentCardSchemaData(oldPropositionId));
+                                    .getContentCardSchemaData(oldActivityId));
 
                     // set up propositionInfo so getPropositionsFromContentCardRulesEngine can
                     // reconstruct propositions from evaluate() results
                     String newPropositionId = "newPropositionId";
+                    String newActivityId = "newActivityId";
                     try {
                         Map<String, Object> activity = new HashMap<>();
-                        activity.put("id", "newActivityId");
+                        activity.put("id", newActivityId);
                         Map<String, Object> scopeDetails = new HashMap<>();
                         scopeDetails.put("activity", activity);
                         scopeDetails.put("correlationID", "testCorrelationId");
@@ -3209,11 +3212,11 @@ public class EdgePersonalizationResponseHandlerTests {
                     // verify old proposition's ContentCardMapper entry was removed
                     assertNull(
                             ContentCardMapper.getInstance()
-                                    .getContentCardSchemaData(oldPropositionId));
-                    // verify new proposition is stored in ContentCardMapper
+                                    .getContentCardSchemaData(oldActivityId));
+                    // verify new proposition is stored in ContentCardMapper (keyed by activityId)
                     assertNotNull(
                             ContentCardMapper.getInstance()
-                                    .getContentCardSchemaData(newPropositionId));
+                                    .getContentCardSchemaData(newActivityId));
                 });
     }
 

--- a/code/messaging/src/test/java/com/adobe/marketing/mobile/messaging/EdgePersonalizationResponseHandlerTests.java
+++ b/code/messaging/src/test/java/com/adobe/marketing/mobile/messaging/EdgePersonalizationResponseHandlerTests.java
@@ -2851,8 +2851,7 @@ public class EdgePersonalizationResponseHandlerTests {
     // removeOrReplaceContentCards
     // ========================================================================================
     @Test
-    public void
-            test_removeOrReplaceContentCards_EvictsAllRequestedSurfaces_WhenNoQualifiedCards() {
+    public void test_removeOrReplaceContentCards_EvictsAllRequestedSurfaces_WhenNoQualifiedCards() {
         runUsingMockedServiceProvider(
                 () -> {
                     // setup: pre-populate contentCardsBySurface with two surfaces
@@ -3003,8 +3002,7 @@ public class EdgePersonalizationResponseHandlerTests {
                                 (Map<String, PropositionInfo>)
                                         propositionInfoField.get(
                                                 edgePersonalizationResponseHandler);
-                        propositionInfoMap.put(
-                                "183639c4-cb37-458e-a8ef-4e130d767ebf", info);
+                        propositionInfoMap.put("183639c4-cb37-458e-a8ef-4e130d767ebf", info);
                     } catch (Exception e) {
                         fail("Failed to set propositionInfo via reflection: " + e.getMessage());
                     }
@@ -3012,8 +3010,7 @@ public class EdgePersonalizationResponseHandlerTests {
                     // mock evaluate to return 1 qualified item for surfaceA only
                     Map<Surface, List<PropositionItem>> evaluateResult = new HashMap<>();
                     evaluateResult.put(
-                            surfaceA,
-                            MessagingTestUtils.createMessagingPropositionItemList(1));
+                            surfaceA, MessagingTestUtils.createMessagingPropositionItemList(1));
                     when(mockContentCardRulesEngine.evaluate(any(Event.class)))
                             .thenReturn(evaluateResult);
 
@@ -3113,8 +3110,7 @@ public class EdgePersonalizationResponseHandlerTests {
                     // pre-populate ContentCardMapper with an entry keyed by activityId
                     seedContentCardMapper(activityId);
                     assertNotNull(
-                            ContentCardMapper.getInstance()
-                                    .getContentCardSchemaData(activityId));
+                            ContentCardMapper.getInstance().getContentCardSchemaData(activityId));
 
                     when(mockContentCardRulesEngine.evaluate(any(Event.class))).thenReturn(null);
 
@@ -3133,8 +3129,7 @@ public class EdgePersonalizationResponseHandlerTests {
                                     .get(surfaceA));
                     // verify ContentCardMapper entry was removed
                     assertNull(
-                            ContentCardMapper.getInstance()
-                                    .getContentCardSchemaData(activityId));
+                            ContentCardMapper.getInstance().getContentCardSchemaData(activityId));
                 });
     }
 
@@ -3188,16 +3183,14 @@ public class EdgePersonalizationResponseHandlerTests {
                                 (Map<String, PropositionInfo>)
                                         propositionInfoField.get(
                                                 edgePersonalizationResponseHandler);
-                        propositionInfoMap.put(
-                                "183639c4-cb37-458e-a8ef-4e130d767ebf", info);
+                        propositionInfoMap.put("183639c4-cb37-458e-a8ef-4e130d767ebf", info);
                     } catch (Exception e) {
                         fail("Failed to set propositionInfo via reflection: " + e.getMessage());
                     }
 
                     Map<Surface, List<PropositionItem>> evaluateResult = new HashMap<>();
                     evaluateResult.put(
-                            surfaceA,
-                            MessagingTestUtils.createMessagingPropositionItemList(1));
+                            surfaceA, MessagingTestUtils.createMessagingPropositionItemList(1));
                     when(mockContentCardRulesEngine.evaluate(any(Event.class)))
                             .thenReturn(evaluateResult);
 
@@ -3224,8 +3217,7 @@ public class EdgePersonalizationResponseHandlerTests {
     // removeOrReplaceContentCards — edge cases
     // ========================================================================================
     @Test
-    public void
-            test_removeOrReplaceContentCards_NoOp_WhenRequestedSurfacesEmpty() {
+    public void test_removeOrReplaceContentCards_NoOp_WhenRequestedSurfacesEmpty() {
         runUsingMockedServiceProvider(
                 () -> {
                     Surface surfaceA = new Surface("feed1");
@@ -3258,8 +3250,7 @@ public class EdgePersonalizationResponseHandlerTests {
     }
 
     @Test
-    public void
-            test_removeOrReplaceContentCards_NoError_WhenRequestedSurfaceNeverCached() {
+    public void test_removeOrReplaceContentCards_NoError_WhenRequestedSurfaceNeverCached() {
         runUsingMockedServiceProvider(
                 () -> {
                     Surface surfaceA = new Surface("feed1");

--- a/code/messaging/src/test/java/com/adobe/marketing/mobile/messaging/EdgePersonalizationResponseHandlerTests.java
+++ b/code/messaging/src/test/java/com/adobe/marketing/mobile/messaging/EdgePersonalizationResponseHandlerTests.java
@@ -1404,10 +1404,11 @@ public class EdgePersonalizationResponseHandlerTests {
                         assertEquals(3, rulesListCaptor.getAllValues().get(0).size());
                         assertEquals(15, rulesListCaptor.getAllValues().get(1).size());
 
-                        // verify parsed rules replaced in feed rules engine for both responses
-                        verify(mockContentCardRulesEngine, times(1))
+                        // verify content card rules engine synced for both responses
+                        verify(mockContentCardRulesEngine, times(2))
                                 .replaceRules(contentCardRulesListCaptor.capture());
-                        assertEquals(4, contentCardRulesListCaptor.getAllValues().get(0).size());
+                        assertEquals(0, contentCardRulesListCaptor.getAllValues().get(0).size());
+                        assertEquals(4, contentCardRulesListCaptor.getAllValues().get(1).size());
                         List<LaunchRule> eventHistoryRules = new ArrayList<>();
                         List<LaunchRule> inAppRules = new ArrayList<>();
                         for (LaunchRule launchRule : rulesListCaptor.getAllValues().get(1)) {
@@ -1494,11 +1495,14 @@ public class EdgePersonalizationResponseHandlerTests {
                         // test
                         edgePersonalizationResponseHandler.handleProcessCompletedEvent(mockEvent);
 
-                        // verify in-app rules engine not called
-                        verifyNoInteractions(mockMessagingRulesEngine);
-
-                        // verify feed rules engine not called
-                        verifyNoInteractions(mockContentCardRulesEngine);
+                        // verify rules engines synced with empty rules (code-based propositions
+                        // produce no rules)
+                        verify(mockMessagingRulesEngine, times(1))
+                                .replaceRules(rulesListCaptor.capture());
+                        assertEquals(0, rulesListCaptor.getValue().size());
+                        verify(mockContentCardRulesEngine, times(1))
+                                .replaceRules(contentCardRulesListCaptor.capture());
+                        assertEquals(0, contentCardRulesListCaptor.getValue().size());
 
                         // verify received propositions event is dispatched
                         ArgumentCaptor<Event> dispatchEventArgumentCaptor =
@@ -1556,11 +1560,13 @@ public class EdgePersonalizationResponseHandlerTests {
                         // test
                         edgePersonalizationResponseHandler.handleProcessCompletedEvent(mockEvent);
 
-                        // verify rules not replaced in in-app rules engine
-                        verify(mockMessagingRulesEngine, times(0)).replaceRules(anyList());
-
-                        // verify rules not replaced in feed rules engine
-                        verify(mockContentCardRulesEngine, times(0)).replaceRules(anyList());
+                        // verify rules engines synced with empty rules
+                        verify(mockMessagingRulesEngine, times(1))
+                                .replaceRules(rulesListCaptor.capture());
+                        assertEquals(0, rulesListCaptor.getValue().size());
+                        verify(mockContentCardRulesEngine, times(1))
+                                .replaceRules(contentCardRulesListCaptor.capture());
+                        assertEquals(0, contentCardRulesListCaptor.getValue().size());
 
                         // verify received propositions event not dispatched
                         verify(mockExtensionApi, times(0)).dispatch(any(Event.class));
@@ -1659,11 +1665,14 @@ public class EdgePersonalizationResponseHandlerTests {
                         // test
                         edgePersonalizationResponseHandler.handleProcessCompletedEvent(mockEvent);
 
-                        // verify rules not replaced in in-app rules engine
-                        verify(mockMessagingRulesEngine, times(0)).replaceRules(anyList());
-
-                        // verify rules not replaced in feed rules engine
-                        verify(mockContentCardRulesEngine, times(0)).replaceRules(anyList());
+                        // verify rules engines synced with empty rules (invalid payload produces no
+                        // parseable rules)
+                        verify(mockMessagingRulesEngine, times(1))
+                                .replaceRules(rulesListCaptor.capture());
+                        assertEquals(0, rulesListCaptor.getValue().size());
+                        verify(mockContentCardRulesEngine, times(1))
+                                .replaceRules(contentCardRulesListCaptor.capture());
+                        assertEquals(0, contentCardRulesListCaptor.getValue().size());
 
                         // verify received propositions event not dispatched
                         verify(mockExtensionApi, times(0)).dispatch(any(Event.class));

--- a/code/testapp/build.gradle.kts
+++ b/code/testapp/build.gradle.kts
@@ -69,10 +69,12 @@ dependencies {
     implementation("com.google.android.material:material:1.11.0")
 
     implementation(platform("androidx.compose:compose-bom:2024.10.00"))
+    implementation("androidx.activity:activity-compose")
     implementation("androidx.compose.runtime:runtime")
     implementation("androidx.compose.ui:ui")
     implementation("androidx.compose.ui:ui-tooling")
     implementation("androidx.compose.material3:material3")
     implementation("androidx.lifecycle:lifecycle-viewmodel-compose:2.8.6")
     implementation("androidx.lifecycle:lifecycle-runtime-compose:2.8.6")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.8.1")
 }

--- a/code/testapp/src/main/AndroidManifest.xml
+++ b/code/testapp/src/main/AndroidManifest.xml
@@ -26,6 +26,12 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
         <activity
+            android:name=".ContentCardsTestActivity"
+            android:exported="false"
+            android:label="@string/title_activity_content_cards_test"
+            android:parentActivityName=".MainActivity"
+            android:theme="@style/AppTheme.NoActionBar" />
+        <activity
             android:name=".ScrollingFeedActivity"
             android:exported="false"
             android:label="@string/title_activity_message_feed"

--- a/code/testapp/src/main/java/com/adobe/marketing/mobile/messagingsample/ContentCardsTestActivity.kt
+++ b/code/testapp/src/main/java/com/adobe/marketing/mobile/messagingsample/ContentCardsTestActivity.kt
@@ -1,0 +1,319 @@
+/*
+  Copyright 2025 Adobe. All rights reserved.
+  This file is licensed to you under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License. You may obtain a copy
+  of the License at http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software distributed under
+  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+  OF ANY KIND, either express or implied. See the License for the specific language
+  governing permissions and limitations under the License.
+*/
+
+package com.adobe.marketing.mobile.messagingsample
+
+import android.os.Bundle
+import android.text.format.DateFormat
+import android.widget.Toast
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.adobe.marketing.mobile.Messaging
+import com.adobe.marketing.mobile.MobileCore
+import com.adobe.marketing.mobile.aepcomposeui.AepUI
+import com.adobe.marketing.mobile.aepcomposeui.ImageOnlyUI
+import com.adobe.marketing.mobile.aepcomposeui.LargeImageUI
+import com.adobe.marketing.mobile.aepcomposeui.SmallImageUI
+import com.adobe.marketing.mobile.aepcomposeui.components.ImageOnlyCard
+import com.adobe.marketing.mobile.aepcomposeui.components.LargeImageCard
+import com.adobe.marketing.mobile.aepcomposeui.components.SmallImageCard
+import com.adobe.marketing.mobile.aepcomposeui.observers.AepUIEventObserver
+import com.adobe.marketing.mobile.aepcomposeui.style.AepCardStyle
+import com.adobe.marketing.mobile.aepcomposeui.style.AepColumnStyle
+import com.adobe.marketing.mobile.aepcomposeui.style.AepImageStyle
+import com.adobe.marketing.mobile.aepcomposeui.style.AepRowStyle
+import com.adobe.marketing.mobile.aepcomposeui.style.AepUIStyle
+import com.adobe.marketing.mobile.aepcomposeui.style.ImageOnlyUIStyle
+import com.adobe.marketing.mobile.aepcomposeui.style.LargeImageUIStyle
+import com.adobe.marketing.mobile.aepcomposeui.style.SmallImageUIStyle
+import com.adobe.marketing.mobile.messaging.Surface
+
+class ContentCardsTestActivity : ComponentActivity() {
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContent {
+            AppTheme {
+                ContentCardsTestScreen()
+            }
+        }
+    }
+}
+
+@Composable
+private fun ContentCardsTestScreen(viewModel: ContentCardsTestViewModel = viewModel()) {
+    val context = LocalContext.current
+    var surfacesRaw by remember { mutableStateOf("card/ms, card/ms2") }
+    var triggerAction by remember { mutableStateOf("") }
+    var status by remember { mutableStateOf("") }
+
+    val sections by viewModel.sections.collectAsStateWithLifecycle()
+    val itemsStyle = rememberContentCardItemsStyle()
+
+    Column(
+        modifier =
+            Modifier.fillMaxSize()
+                .verticalScroll(rememberScrollState())
+                .padding(16.dp)
+    ) {
+        Text(
+            text = stringResource(R.string.content_cards_surfaces_label),
+            style = MaterialTheme.typography.titleSmall,
+            fontWeight = FontWeight.Bold
+        )
+        OutlinedTextField(
+            value = surfacesRaw,
+            onValueChange = { surfacesRaw = it },
+            modifier = Modifier.fillMaxWidth().padding(top = 4.dp),
+            label = { Text(stringResource(R.string.content_cards_surfaces_label)) },
+            placeholder = { Text(stringResource(R.string.content_cards_surfaces_hint)) },
+            minLines = 2
+        )
+        Button(
+            onClick = {
+                val entries = parseSurfaceEntries(surfacesRaw)
+                if (entries == null) {
+                    Toast.makeText(context, "Enter at least one surface path", Toast.LENGTH_SHORT)
+                        .show()
+                    return@Button
+                }
+                Messaging.updatePropositionsForSurfaces(entries.map { it.second })
+                status =
+                    "updatePropositionsForSurfaces dispatched (${entries.size} surface(s)). Tap Get content to refresh the card UI."
+            },
+            modifier = Modifier.fillMaxWidth().padding(top = 8.dp)
+        ) {
+            Text(stringResource(R.string.content_cards_refresh))
+        }
+        Text(
+            text = stringResource(R.string.content_cards_trigger_action_label),
+            style = MaterialTheme.typography.titleSmall,
+            fontWeight = FontWeight.Bold,
+            modifier = Modifier.padding(top = 12.dp)
+        )
+        OutlinedTextField(
+            value = triggerAction,
+            onValueChange = { triggerAction = it },
+            modifier = Modifier.fillMaxWidth().padding(top = 4.dp),
+            label = { Text(stringResource(R.string.content_cards_trigger_action_label)) },
+            placeholder = { Text(stringResource(R.string.content_cards_trigger_action_hint)) },
+            singleLine = true
+        )
+        Button(
+            onClick = {
+                val action = triggerAction.trim()
+                if (action.isEmpty()) {
+                    Toast.makeText(
+                            context,
+                            "Enter a trigger action name",
+                            Toast.LENGTH_SHORT
+                        )
+                        .show()
+                    return@Button
+                }
+                MobileCore.trackAction(action, null)
+                status = "MobileCore.trackAction(\"$action\", null)"
+            },
+            modifier = Modifier.fillMaxWidth().padding(top = 8.dp)
+        ) {
+            Text(stringResource(R.string.content_cards_send_action))
+        }
+        Button(
+            onClick = {
+                val entries = parseSurfaceEntries(surfacesRaw)
+                if (entries == null) {
+                    Toast.makeText(context, "Enter at least one surface path", Toast.LENGTH_SHORT)
+                        .show()
+                    return@Button
+                }
+                viewModel.setSurfaceEntries(entries)
+                val time =
+                    DateFormat.getTimeFormat(context).format(System.currentTimeMillis())
+                status = "Card UI loaded from cache ($time)"
+            },
+            modifier = Modifier.fillMaxWidth()
+        ) {
+            Text(stringResource(R.string.content_cards_get_content))
+        }
+        Text(
+            text = status,
+            style = MaterialTheme.typography.bodySmall,
+            modifier = Modifier.padding(top = 8.dp)
+        )
+        Text(
+            text = stringResource(R.string.content_cards_results_label),
+            style = MaterialTheme.typography.titleSmall,
+            fontWeight = FontWeight.Bold,
+            modifier = Modifier.padding(top = 12.dp)
+        )
+        if (sections.isEmpty()) {
+            Text(
+                text =
+                    "Tap Get content to load ContentCardUIProvider output. Refresh only fetches propositions from Edge (no UI update).",
+                style = MaterialTheme.typography.bodySmall,
+                modifier = Modifier.padding(top = 4.dp)
+            )
+        } else {
+            sections.forEach { section ->
+                SurfaceCardsSection(
+                    section = section,
+                    itemsStyle = itemsStyle,
+                    modifier = Modifier.padding(top = 8.dp)
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun rememberContentCardItemsStyle(): AepUIStyle {
+    return remember {
+        val cardStyle = AepCardStyle(modifier = Modifier.padding(8.dp))
+        val smallImageCardStyle =
+            SmallImageUIStyle.Builder()
+                .cardStyle(cardStyle)
+                .rootRowStyle(
+                    AepRowStyle(
+                        modifier = Modifier.fillMaxWidth().padding(8.dp),
+                        horizontalArrangement =
+                            Arrangement.spacedBy(8.dp, Alignment.CenterHorizontally),
+                        verticalAlignment = Alignment.CenterVertically
+                    )
+                )
+                .build()
+        val largeImageCardStyle =
+            LargeImageUIStyle.Builder()
+                .cardStyle(cardStyle)
+                .rootColumnStyle(AepColumnStyle(modifier = Modifier.fillMaxWidth().padding(8.dp)))
+                .build()
+        val imageOnlyCardStyle =
+            ImageOnlyUIStyle.Builder()
+                .cardStyle(cardStyle)
+                .imageStyle(AepImageStyle(modifier = Modifier.fillMaxWidth()))
+                .build()
+        AepUIStyle(
+            smallImageUIStyle = smallImageCardStyle,
+            largeImageUIStyle = largeImageCardStyle,
+            imageOnlyUIStyle = imageOnlyCardStyle,
+        )
+    }
+}
+
+@Composable
+private fun SurfaceCardsSection(
+    section: SurfaceCardSection,
+    itemsStyle: AepUIStyle,
+    modifier: Modifier = Modifier,
+) {
+    Column(modifier = modifier.fillMaxWidth()) {
+        Text(
+            text = "--------------${section.pathToken}--------------",
+            style = MaterialTheme.typography.titleSmall,
+            fontWeight = FontWeight.SemiBold,
+            modifier = Modifier.padding(vertical = 4.dp)
+        )
+        val flow = remember(section.provider) { section.provider.getContentCardUIFlow() }
+        val result by flow.collectAsStateWithLifecycle(initialValue = Result.success(emptyList()))
+        result.fold(
+            onSuccess = { list ->
+                if (list.isEmpty()) {
+                    Text(
+                        text = "(no content cards)",
+                        style = MaterialTheme.typography.bodySmall,
+                        modifier = Modifier.padding(vertical = 4.dp)
+                    )
+                } else {
+                    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+                        list.forEach { aepUI ->
+                            ContentCardRow(
+                                aepUI = aepUI,
+                                itemsStyle = itemsStyle,
+                                observer = section.observer
+                            )
+                        }
+                    }
+                }
+            },
+            onFailure = { e ->
+                Text(
+                    text = e.message ?: "Error loading content cards",
+                    color = MaterialTheme.colorScheme.error,
+                    style = MaterialTheme.typography.bodySmall,
+                    modifier = Modifier.padding(vertical = 4.dp)
+                )
+            }
+        )
+    }
+}
+
+@Composable
+private fun ContentCardRow(
+    aepUI: AepUI<*, *>,
+    itemsStyle: AepUIStyle,
+    observer: AepUIEventObserver?,
+) {
+    val state = aepUI.getState()
+    if (state.dismissed) {
+        return
+    }
+    when (aepUI) {
+        is SmallImageUI ->
+            SmallImageCard(
+                ui = aepUI,
+                style = itemsStyle.smallImageUIStyle,
+                observer = observer
+            )
+        is LargeImageUI ->
+            LargeImageCard(
+                ui = aepUI,
+                style = itemsStyle.largeImageUIStyle,
+                observer = observer
+            )
+        is ImageOnlyUI ->
+            ImageOnlyCard(
+                ui = aepUI,
+                style = itemsStyle.imageOnlyUIStyle,
+                observer = observer
+            )
+    }
+}
+
+private fun parseSurfaceEntries(raw: String): List<Pair<String, Surface>>? {
+    val entries =
+        raw.split(",").map { it.trim() }.filter { it.isNotEmpty() }.map { token ->
+            token to Surface(token)
+        }
+    return if (entries.isEmpty()) null else entries
+}

--- a/code/testapp/src/main/java/com/adobe/marketing/mobile/messagingsample/ContentCardsTestViewModel.kt
+++ b/code/testapp/src/main/java/com/adobe/marketing/mobile/messagingsample/ContentCardsTestViewModel.kt
@@ -1,0 +1,57 @@
+/*
+  Copyright 2025 Adobe. All rights reserved.
+  This file is licensed to you under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License. You may obtain a copy
+  of the License at http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software distributed under
+  the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+  OF ANY KIND, either express or implied. See the License for the specific language
+  governing permissions and limitations under the License.
+*/
+
+package com.adobe.marketing.mobile.messagingsample
+
+import androidx.lifecycle.ViewModel
+import com.adobe.marketing.mobile.aepcomposeui.AepUI
+import com.adobe.marketing.mobile.messaging.ContentCardEventObserver
+import com.adobe.marketing.mobile.messaging.ContentCardUIEventListener
+import com.adobe.marketing.mobile.messaging.ContentCardUIProvider
+import com.adobe.marketing.mobile.messaging.Surface
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+data class SurfaceCardSection(
+    val pathToken: String,
+    val surface: Surface,
+    val provider: ContentCardUIProvider,
+    val observer: ContentCardEventObserver,
+)
+
+class ContentCardsTestViewModel : ViewModel() {
+
+    private val _sections = MutableStateFlow<List<SurfaceCardSection>>(emptyList())
+    val sections: StateFlow<List<SurfaceCardSection>> = _sections.asStateFlow()
+
+    fun setSurfaceEntries(entries: List<Pair<String, Surface>>) {
+        _sections.value =
+            entries.map { (path, surface) ->
+                val provider = ContentCardUIProvider(surface)
+                val observer =
+                    ContentCardEventObserver(SampleContentCardEventCallback, provider)
+                SurfaceCardSection(path, surface, provider, observer)
+            }
+    }
+
+    private object SampleContentCardEventCallback : ContentCardUIEventListener {
+        override fun onDisplay(aepUI: AepUI<*, *>) {}
+
+        override fun onDismiss(aepUI: AepUI<*, *>) {}
+
+        override fun onInteract(
+            aepUI: AepUI<*, *>,
+            interactionId: String?,
+            actionUrl: String?
+        ): Boolean = false
+    }
+}

--- a/code/testapp/src/main/java/com/adobe/marketing/mobile/messagingsample/MainActivity.kt
+++ b/code/testapp/src/main/java/com/adobe/marketing/mobile/messagingsample/MainActivity.kt
@@ -297,6 +297,10 @@ class MainActivity : ComponentActivity() {
             startActivity(Intent(this, ScrollingFeedActivity::class.java))
         }
 
+        binding.btnDetailpage.setOnClickListener {
+            startActivity(Intent(this, ContentCardsTestActivity::class.java))
+        }
+
         binding.btnCheckCodeBased.setOnClickListener {
             startActivity(Intent(this, CodeBasedExperienceActivity::class.java))
         }

--- a/code/testapp/src/main/res/values/strings.xml
+++ b/code/testapp/src/main/res/values/strings.xml
@@ -17,6 +17,15 @@
     <string name="title_activity_message_feed">Message Feed Activity</string>
     <string name="title_activity_single_feed">Single Feed Activity</string>
     <string name="title_activity_code_based">Code Based Experience Activity</string>
+    <string name="title_activity_content_cards_test">Content cards (test)</string>
+    <string name="content_cards_surfaces_label">Surfaces (comma-separated paths)</string>
+    <string name="content_cards_surfaces_hint">card/ms, card/ms2</string>
+    <string name="content_cards_refresh">Refresh messages</string>
+    <string name="content_cards_trigger_action_label">Trigger action (for qualification)</string>
+    <string name="content_cards_trigger_action_hint">Action name from your AJO rule</string>
+    <string name="content_cards_send_action">Send action</string>
+    <string name="content_cards_get_content">Get content</string>
+    <string name="content_cards_results_label">Content cards</string>
     <string name="large_text">
         "Material is the metaphor.\n\n"
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Authoritative content-card refresh after personalization (removeOrReplaceContentCards); ContentCardMapper removals keyed by activityId; safer handling when a proposition has no items; unit test updates (EdgePersonalizationResponseHandlerTests). Instrumentation coverage for full eviction and unrequested-surface preservation (MessagingPublicAPITests + empty payload fixture). Test app: Compose ContentCardsTestActivity (comma-separated surfaces, refresh vs get UI, trackAction), wired from Main “Second Activity”.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

Stops stale content cards when the server returns fewer or no cards for requested surfaces. Aligns iOS with Android’s authoritative refresh behavior and adds focused tests plus minimal demo flows to reproduce refresh, qualification (trackAction), and multi-surface fetches.

## How Has This Been Tested?

./gradlew :messaging:connectedDebugAndroidTest (content-card instrumentation); manual Content Cards (test) screen.

Functional Tests, Unit Tests and manual testing by creating multiple campaigns and disabling them to reproduce the scenario. 

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
